### PR TITLE
Update Compose compiler to 1.4.0 and Kotlin to 1.8.0

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/video/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/video/android/Dependencies.kt
@@ -4,10 +4,10 @@ object Versions {
     internal const val ANDROID_GRADLE_PLUGIN = "7.3.1"
     internal const val ANDROID_GRADLE_SPOTLESS = "6.7.0"
     internal const val GRADLE_NEXUS_PUBLISH_PLUGIN = "1.1.0"
-    internal const val KOTLIN = "1.7.20"
+    internal const val KOTLIN = "1.8.0"
     internal const val KOTLIN_GRADLE_DOKKA = "1.7.20"
     internal const val KOTLIN_SERIALIZATION_JSON = "1.4.0"
-    internal const val KOTLIN_BINARY_VALIDATOR = "0.11.1"
+    internal const val KOTLIN_BINARY_VALIDATOR = "0.12.1"
     internal const val KOTLIN_COROUTINE = "1.6.4"
 
     internal const val MATERIAL = "1.6.1"
@@ -18,7 +18,7 @@ object Versions {
     internal const val ACTIVITY_COMPOSE = "1.5.0"
 
     internal const val COMPOSE_BOM = "2022.12.00"
-    const val COMPOSE_COMPILER = "1.3.2"
+    const val COMPOSE_COMPILER = "1.4.0"
     internal const val COIL = "2.2.1"
 
     internal const val WIRE = "4.4.1"

--- a/stream-video-android-compose/api/stream-video-android-compose.api
+++ b/stream-video-android-compose/api/stream-video-android-compose.api
@@ -94,6 +94,7 @@ public abstract class io/getstream/video/android/compose/state/ui/participants/P
 }
 
 public final class io/getstream/video/android/compose/theme/StreamColors {
+	public static final field $stable I
 	public static final field Companion Lio/getstream/video/android/compose/theme/StreamColors$Companion;
 	public synthetic fun <init> (JJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
@@ -139,6 +140,7 @@ public final class io/getstream/video/android/compose/theme/StreamColors$Compani
 }
 
 public final class io/getstream/video/android/compose/theme/StreamDimens {
+	public static final field $stable I
 	public static final field Companion Lio/getstream/video/android/compose/theme/StreamDimens$Companion;
 	public synthetic fun <init> (FFFFFFFFFFFJJJJFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-D9Ej5fM ()F
@@ -243,6 +245,7 @@ public final class io/getstream/video/android/compose/theme/StreamDimens$Compani
 }
 
 public final class io/getstream/video/android/compose/theme/StreamShapes {
+	public static final field $stable I
 	public static final field Companion Lio/getstream/video/android/compose/theme/StreamShapes$Companion;
 	public fun <init> (Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Shape;)V
 	public final fun component1 ()Landroidx/compose/ui/graphics/Shape;
@@ -273,6 +276,7 @@ public final class io/getstream/video/android/compose/theme/StreamShapes$Compani
 }
 
 public final class io/getstream/video/android/compose/theme/StreamTypography {
+	public static final field $stable I
 	public static final field Companion Lio/getstream/video/android/compose/theme/StreamTypography$Companion;
 	public fun <init> (Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/text/TextStyle;)V
 	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;

--- a/stream-video-android/api/stream-video-android.api
+++ b/stream-video-android/api/stream-video-android.api
@@ -2209,7 +2209,6 @@ public final class io/getstream/video/android/model/Device {
 
 public final class io/getstream/video/android/model/Device$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/getstream/video/android/model/Device$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/getstream/video/android/model/Device;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -2237,7 +2236,6 @@ public final class io/getstream/video/android/model/IceCandidate {
 
 public final class io/getstream/video/android/model/IceCandidate$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/getstream/video/android/model/IceCandidate$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/getstream/video/android/model/IceCandidate;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -2400,7 +2398,6 @@ public final class io/getstream/video/android/model/User {
 
 public final class io/getstream/video/android/model/User$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/getstream/video/android/model/User$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/getstream/video/android/model/User;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -2443,7 +2440,6 @@ public final class io/getstream/video/android/model/UserDevices {
 
 public final class io/getstream/video/android/model/UserDevices$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/getstream/video/android/model/UserDevices$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/getstream/video/android/model/UserDevices;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
@@ -2896,7 +2892,6 @@ public final class io/getstream/video/android/socket/ErrorResponse {
 
 public final class io/getstream/video/android/socket/ErrorResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lio/getstream/video/android/socket/ErrorResponse$$serializer;
-	public static final synthetic field descriptor Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lio/getstream/video/android/socket/ErrorResponse;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;


### PR DESCRIPTION
### 🎯 Goal

Update Compose compiler to 1.4.0 and Kotlin to 1.8.0.