### PR TITLE
Temporary fix for notification format validation (+ PiP fixes)

### DIFF
--- a/dogfooding/src/main/AndroidManifest.xml
+++ b/dogfooding/src/main/AndroidManifest.xml
@@ -57,6 +57,7 @@
             android:name=".IncomingCallActivity"
             android:exported="false"
             android:showOnLockScreen="true"
+            android:supportsPictureInPicture="true"
             android:showWhenLocked="true">
             <intent-filter android:priority="1">
                 <action android:name="io.getstream.video.android.action.INCOMING_CALL" />

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/IncomingCallActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/dogfooding/IncomingCallActivity.kt
@@ -50,7 +50,10 @@ class IncomingCallActivity : ComponentActivity() {
         val call = StreamVideo.instance().call(callId.type, callId.id)
 
         lifecycleScope.launch {
-            if (NotificationHandler.ACTION_ACCEPT_CALL == intent.action) {
+
+            // We also check if savedInstanceState is null to prevent duplicate calls when activity
+            // is recreated (e.g. when entering PiP mode)
+            if (NotificationHandler.ACTION_ACCEPT_CALL == intent.action && savedInstanceState == null) {
                 call.accept()
                 call.join()
             }

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -1,6 +1,5 @@
 public final class io/getstream/video/android/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field CORE_VIDEO_DOMAIN Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public static final field STREAM_VIDEO_VERSION Ljava/lang/String;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -39,6 +39,7 @@ internal class VideoPushDelegate(
     context: Context
 ) : PushDelegate(context) {
     private val logger = StreamLog.getLogger("VideoPushDelegate")
+    private val DEFAULT_CALL_TEXT = "Unknown caller"
     private val userDataStore: StreamUserDataStore by lazy {
         StreamUserDataStore.install(context)
     }
@@ -78,17 +79,17 @@ internal class VideoPushDelegate(
     }
 
     private fun handleRingType(callId: StreamCallId, payload: Map<String, Any?>) {
-        val callDisplayName = payload[KEY_CALL_DISPLAY_NAME] as String
+        val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         streamVideo?.onRingingCall(callId, callDisplayName)
     }
 
     private fun handleNotificationType(callId: StreamCallId, payload: Map<String, Any?>) {
-        val callDisplayName = payload[KEY_CALL_DISPLAY_NAME] as String
+        val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         streamVideo?.onNotification(callId, callDisplayName)
     }
 
     private fun handleLiveStartedType(callId: StreamCallId, payload: Map<String, Any?>) {
-        val callDisplayName = payload[KEY_CALL_DISPLAY_NAME] as String
+        val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         streamVideo?.onLiveCall(callId, callDisplayName)
     }
 
@@ -145,19 +146,25 @@ internal class VideoPushDelegate(
      * Verify if the map contains all keys/values for a Ring Type.
      */
     private fun Map<String, Any?>.isValidRingType(): Boolean =
-        !(this[KEY_CALL_DISPLAY_NAME] as? String).isNullOrBlank()
+        // TODO: KEY_CALL_DISPLAY_NAME can be empty. Are there any other important key/values?
+        // !(this[KEY_CALL_DISPLAY_NAME] as? String).isNullOrBlank()
+        true
 
     /**
      * Verify if the map contains all keys/values for a Notification Type.
      */
     private fun Map<String, Any?>.isValidNotificationType(): Boolean =
-        !(this[KEY_CALL_DISPLAY_NAME] as? String).isNullOrBlank()
+        // TODO: KEY_CALL_DISPLAY_NAME can be empty. Are there any other important key/values?
+        // !(this[KEY_CALL_DISPLAY_NAME] as? String).isNullOrBlank()
+        true
 
     /**
      * Verify if the map contains all keys/values for a Live Started Type.
      */
     private fun Map<String, Any?>.isValidLiveStarted(): Boolean =
-        !(this[KEY_CALL_DISPLAY_NAME] as? String).isNullOrBlank()
+        // TODO: KEY_CALL_DISPLAY_NAME can be empty. Are there any other important key/values?
+        // !(this[KEY_CALL_DISPLAY_NAME] as? String).isNullOrBlank()
+        true
     /**
      * Verify if the map contains key/value from Stream Server.
      */
@@ -178,6 +185,7 @@ internal class VideoPushDelegate(
         private const val KEY_TYPE_LIVE_STARTED = "call.live_started"
         private const val KEY_CALL_CID = "call_cid"
         private const val KEY_CALL_DISPLAY_NAME = "call_display_name"
+        private const val KEY_CREATED_BY_DISPLAY_NAME = "created_by_display_name"
         private const val VALUE_STREAM_SENDER = "stream.video"
     }
 }


### PR DESCRIPTION
The PR fixes three issues and one of them is a temporary fix to unblock further work:

- `IncomingCallActivity` was missing `supportsPictureInPicture=true` (causing a crash if home button was clicked on a call that was joined from notification)
- `IncomingCallActivity` would crash if re-created for example during PiP mode, `call.join` could be called repeatedly
- The notification format checks in `VideoDelegate` are not valid anymore. The `call_display_name` in the push bundle is empty. Other platforms are not using this field - they use `created_by_display_name` instead. We need to clarify this inconsistency and make a proper fix later, but for now this will unblock us from further testing.