### PR TITLE
Init StreamVideo properly into VideoPushDelegate

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -1,6 +1,5 @@
 public final class io/getstream/video/android/core/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field CORE_VIDEO_DOMAIN Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public static final field STREAM_VIDEO_VERSION Ljava/lang/String;


### PR DESCRIPTION
### 🎯 Goal
Our Push Notification Implementation needs a StreamVideo instance to work. We should reuse the one our customers already created, but could be the case our customers didn't initialized it properly.
If that is the case, we should try to create one from the persisted data, and after all our process is completed, "uninstall" this instance to ensure we don't override any customer config

### 🎉 GIF
![](https://media.giphy.com/media/xT8qAYmHc1qk2vf9DO/giphy.gif)