### PR TITLE
AVS-54 RejectCallBroadcastReceiver uses wrong package name in manifest

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -1,6 +1,5 @@
 public final class io/getstream/video/android/core/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field CORE_VIDEO_DOMAIN Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public static final field STREAM_VIDEO_VERSION Ljava/lang/String;

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -52,12 +52,12 @@
         </provider>
 
         <receiver
-            android:name=".core.notifications.internal.RejectCallBroadcastReceiver"
+            android:name=".notifications.internal.RejectCallBroadcastReceiver"
             android:exported="false">
             <intent-filter android:priority="-1">
                 <action android:name="io.getstream.video.android.action.REJECT_CALL" />
             </intent-filter>
         </receiver>
-        <activity android:name=".core.notifications.internal.DismissNotificationActivity" />
+        <activity android:name=".notifications.internal.DismissNotificationActivity" />
     </application>
 </manifest>


### PR DESCRIPTION
The `RejectCallBroadcastReceiver` package is wrong - app will crash if you reject or dismiss a call notification.