### PR TITLE
AVS-33 Report version number of SDK on all API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 - [ ] Ringing: Sounds for incoming, outgoing, call timed out. Sound for someone joining a call (Disabled by default). Docs on how to change them
 - [ ] Publish app on play store
 - [ ] Buttons to simulate ice restart and SFU switching (Jaewoong)
-- [ ] Report version number of SDK on all API calls (Daniel)
+- [x] Report version number of SDK on all API calls (Daniel)
 - [ ] Bug: java.net.UnknownHostException: Unable to resolve host "hint.stream-io-video.com" isn't throw but instead logged as INFO (Daniel)
 - [ ] Bug: screensharing is broken. android doesn’t receive/render (not sure) the screenshare. video shows up as the gray avatar
 - [X] Deeplink support for video call demo & dogfooding app (skip auth for the video demo, keep it for dogfooding) (Jaewoong)

--- a/stream-video-android-core/build.gradle.kts
+++ b/stream-video-android-core/build.gradle.kts
@@ -53,6 +53,7 @@ android {
         minSdk = Configuration.minSdk
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-proguard-rules.pro")
+        buildConfigField("String", "STREAM_VIDEO_VERSION", "\"${Configuration.versionName}\"")
     }
 
     testOptions {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallStats.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallStats.kt
@@ -18,6 +18,7 @@ package io.getstream.video.android.core
 
 import android.os.Build
 import io.getstream.log.taggedLogger
+import io.getstream.video.android.BuildConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -150,8 +151,7 @@ public class CallStats(val call: Call, val callScope: CoroutineScope) {
 
         val sfu = call.session?.sfuUrl
 
-        val sdk = "android"
-        // TODO: How do we get this? val version = Configuration.versionName
+        val version = BuildConfig.STREAM_VIDEO_VERSION
         val osVersion = Build.VERSION.RELEASE ?: ""
 
         val vendor = Build.MANUFACTURER ?: ""
@@ -164,7 +164,7 @@ public class CallStats(val call: Call, val callScope: CoroutineScope) {
             maxResolution = maxResolution,
             sfu = sfu ?: "",
             os = osVersion,
-            sdkVersion = "0.1",
+            sdkVersion = version,
             deviceModel = deviceModel,
         )
         _local.value = local

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideo.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideo.kt
@@ -17,9 +17,11 @@
 package io.getstream.video.android.core
 
 import android.content.Context
+import android.os.Build
 import io.getstream.android.push.PushDevice
 import io.getstream.log.StreamLog
 import io.getstream.result.Result
+import io.getstream.video.android.BuildConfig
 import io.getstream.video.android.core.events.VideoEventListener
 import io.getstream.video.android.core.model.EdgeData
 import io.getstream.video.android.core.model.QueriedCalls
@@ -157,6 +159,27 @@ public interface StreamVideo : NotificationHandler {
                 }
                 internalStreamVideo = streamVideo
             }
+        }
+
+        /**
+         * Builds a detailed header of information we track around the SDK, Android OS, API Level, device name and
+         * vendor and more.
+         *
+         * @return String formatted header that contains all the information.
+         */
+        internal fun buildSdkTrackingHeaders(): String {
+            val clientInformation = "stream-video-android-${BuildConfig.STREAM_VIDEO_VERSION}"
+
+            val buildModel = Build.MODEL
+            val deviceManufacturer = Build.MANUFACTURER
+            val apiLevel = Build.VERSION.SDK_INT
+            val osName = "Android ${Build.VERSION.RELEASE}"
+
+            return clientInformation +
+                    "|os=$osName" +
+                    "|api_version=$apiLevel" +
+                    "|device_vendor=$deviceManufacturer" +
+                    "|device_model=$buildModel"
         }
 
         /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -18,6 +18,7 @@ package io.getstream.video.android.core.socket
 
 import com.squareup.moshi.JsonAdapter
 import io.getstream.log.taggedLogger
+import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.call.signal.socket.RTCEventMapper
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.events.ErrorEvent
@@ -201,6 +202,7 @@ open class PersistentSocket<T>(
             .url(url)
             .addHeader("Connection", "Upgrade")
             .addHeader("Upgrade", "websocket")
+            .addHeader("X-Stream-Client", StreamVideo.buildSdkTrackingHeaders())
             .build()
 
         return httpClient.newWebSocket(request, this)


### PR DESCRIPTION
This PR adds the SDK version number and other device-related stats to all API calls and sockets. 
I also fixed one TODO where we were didn't know how to get the SDK version properly.

Example header:
`stream-video-android-0.1.0|os=Android 13|api_version=33|device_vendor=Google|device_model=Pixel 4a`
