### PR TITLE
Update GitHub CI token for releasing dokka

### DIFF
--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: Deploy to GitHub pages
         uses: peaceiris/actions-gh-pages@v3
         with:
-          github_token: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}
+          github_token: ${{ secrets.STREAM_CI_TOKEN }}
           publish_dir: ./build/dokka/htmlMultiModule
           publish_branch: gh-pages


### PR DESCRIPTION
Update GitHub CI token for releasing dokka.