### PR TITLE
AVS-13 Add speaking-while-muted detection into the SDK

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -40,6 +40,7 @@ public final class io/getstream/video/android/core/Call {
 	public final fun muteUsers (Ljava/util/List;ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun muteUsers$default (Lio/getstream/video/android/core/Call;Ljava/util/List;ZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun notify (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun processAudioSample (Lorg/webrtc/audio/JavaAudioDeviceModule$AudioSamples;)V
 	public final fun queryMembers (Ljava/util/Map;Ljava/util/List;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun queryMembers$default (Lio/getstream/video/android/core/Call;Ljava/util/Map;Ljava/util/List;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun reconnectOrSwitchSfu (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -136,6 +137,7 @@ public final class io/getstream/video/android/core/CallState {
 	public final fun handleEvent (Lorg/openapitools/client/models/VideoEvent;)V
 	public final fun hasPermission (Ljava/lang/String;)Lkotlinx/coroutines/flow/StateFlow;
 	public final fun isReconnecting ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun markSpeakingAsMuted ()V
 	public final fun pin (Ljava/lang/String;)V
 	public final fun unpin (Ljava/lang/String;)V
 	public final fun updateFromResponse (Lorg/openapitools/client/models/CallResponse;)V
@@ -815,6 +817,7 @@ public final class io/getstream/video/android/core/call/connection/StreamPeerCon
 	public static synthetic fun makePeerConnection$default (Lio/getstream/video/android/core/call/connection/StreamPeerConnectionFactory;Lkotlinx/coroutines/CoroutineScope;Lorg/webrtc/PeerConnection$RTCConfiguration;Lio/getstream/video/android/core/model/StreamPeerType;Lorg/webrtc/MediaConstraints;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;IILjava/lang/Object;)Lio/getstream/video/android/core/call/connection/StreamPeerConnection;
 	public final fun makeVideoSource (Z)Lorg/webrtc/VideoSource;
 	public final fun makeVideoTrack (Lorg/webrtc/VideoSource;Ljava/lang/String;)Lorg/webrtc/VideoTrack;
+	public final fun setAudioSampleCallback (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/getstream/video/android/core/call/signal/socket/RTCEventMapper {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -309,6 +309,10 @@ public class RtcSession internal constructor(
                 setVideoSubscriptions()
             }
         }
+
+        clientImpl.peerConnectionFactory.setAudioSampleCallback { it ->
+            call.processAudioSample(it)
+        }
     }
 
     private fun listenToSocket() {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/DecibelThresholdDetection.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/DecibelThresholdDetection.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.video.android.core.call.utils
 
-import androidx.annotation.WorkerThread
 import kotlin.math.log10
 import kotlin.math.pow
 
@@ -43,7 +42,6 @@ internal class DecibelThresholdDetection(
      * Forward the input audio data from the microphone to this function.
      * Only 16bit PCM audio format is accepted.
      */
-    @WorkerThread
     fun processSoundInput(pcmByteArray: ByteArray) {
         val decibels = calculateAverageDecibelPower(pcmByteArray)
         if (!decibels.isInfinite()) {
@@ -105,8 +103,7 @@ internal class DecibelThresholdDetection(
                 sumOfDecibels += it
             }
 
-            val averageValue = sumOfDecibels / decibelSamples.size.toDouble()
-            return averageValue
+            return sumOfDecibels / decibelSamples.size.toDouble()
         } else {
             return 0.toDouble()
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/DecibelThresholdDetection.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/DecibelThresholdDetection.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.utils
+
+import androidx.annotation.WorkerThread
+import kotlin.math.log10
+import kotlin.math.pow
+
+/**
+ * The average decibel value is calculated within the last X milliseconds defined
+ * in this constant.
+ */
+private const val SAMPLING_TIME_MS = 600
+
+/**
+ * Use to detect if the volume of a sound sample reaches a specific decibel value threshold.
+ * @param thresholdInDecibels - the threshold value in decibels. If the average decibel value goes
+ * beyond this level then the [thresholdCrossedCallback] is invoked.
+ * @param thresholdCrossedCallback - invoked when the threshold is met
+ */
+internal class DecibelThresholdDetection(
+    val thresholdInDecibels: Int = 45,
+    val thresholdCrossedCallback: () -> Unit
+) {
+
+    private val decibelSamples = LinkedHashMap<Long, Double>()
+
+    /**
+     * Forward the input audio data from the microphone to this function.
+     * Only 16bit PCM audio format is accepted.
+     */
+    @WorkerThread
+    fun processSoundInput(pcmByteArray: ByteArray) {
+        val decibels = calculateAverageDecibelPower(pcmByteArray)
+        if (!decibels.isInfinite()) {
+            val average = calculateDecibelAverage(decibels)
+            if (average >= thresholdInDecibels) {
+                thresholdCrossedCallback.invoke()
+                // we can clear the average values to start again
+                decibelSamples.clear()
+            }
+        }
+    }
+
+    private fun calculateAverageDecibelPower(pcmData: ByteArray): Double {
+        // For code clarity the following code expects the pcmData to be in PCM 16bit format.
+        // And this is the default format used by the JavaAudioDeviceModule, so unless someone
+        // in this class will override the default value then we are safe.
+
+        val referencePressure = 0.00002 // 20 µPa (reference pressure for 0 dB)
+        val referenceAmplitude = 32767.0 // Maximum amplitude for 16-bit signed PCM
+
+        var totalSquaredAmplitude = 0.0
+
+        for (i in pcmData.indices step 2) {
+            val sample = ((pcmData[i + 1].toInt() shl 8) or (pcmData[i].toInt() and 0xFF)).toDouble()
+            val amplitude = sample / referenceAmplitude
+            totalSquaredAmplitude += amplitude.pow(2)
+        }
+
+        val rmsAmplitude = kotlin.math.sqrt(totalSquaredAmplitude / (pcmData.size / 2))
+        val pressureRatio = rmsAmplitude / referencePressure
+        return 10 * log10(pressureRatio.pow(2))
+    }
+
+    private fun calculateDecibelAverage(decibels: Double): Double {
+        val receivedTime = System.currentTimeMillis()
+
+        // Clear data if stale. Check the the latest recorded sample is not older than the overall
+        // time window length. In this case all the data in the map is stale and we can drop it.
+        if (decibelSamples.isNotEmpty() && System.currentTimeMillis() - decibelSamples.keys.last() > SAMPLING_TIME_MS) {
+            decibelSamples.clear()
+        }
+
+        decibelSamples[receivedTime] = decibels
+
+        // remove old entries from the end - we keep the last X seconds (defined in SAMPLING_TIME_MS)
+        val iterator = decibelSamples.entries.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            if ((System.currentTimeMillis() - entry.key) > SAMPLING_TIME_MS) {
+                iterator.remove()
+            }
+        }
+
+        // calculate the average of the 1 second window
+        if (decibelSamples.isNotEmpty()) {
+            // calculate average
+            var sumOfDecibels = 0.toDouble()
+            decibelSamples.values.forEach {
+                sumOfDecibels += it
+            }
+
+            val averageValue = sumOfDecibels / decibelSamples.size.toDouble()
+            return averageValue
+        } else {
+            return 0.toDouble()
+        }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallStateTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallStateTest.kt
@@ -19,6 +19,7 @@ package io.getstream.video.android.core
 import com.google.common.truth.Truth.assertThat
 import io.getstream.video.android.core.base.IntegrationTestBase
 import io.getstream.video.android.model.User
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -28,6 +29,8 @@ import org.openapitools.client.models.ScreensharingSettingsRequest
 import org.robolectric.RobolectricTestRunner
 import org.threeten.bp.Clock
 import org.threeten.bp.OffsetDateTime
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
 class CallStateTest : IntegrationTestBase() {
@@ -146,5 +149,16 @@ class CallStateTest : IntegrationTestBase() {
                 assertThat(call.state.settings.value).isNotNull()
             }
         }
+    }
+
+    @Test
+    fun `Setting the speaking while muted flag will reset itself after delay`() = runTest {
+        // we can make multiple calls, this should have no impact on the reset logic or duration
+        call.state.markSpeakingAsMuted()
+        call.state.markSpeakingAsMuted()
+        call.state.markSpeakingAsMuted()
+        assertTrue(call.state.speakingWhileMuted.value)
+        delay(2500)
+        assertFalse(call.state.speakingWhileMuted.value)
     }
 }


### PR DESCRIPTION
This change makes the `CallState.speakingWhileMuted` StateFlow in the SDK functional. 
UI can listen to this `StateFlow` and display a warning to the user if he is speaking while the microphone is muted. 
**Note**: The flag will reset itself automatically after 2 seconds.

We intercept the `AudioSamples` callback from the `JavaAudioDeviceModule` in WebRTC and then do basic average decibel level analysis. The flag is set if the average decibel value surpasses a certain level. The analysis is only done while in call and only when the microphone is muted.

A separate PR should be create later to connect the application UI with the flag and display the actual warning.