### PR TITLE
AVS-35 Fix participant count before call is joined

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 - [ ] Local Video disconnects sometimes (ICE restarts issue for the publisher. we're waiting for the backend support) (Thierry)
 - [ ] Call Analytics stateflow (Thierry)
 - [ ] Automatically handle pagination and sorting on > 6 participants in the sample app (Daniel)
-- [ ] Bug: Sample app has a bug where we don't subscribe to call changes, we need to use call.get in the preview screen so we know the number of participants (Daniel)
+- [X] Bug: Sample app has a bug where we don't subscribe to call changes, we need to use call.get in the preview screen so we know the number of participants (Daniel)
 - [ ] Ringing: Make it easy to test
 - [ ] Ringing: Make a list of what needs to be configurable
 - [ ] Ringing: Sounds for incoming, outgoing, call timed out. Sound for someone joining a call (Disabled by default). Docs on how to change them

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/lobby/CallLobbyScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/lobby/CallLobbyScreen.kt
@@ -236,7 +236,7 @@ private fun CallLobbyBody(
 private fun LobbyDescription(
     callLobbyViewModel: CallLobbyViewModel
 ) {
-    val participants by callLobbyViewModel.call.state.participants.collectAsState()
+    val session by callLobbyViewModel.call.state.session.collectAsState()
 
     Column(
         modifier = Modifier
@@ -248,7 +248,7 @@ private fun LobbyDescription(
     ) {
         Text(
             modifier = Modifier.padding(start = 32.dp, end = 32.dp, top = 12.dp, bottom = 8.dp),
-            text = stringResource(id = R.string.join_call_description, participants.size),
+            text = stringResource(id = R.string.join_call_description, session?.participants?.size ?: 0),
             color = Color.White
         )
 

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/lobby/CallLobbyViewModel.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/lobby/CallLobbyViewModel.kt
@@ -49,7 +49,12 @@ class CallLobbyViewModel @Inject constructor(
 
     val call: Call by lazy {
         val streamVideo = StreamVideo.instance()
-        streamVideo.call(type = callId.type, id = callId.id)
+        val call = streamVideo.call(type = callId.type, id = callId.id)
+        // start listening to the call events to get the participant count
+        viewModelScope.launch {
+            call.get()
+        }
+        call
     }
 
     val user: User? = dataStore.user.value


### PR DESCRIPTION
This adds handling of new Session events (`CallSessionStartedEvent`, `CallSessionEndedEvent`, `CallSessionParticipantLeftEvent`, `CallSessionParticipantJoinedEvent`). The count of participants can now be observed before the call is joined, as long as you execute `call.get()` at least once. Use `call.state.session.participants` to get the list (which is different than `call.state.participants`).