### PR TITLE
AVS-37 Handle pagination of participants if count > 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 ### 0.2.0 milestone
 
 - [ ] Call Analytics stateflow (Thierry)
-- [ ] Automatically handle pagination and sorting on > 6 participants in the sample app (Daniel)
 - [ ] Ringing: Make it easy to test
 - [ ] Example Button to switch speakerphone/earpiece
 - [ ] Ringing: Make a list of what needs to be configurable
@@ -86,6 +85,7 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 - [ ] Publish app on play store
 - [ ] Bug: Screensharing on Firefox has some issues when rendering on android (Daniel)
 - [X] Chat Integration (Jaewoong)
+- [X] Automatically handle pagination and sorting on > 6 participants in the sample app (Daniel)
 - [X] Buttons to simulate ice restart and SFU switching (Jaewoong)
 - [X] Bug: java.net.UnknownHostException: Unable to resolve host "hint.stream-io-video.com" isn't throw but instead logged as INFO (Daniel)
 - [X] Bug: Call.join will throw an exception if error is other than HttpException

--- a/stream-video-android-compose/api/stream-video-android-compose.api
+++ b/stream-video-android-compose/api/stream-video-android-compose.api
@@ -912,6 +912,7 @@ public final class io/getstream/video/android/compose/ui/components/call/rendere
 	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public static field lambda-6 Lkotlin/jvm/functions/Function2;
 	public static field lambda-7 Lkotlin/jvm/functions/Function2;
+	public static field lambda-8 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function6;
 	public final fun getLambda-2$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
@@ -920,6 +921,7 @@ public final class io/getstream/video/android/compose/ui/components/call/rendere
 	public final fun getLambda-5$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-6$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-7$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-8$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/renderer/internal/ComposableSingletons$LazyColumnVideoRendererKt {
@@ -971,6 +973,7 @@ public final class io/getstream/video/android/compose/ui/components/call/rendere
 	public static field lambda-5 Lkotlin/jvm/functions/Function2;
 	public static field lambda-6 Lkotlin/jvm/functions/Function2;
 	public static field lambda-7 Lkotlin/jvm/functions/Function2;
+	public static field lambda-8 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function6;
 	public final fun getLambda-2$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
@@ -979,6 +982,7 @@ public final class io/getstream/video/android/compose/ui/components/call/rendere
 	public final fun getLambda-5$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-6$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-7$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-8$stream_video_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/renderer/internal/ScreenShareVideoRendererKt {

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
@@ -305,7 +305,10 @@ internal fun BoxScope.LandscapeVideoRenderer(
                     modifier = Modifier.fillMaxSize(),
                     columns = GridCells.Fixed(3),
                     content = {
-                        items(callParticipants.size) { key ->
+                        items(
+                            count = callParticipants.size,
+                            key = { callParticipants[it].sessionId }
+                        ) { key ->
                             // make 2 items exactly fit available height
                             val itemHeight = with(LocalDensity.current) {
                                 (constraints.maxHeight / 2).toDp()

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
@@ -19,16 +19,20 @@ package io.getstream.video.android.compose.ui.components.call.renderer.internal
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
@@ -224,7 +228,7 @@ internal fun BoxScope.LandscapeVideoRenderer(
             }
         }
 
-        else -> {
+        6 -> {
             val firstParticipant = callParticipants[0]
             val secondParticipant = callParticipants[1]
             val thirdParticipant = callParticipants[2]
@@ -291,6 +295,33 @@ internal fun BoxScope.LandscapeVideoRenderer(
                         )
                     )
                 }
+            }
+        }
+
+        else -> {
+            BoxWithConstraints(modifier = Modifier.fillMaxHeight()) {
+
+                LazyVerticalGrid(
+                    modifier = Modifier.fillMaxSize(),
+                    columns = GridCells.Fixed(3),
+                    content = {
+                        items(callParticipants.size) { key ->
+                            // make 2 items exactly fit available height
+                            val itemHeight = with(LocalDensity.current) {
+                                (constraints.maxHeight / 2).toDp()
+                            }
+                            val participant = callParticipants[key]
+                            videoRenderer.invoke(
+                                modifier = modifier.height(itemHeight),
+                                call = call,
+                                participant = participant,
+                                style = style.copy(
+                                    isFocused = dominantSpeaker?.sessionId == participant.sessionId
+                                )
+                            )
+                        }
+                    }
+                )
             }
         }
     }
@@ -450,6 +481,30 @@ private fun LandscapeParticipantsPreview6() {
                 call = mockCall,
                 dominantSpeaker = participants[0],
                 callParticipants = participants.take(6),
+                modifier = Modifier.fillMaxSize(),
+                parentSize = IntSize(screenWidth, screenHeight)
+            )
+        }
+    }
+}
+
+@Preview(device = Devices.AUTOMOTIVE_1024p, widthDp = 1440, heightDp = 720)
+@Composable
+private fun LandscapeParticipantsPreview7() {
+    StreamMockUtils.initializeStreamVideo(LocalContext.current)
+    VideoTheme {
+        val configuration = LocalConfiguration.current
+        val screenWidth = configuration.screenWidthDp
+        val screenHeight = configuration.screenHeightDp
+        val participants = mockParticipantList
+
+        Box(
+            modifier = Modifier.background(color = VideoTheme.colors.appBackground)
+        ) {
+            LandscapeVideoRenderer(
+                call = mockCall,
+                dominantSpeaker = participants[0],
+                callParticipants = participants.take(7),
                 modifier = Modifier.fillMaxSize(),
                 parentSize = IntSize(screenWidth, screenHeight)
             )

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
@@ -19,15 +19,19 @@ package io.getstream.video.android.compose.ui.components.call.renderer.internal
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.IntSize
@@ -243,7 +247,7 @@ internal fun BoxScope.PortraitVideoRenderer(
             }
         }
 
-        else -> {
+        6 -> {
             val firstParticipant = callParticipants[0]
             val secondParticipant = callParticipants[1]
             val thirdParticipant = callParticipants[2]
@@ -309,6 +313,33 @@ internal fun BoxScope.PortraitVideoRenderer(
                         )
                     )
                 }
+            }
+        }
+
+        else -> {
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+
+                LazyVerticalGrid(
+                    modifier = Modifier.fillMaxSize(),
+                    columns = GridCells.Fixed(2),
+                    content = {
+                        items(callParticipants.size) { key ->
+                            // make 3 items exactly fit available height
+                            val itemHeight = with(LocalDensity.current) {
+                                (constraints.maxHeight / 3).toDp()
+                            }
+                            val participant = callParticipants[key]
+                            videoRenderer.invoke(
+                                modifier = modifier.height(itemHeight),
+                                call = call,
+                                participant = participant,
+                                style = style.copy(
+                                    isFocused = dominantSpeaker?.sessionId == participant.sessionId
+                                )
+                            )
+                        }
+                    }
+                )
             }
         }
     }
