### PR TITLE
Code generation

### DIFF
--- a/generate-openapi.sh
+++ b/generate-openapi.sh
@@ -66,4 +66,9 @@ for FILE in $APIS_ROOT/*.kt; do
 
 done
 
+echo Copying models and services
+
 cp -r "$CLIENT_ROOT/" "$PROJECT_ROOT/stream-video-android-core/src/main/kotlin/org/openapitools/client"
+cp -r "$PROTOCOL_ROOT/protobuf/." "$PROJECT_ROOT/stream-video-android-core/src/main/proto"
+
+echo Done!


### PR DESCRIPTION
Closes #252 

Added a script `generate-openapi.sh` that pulls the `protocol` repo, generates the open API spec, and copies the protos and the generated OpenAPI spec code to the project.