### PR TITLE
AVS-31 Handle non-HttpExceptions in call.join() and other API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 - [ ] Report version number of SDK on all API calls (Daniel)
 - [ ] Bug: java.net.UnknownHostException: Unable to resolve host "hint.stream-io-video.com" isn't throw but instead logged as INFO (Daniel)
 - [ ] Bug: screensharing is broken. android doesn’t receive/render (not sure) the screenshare. video shows up as the gray avatar
-- [ ] Bug: Call.join will throw an exception if error is other than HttpException
+- [X] Bug: Call.join will throw an exception if error is other than HttpException
 - [X] Deeplink support for video call demo & dogfooding app (skip auth for the video demo, keep it for dogfooding) (Jaewoong)
 - [X] XML version of VideoRenderer (Jaewoong)
 - [X] sortedParticipants stateflow doesn't update accurately (Thierry)

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/call/CallActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/ui/call/CallActivity.kt
@@ -19,9 +19,12 @@ package io.getstream.video.android.dogfooding.ui.call
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
+import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.lifecycle.lifecycleScope
+import io.getstream.result.Result
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.model.StreamCallId
 import kotlinx.coroutines.launch
@@ -38,7 +41,20 @@ class CallActivity : ComponentActivity() {
         val call = streamVideo.call(type = cid.type, id = cid.id)
 
         // step 2 - join a call
-        lifecycleScope.launch { call.join(create = true) }
+        lifecycleScope.launch {
+            val result = call.join(create = true)
+
+            // Unable to join. Device is offline or other usually connection issue.
+            if (result is Result.Failure) {
+                Log.e("CallActivity", "Call.join failed ${result.value}")
+                Toast.makeText(
+                    this@CallActivity,
+                    "Failed to join call (${result.value.message})",
+                    Toast.LENGTH_SHORT
+                ).show()
+                finish()
+            }
+        }
 
         // step 3 - build a call screen
         setContent {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -190,6 +190,9 @@ internal class StreamVideoImpl internal constructor(
                         Success(apiCall())
                     } catch (e: HttpException) {
                         parseError(e)
+                    } catch (e: Throwable) {
+                        // rethrow exception (will be handled by outer-catch)
+                        throw e
                     }
 
                     // set the token, repeat API call
@@ -197,6 +200,9 @@ internal class StreamVideoImpl internal constructor(
                 } else {
                     failure
                 }
+            } catch (e: Throwable) {
+                // Other issues. For example UnknownHostException.
+                Failure(Error.ThrowableError(e.message ?: "", e))
             }
         }
     }


### PR DESCRIPTION
We were not handling non-HttpExceptions in the `StreamVideoImpl.wrapAPICall()` wrapper that is used for all API calls. For an `UnknownHostException` (device is offline) would not be caught and would crash the app. A correct behaviour is to handle all exceptions and report `Result.Failure`. 

I added some very basic error handling to the dogfooding Call Activity - it will just show a Toast and log the error. 