### PR TITLE
AVS-32 Handle exceptions when logging-in in dogfooding app

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 - [ ] Publish app on play store
 - [ ] Buttons to simulate ice restart and SFU switching (Jaewoong)
 - [ ] Report version number of SDK on all API calls (Daniel)
-- [ ] Bug: java.net.UnknownHostException: Unable to resolve host "hint.stream-io-video.com" isn't throw but instead logged as INFO (Daniel)
+- [x] Bug: java.net.UnknownHostException: Unable to resolve host "hint.stream-io-video.com" isn't throw but instead logged as INFO (Daniel)
 - [ ] Bug: screensharing is broken. android doesn’t receive/render (not sure) the screenshare. video shows up as the gray avatar
 - [X] Deeplink support for video call demo & dogfooding app (skip auth for the video demo, keep it for dogfooding) (Jaewoong)
 - [X] XML version of VideoRenderer (Jaewoong)

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/call/CallScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/call/CallScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/login/LoginScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/login/LoginScreen.kt
@@ -74,7 +74,9 @@ fun LoginScreen(
     navigateToCallJoin: () -> Unit
 ) {
     val uiState by loginViewModel.uiState.collectAsState(initial = LoginUiState.Nothing)
-    val isLoading by remember(uiState) { mutableStateOf(uiState !is LoginUiState.Nothing) }
+    val isLoading by remember(uiState) {
+        mutableStateOf(uiState !is LoginUiState.Nothing && uiState !is LoginUiState.SignInFailure)
+    }
     var isShowingEmailLoginDialog by remember { mutableStateOf(false) }
 
     HandleLoginUiStates(loginUiState = uiState, navigateToCallJoin = navigateToCallJoin)
@@ -287,6 +289,10 @@ private fun HandleLoginUiStates(
                 )
 
                 navigateToCallJoin.invoke()
+            }
+
+            is LoginUiState.SignInFailure -> {
+                Toast.makeText(context, "Login failed! (${loginUiState.errorMessage})", Toast.LENGTH_SHORT).show()
             }
 
             else -> Unit

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/login/LoginViewModel.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/login/LoginViewModel.kt
@@ -17,6 +17,7 @@
 package io.getstream.video.android.dogfooding.ui.login
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.firebase.auth.FirebaseAuth
@@ -66,11 +67,17 @@ class LoginViewModel @Inject constructor(
     }
 
     private fun signInInSuccess(email: String) = flow<LoginUiState> {
-        val response = StreamVideoNetwork.tokenService.fetchToken(
-            userId = email,
-            apiKey = API_KEY
-        )
-        emit(LoginUiState.SignInComplete(response))
+
+        try {
+            val response = StreamVideoNetwork.tokenService.fetchToken(
+                userId = email,
+                apiKey = API_KEY
+            )
+            emit(LoginUiState.SignInComplete(response))
+        } catch (exception: Throwable) {
+            emit(LoginUiState.SignInFailure(exception.message ?: "General error"))
+            Log.e("LoginViewModel", "Failed to fetch token - cause: $exception")
+        }
     }.flowOn(Dispatchers.IO)
 
     init {
@@ -121,6 +128,8 @@ sealed interface LoginUiState {
     object GoogleSignIn : LoginUiState
 
     data class SignInComplete(val tokenResponse: TokenResponse) : LoginUiState
+
+    data class SignInFailure(val errorMessage: String) : LoginUiState
 }
 
 sealed interface LoginEvent {


### PR DESCRIPTION
Added a simple implementation for handling exceptions when fetching the token. This will give the developers a quick feedback (via Toast and LogCat) that something is wrong. Previously the app would just crash without any stacktrace when you click Login in offline or you restart the app while you are offline (and this makes it really difficult to see what is going wrong because of the missing Log / stacktrace).

I used the Android Log and not our own Stream Logger because this log is only related to the dogfooding app code.