### PR TITLE
Minor fix for chat with video integration & tokens

### DIFF
--- a/docusaurus/docs/Android/02-guides/05-chat-with-video.mdx
+++ b/docusaurus/docs/Android/02-guides/05-chat-with-video.mdx
@@ -344,7 +344,7 @@ fun initializeStreamVideo(
 
     return StreamVideoBuilder( // 2
         context = this,
-        credentialsProvider = credentialsProvider,
+        credentialsProvider = this.credentialsProvider,
         androidInputs = setOf(
             CallServiceInput.from(CallService::class), // 3
             CallActivityInput.from(CallActivity::class),

--- a/examples/chat-with-video/chat-with-video-final/src/main/java/io/getstream/video/chat_with_video_final/application/ChatWithVideoApp.kt
+++ b/examples/chat-with-video/chat-with-video-final/src/main/java/io/getstream/video/chat_with_video_final/application/ChatWithVideoApp.kt
@@ -25,6 +25,8 @@ import io.getstream.chat.android.compose.ui.attachments.StreamAttachmentFactorie
 import io.getstream.chat.android.offline.plugin.factory.StreamOfflinePluginFactory
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
 import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
+import io.getstream.log.StreamLog
+import io.getstream.log.android.AndroidStreamLogger
 import io.getstream.video.android.BuildConfig
 import io.getstream.video.android.StreamVideo
 import io.getstream.video.android.StreamVideoBuilder
@@ -80,6 +82,14 @@ class ChatWithVideoApp : Application() {
         listOf(CallAttachmentFactory()) + StreamAttachmentFactories.defaultFactories()
     }
 
+    override fun onCreate() {
+        super.onCreate()
+        if (BuildConfig.DEBUG) {
+            StreamLog.setValidator { _, _ -> true }
+            StreamLog.install(AndroidStreamLogger())
+        }
+    }
+
     lateinit var credentialsProvider: CredentialsProvider
         private set
 
@@ -100,7 +110,7 @@ class ChatWithVideoApp : Application() {
 
         return StreamVideoBuilder(
             context = this,
-            credentialsProvider = credentialsProvider,
+            credentialsProvider = this.credentialsProvider,
             androidInputs = setOf(
                 CallServiceInput.from(CallService::class),
                 CallActivityInput.from(CallActivity::class),


### PR DESCRIPTION
### 🎯 Goal

Fixes #177 

Seems like in the case of multiple login/logout in the case of Chat + Video, we had mismatched providers which caused empty tokens in the response.

Steps to repro on develop:
1. Run Chat + Video App
2. Log in with any user
3. Join a call (initializes Stream video)
4. Test things like mute/unmute works
5. leave the call (clears SFU token, sets to null)
6. log out (leaves the stream video instance running)
7. Log in again (diff user if poss for max regression)
8. Join a call
9. Test mute/unmute (shouldn't work, auth bearer should be empty)

To test this fix, just do all the steps as above on this branch and the token shouldn't be empty/null.