### PR TITLE
Fix wrong maven package name for stream-video-android-ui-common

### DIFF
--- a/stream-video-android-ui-common/build.gradle.kts
+++ b/stream-video-android-ui-common/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 
 rootProject.extra.apply {
     set("PUBLISH_GROUP_ID", Configuration.artifactGroup)
-    set("PUBLISH_ARTIFACT_ID", "stream-video-android-xml")
+    set("PUBLISH_ARTIFACT_ID", "stream-video-android-ui-common")
     set("PUBLISH_VERSION", rootProject.extra.get("rootVersionName"))
 }
 


### PR DESCRIPTION
### 🎯 Goal

Fix wrong maven package name for stream-video-android-ui-common.