### PR TITLE
Change the deeplink URL and fix URL parsing	

### DIFF
--- a/dogfooding/src/main/AndroidManifest.xml
+++ b/dogfooding/src/main/AndroidManifest.xml
@@ -71,7 +71,7 @@
             android:name=".DeeplinkingActivity"
             android:exported="true"
             android:launchMode="singleTask">
-            <tools:validation testUrl="https://stream-calls-dogfood.vercel.app" />
+            <tools:validation testUrl="https://stream-video-demo.vercel.app" />
             <intent-filter
                 android:autoVerify="true"
                 android:label="@string/filter_call_link">
@@ -82,7 +82,7 @@
                 <category android:name="android.intent.category.BROWSABLE" />
 
                 <data android:scheme="https" />
-                <data android:host="stream-calls-dogfood.vercel.app" />
+                <data android:host="stream-video-demo.vercel.app" />
             </intent-filter>
         </activity>
     </application>

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
@@ -65,7 +65,7 @@ class DeeplinkingActivity : ComponentActivity() {
         }
 
         val data: Uri = intent?.data ?: return
-        val callId = data.toString().split("/").lastOrNull() ?: return
+        val callId = data.getQueryParameter("id") ?: return
 
         logger.d { "Action: ${intent?.action}" }
         logger.d { "Data: ${intent?.data}" }


### PR DESCRIPTION
This changes the original "dogfood" deeplink handling to the new demo URL. And the URL is now parsed more safely.