### PR TITLE
[Fix] Docusaurus deployment action using Node 16

### DIFF
--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - develop
+    paths:
+      - 'docusaurus/**'
 
 jobs:
   push_docusaurus:
@@ -11,6 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup Node 16
+        uses: actions/setup-node@v3.1.0
+        with:
+          node-version: 16
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
### 🎯 Goal

This PR fixes the currently failing docusaurus staging deployment action.
Due to the GitHub Action not specifying node 16 as the runtime for `stream-chat-docusaurus` it currently fails when trying to execute the build.

This PR fixes it and adds a trigger to only execute when files inside of the `docusaurus` folder are changed. This limits the action to only run when there are actual changes to the documentation.

### 🛠 Implementation details

Add `paths` trigger and specify node setup to use node 16.

### 🎨 UI Changes

None

### 🧪 Testing

Possible to test locally with [act](https://github.com/nektos/act) but otherwise only possible to see it when running on GitHub.


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs