### PR TITLE
AVS-50 Call notification doesn't hide after Answer.

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
@@ -24,6 +24,7 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
+import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.lifecycleScope
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.call.activecall.CallContent
@@ -45,6 +46,9 @@ class IncomingCallActivity : ComponentActivity() {
 
         // release the lock and turn on screen.
         showWhenLockedAndTurnScreenOn()
+
+        // TODO: Should we also add a cancel function to the NotificationHandler interface?
+        NotificationManagerCompat.from(application).cancel(NotificationHandler.INCOMING_CALL_NOTIFICATION_ID)
 
         val callId = intent.streamCallId(NotificationHandler.INTENT_EXTRA_CALL_CID)!!
         val call = StreamVideo.instance().call(callId.type, callId.id)


### PR DESCRIPTION
The dogfooding app didn't hide the notification once the call intent was received. For future we should think about adding a function for cancelling notifications into the SDK.