### PR TITLE
AVS-36 Fix screensharing not visible

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ParticipantState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ParticipantState.kt
@@ -257,6 +257,6 @@ public data class ParticipantState(
         sessionId = sessionId,
         track = track,
         enabled = enabled,
-        type = TrackType.TRACK_TYPE_VIDEO
+        type = TrackType.TRACK_TYPE_SCREEN_SHARE
     )
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -849,29 +849,15 @@ public class RtcSession internal constructor(
         val tracks = participants.map { participant ->
             val trackDisplay = trackDisplayResolution[participant.sessionId] ?: emptyMap()
 
-            val tracks = mutableListOf<TrackSubscriptionDetails>()
-            val entries = trackDisplay.entries.filter { it.value.visible }
-            entries.forEach { entry ->
-                dynascaleLogger.i { "[visibleTracks] $sessionId subscribing ${participant.sessionId} to : ${entry.key}" }
-                if (participant.videoEnabled.value) {
-                    tracks.add(TrackSubscriptionDetails(
-                        user_id = participant.user.value.id,
-                        track_type = entry.key,
-                        dimension = entry.value.dimensions,
-                        session_id = participant.sessionId
-                    ))
-                }
-
-                if (participant.screenSharingEnabled.value) {
-                    tracks.add(TrackSubscriptionDetails(
-                        user_id = participant.user.value.id,
-                        track_type = TrackType.TRACK_TYPE_SCREEN_SHARE,
-                        dimension = entry.value.dimensions,
-                        session_id = participant.sessionId
-                    ))
-                }
+            trackDisplay.entries.filter { it.value.visible }.map { display ->
+                dynascaleLogger.i { "[visibleTracks] $sessionId subscribing ${participant.sessionId} to : ${display.key}" }
+                TrackSubscriptionDetails(
+                    user_id = participant.user.value.id,
+                    track_type = display.key,
+                    dimension = display.value.dimensions,
+                    session_id = participant.sessionId
+                )
             }
-            tracks
         }.flatten()
         return tracks
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -849,15 +849,29 @@ public class RtcSession internal constructor(
         val tracks = participants.map { participant ->
             val trackDisplay = trackDisplayResolution[participant.sessionId] ?: emptyMap()
 
-            trackDisplay.entries.filter { it.value.visible }.map { display ->
-                dynascaleLogger.i { "[visibleTracks] $sessionId subscribing ${participant.sessionId} to : ${display.key}" }
-                TrackSubscriptionDetails(
-                    user_id = participant.user.value.id,
-                    track_type = display.key,
-                    dimension = display.value.dimensions,
-                    session_id = participant.sessionId
-                )
+            val tracks = mutableListOf<TrackSubscriptionDetails>()
+            val entries = trackDisplay.entries.filter { it.value.visible }
+            entries.forEach { entry ->
+                dynascaleLogger.i { "[visibleTracks] $sessionId subscribing ${participant.sessionId} to : ${entry.key}" }
+                if (participant.videoEnabled.value) {
+                    tracks.add(TrackSubscriptionDetails(
+                        user_id = participant.user.value.id,
+                        track_type = entry.key,
+                        dimension = entry.value.dimensions,
+                        session_id = participant.sessionId
+                    ))
+                }
+
+                if (participant.screenSharingEnabled.value) {
+                    tracks.add(TrackSubscriptionDetails(
+                        user_id = participant.user.value.id,
+                        track_type = TrackType.TRACK_TYPE_SCREEN_SHARE,
+                        dimension = entry.value.dimensions,
+                        session_id = participant.sessionId
+                    ))
+                }
             }
+            tracks
         }.flatten()
         return tracks
     }


### PR DESCRIPTION
Fixes the screenshare not being displayed.

There are still some resolution related issues. Stopping screensharing will sometimes draw the participant video in wrong resolution (rectangle and top-aligned) and also sharing a larger resolution window with Firefox will just draw a gray screen on Android. We will need to solve these issues in a separate PR. 