### PR TITLE
Update Compose compiler to 1.3.2, Kotlin to 1.7.20 and other dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/video/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/video/android/Dependencies.kt
@@ -1,13 +1,13 @@
 package io.getstream.video.android
 
 object Versions {
-    internal const val ANDROID_GRADLE_PLUGIN = "7.2.1"
+    internal const val ANDROID_GRADLE_PLUGIN = "7.3.0"
     internal const val ANDROID_GRADLE_SPOTLESS = "6.7.0"
     internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
-    internal const val KOTLIN = "1.7.10"
+    internal const val KOTLIN = "1.7.20"
     internal const val KOTLIN_GRADLE_DOKKA = "1.7.10"
-    internal const val KOTLIN_SERIALIZATION_JSON = "1.3.2"
-    internal const val KOTLIN_BINARY_VALIDATOR = "0.11.0"
+    internal const val KOTLIN_SERIALIZATION_JSON = "1.4.0"
+    internal const val KOTLIN_BINARY_VALIDATOR = "0.11.1"
     internal const val KOTLIN_COROUTINE = "1.6.4"
 
     internal const val MATERIAL = "1.6.1"
@@ -17,10 +17,10 @@ object Versions {
     internal const val ACTIVITY_COMPOSE = "1.5.0"
 
     internal const val COMPOSE = "1.2.1"
-    const val COMPOSE_COMPILER = "1.3.0"
-    internal const val COIL = "2.1.0"
+    const val COMPOSE_COMPILER = "1.3.2"
+    internal const val COIL = "2.2.1"
 
-    internal const val WIRE = "4.4.0"
+    internal const val WIRE = "4.4.1"
     internal const val RETROFIT = "2.9.0"
     internal const val OKHTTP = "4.10.0"
 


### PR DESCRIPTION
Update Compose compiler to 1.3.2, Kotlin to 1.7.20, and other dependencies.