### PR TITLE
chore: remove the temporary GH token used for docs

### DIFF
--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -21,6 +21,5 @@ jobs:
         with:
           target-branch: 'staging'
           destination-repository-name: 'stream-video-docusaurus'
-          user-name: 'petyosi'
         env:
-          DOCUSAURUS_GH_TOKEN: ${{secrets.TEMP_STREAM_VIDEO_DOCUSAURUS_TOKEN}}
+          DOCUSAURUS_GH_TOKEN: ${{ secrets.DOCUSAURUS_GH_TOKEN }}


### PR DESCRIPTION
### 🎯 Goal

Petyo used a temporary GH token to make the docusaurus staging builds. This is not needed anymore.

### 🛠 Note

Please remove `TEMP_STREAM_VIDEO_DOCUSAURUS_TOKEN` from the secrets also

