### PR TITLE
AVS-4 Fix: screensharing doesn't stops if participant disconnects

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -500,6 +500,12 @@ public class CallState(private val call: Call, private val user: User) {
 
             is ParticipantLeftEvent -> {
                 removeParticipant(event.participant.session_id)
+
+                // clean up - stop screen-sharing session if it was still running
+                val current = _screenSharingSession.value
+                if (current?.participant?.sessionId == event.participant.session_id) {
+                    _screenSharingSession.value = null
+                }
             }
 
             is SubscriberOfferEvent -> {


### PR DESCRIPTION
Fixes a bug where the screensharing doesn't stop if the participant abruptly leaves the call.

**How to reproduce:**
1) Make a call between Android and browser
2) Share a screen from browser call
3) Close the browser tab / close the browser
**Issue**: Android app will still be showing the screen share.