### PR TITLE
Fix AndroidManifest CallService lint fail

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,10 @@ android {
     composeOptions {
         kotlinCompilerExtensionVersion Versions.COMPOSE_COMPILER
     }
+
+    lintOptions {
+        disable "Instantiatable"
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Fixes build fail due to lint marking `CallService` as `Instantiatable`