@@ -468,6 +499,30 @@ private fun PortraitParticipantsPreview6() {
                 call = mockCall,
                 dominantSpeaker = participants[0],
                 callParticipants = participants.take(6),
+                modifier = Modifier.fillMaxSize(),
+                parentSize = IntSize(screenWidth, screenHeight)
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun PortraitParticipantsPreview7() {
+    StreamMockUtils.initializeStreamVideo(LocalContext.current)
+    VideoTheme {
+        val configuration = LocalConfiguration.current
+        val screenWidth = configuration.screenWidthDp
+        val screenHeight = configuration.screenHeightDp
+        val participants = mockParticipantList
+
+        Box(
+            modifier = Modifier.background(color = VideoTheme.colors.appBackground)
+        ) {
+            PortraitVideoRenderer(
+                call = mockCall,
+                dominantSpeaker = participants[0],
+                callParticipants = participants.take(7),
                 modifier = Modifier.fillMaxSize(),
                 parentSize = IntSize(screenWidth, screenHeight)
             )

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
@@ -323,7 +323,10 @@ internal fun BoxScope.PortraitVideoRenderer(
                     modifier = Modifier.fillMaxSize(),
                     columns = GridCells.Fixed(2),
                     content = {
-                        items(callParticipants.size) { key ->
+                        items(
+                            count = callParticipants.size,
+                            key = { callParticipants[it].sessionId }
+                        ) { key ->
                             // make 3 items exactly fit available height
                             val itemHeight = with(LocalDensity.current) {
                                 (constraints.maxHeight / 3).toDp()


### PR DESCRIPTION
Use `LazyVerticalGrid` if participant size > 6. I left the custom participant "grid" code for participant size up to 6 - this will give us more control over the layout and the LazyVerticalGrid is also more complex to render, so we can defer it until we have 7 and more participants. 