### PR TITLE
AVS-16 Fix state restoration bug in Dogfooding app (StreamVideo init)

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/join/CallJoinScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/join/CallJoinScreen.kt
@@ -75,6 +75,7 @@ fun CallJoinScreen(
     HandleCallJoinUiState(
         callJoinUiState = uiState,
         navigateToCallLobby = navigateToCallLobby,
+        navigateUpToLogin = navigateUpToLogin
     )
 
     Column(
@@ -249,12 +250,14 @@ private fun CallJoinBody(
 private fun HandleCallJoinUiState(
     callJoinUiState: CallJoinUiState,
     navigateToCallLobby: (callId: String) -> Unit,
+    navigateUpToLogin: () -> Unit
 ) {
     LaunchedEffect(key1 = callJoinUiState) {
         when (callJoinUiState) {
             is CallJoinUiState.JoinCompleted ->
                 navigateToCallLobby.invoke(callJoinUiState.callId)
-
+            is CallJoinUiState.GoBackToLogin ->
+                navigateUpToLogin.invoke()
             else -> Unit
         }
     }

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/join/CallJoinViewModel.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/join/CallJoinViewModel.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import java.util.UUID
 import javax.inject.Inject
 
@@ -39,13 +40,15 @@ import javax.inject.Inject
 class CallJoinViewModel @Inject constructor(
     dataStore: StreamUserDataStore,
 ) : ViewModel() {
-
     val user: StateFlow<User?> = dataStore.user
 
     private val event: MutableStateFlow<CallJoinEvent> = MutableStateFlow(CallJoinEvent.Nothing)
     internal val uiState: StateFlow<CallJoinUiState> = event
         .flatMapLatest { event ->
             when (event) {
+                is CallJoinEvent.GoBackToLogin -> {
+                    flowOf(CallJoinUiState.GoBackToLogin)
+                }
                 is CallJoinEvent.JoinCall -> {
                     val call = joinCall(event.callId)
                     flowOf(CallJoinUiState.JoinCompleted(callId = call.cid))
@@ -56,6 +59,17 @@ class CallJoinViewModel @Inject constructor(
             }
         }
         .stateIn(viewModelScope, SharingStarted.Lazily, CallJoinUiState.Nothing)
+
+    init {
+        viewModelScope.launch {
+            // We need to check whether the StreamVideo instance is initialised and go back to Login
+            // if not. In the current implementation we only initialise after Login and if the
+            // Android process is restored then the Login is skipped Stream Video is not initialised.
+            if (!StreamVideo.isInstalled) {
+                event.value = CallJoinEvent.GoBackToLogin
+            }
+        }
+    }
 
     fun handleUiEvent(event: CallJoinEvent) {
         this.event.value = event
@@ -83,6 +97,8 @@ sealed interface CallJoinUiState {
     object Nothing : CallJoinUiState
 
     data class JoinCompleted(val callId: String) : CallJoinUiState
+
+    object GoBackToLogin : CallJoinUiState
 }
 
 sealed interface CallJoinEvent {
@@ -91,4 +107,6 @@ sealed interface CallJoinEvent {
     data class JoinCall(val callId: String? = null) : CallJoinEvent
 
     data class JoinCompleted(val callId: String) : CallJoinEvent
+
+    object GoBackToLogin : CallJoinEvent
 }


### PR DESCRIPTION
The dogfooding app has issues with state restoration after a process kill. So this will happen during normal use - you open the app and then to switch to some other app and leave it running. The system at some point will save the state of the process and kill it. And then the Login Screen is skipped, we go directly into the CallJoinScreen and the StreamVideo instance is not ready yet. As a quick fix we will just kick the user back into Login and he will be automatically forwarded back (if credentials exist).

How to reproduce:
- Launch dogfooding app (no need to do anything)
- Put it into background
- run this command adb shell am kill io.getstream.video.android.dogfooding.debug
- Resume the app and click Join call
```
  Process: io.getstream.video.android.dogfooding.debug, PID: 23957
      java.lang.IllegalStateException: StreamVideoBuilder.build() must be called before obtaining StreamVideo instance.
          at io.getstream.video.android.core.StreamVideo$Companion.instance(StreamVideo.kt:131)
          at io.getstream.video.android.dogfooding.ui.join.CallJoinViewModel.joinCall(CallJoinViewModel.kt:65)
          at io.getstream.video.android.dogfooding.ui.join.CallJoinViewModel.access$joinCall(CallJoinViewModel.kt:38)
          at io.getstream.video.android.dogfooding.ui.join.CallJoinViewModel$special$$inlined$flatMapLatest$1.invokeSuspend(Merge.kt:221)
          at io.getstream.video.android.dogfooding.ui.join.CallJoinViewModel$special$$inlined$flatMapLatest$1.invoke(Unknown Source:13)
          at io.getstream.video.android.dogfooding.ui.join.CallJoinViewModel$special$$inlined$flatMapLatest$1.invoke(Unknown Source:4)
```
