### PR TITLE
AVS-56 Process the install referrer from demo QR code link (call_id)

### DIFF
--- a/dogfooding/build.gradle.kts
+++ b/dogfooding/build.gradle.kts
@@ -183,6 +183,9 @@ dependencies {
     // firebase
     implementation(libs.firebase.crashlytics)
 
+    // Play Install Referrer library - used to extract the meeting link from demo flow after install
+    implementation(libs.play.install.referrer)
+
     // memory detection
     debugImplementation(libs.leakCanary)
 }

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -81,6 +82,19 @@ class DeeplinkingActivity : ComponentActivity() {
                 }
                 startActivity(intent)
                 finish()
+            }
+        }
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun createIntent(
+            context: Context,
+            callId: String,
+        ): Intent {
+            return Intent(context, DeeplinkingActivity::class.java).apply {
+                data = Uri.Builder().appendQueryParameter("id", callId).build()
             }
         }
     }

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/MainActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/MainActivity.kt
@@ -22,12 +22,22 @@ import androidx.activity.compose.setContent
 import dagger.hilt.android.AndroidEntryPoint
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.ui.AppNavHost
+import io.getstream.video.android.util.InstallReferrer
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        // Try to read the Google Play install referrer value. We use it to deliver
+        // the Call ID from the QR code link.
+        @Suppress("KotlinConstantConditions")
+        if (BuildConfig.FLAVOR == "production") {
+            InstallReferrer(this).extractInstallReferrer { callId: String ->
+                startActivity(DeeplinkingActivity.createIntent(this, callId))
+            }
+        }
 
         setContent {
             VideoTheme { AppNavHost() }

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/util/InstallReferrer.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/util/InstallReferrer.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.util
+
+import android.content.Context
+import com.android.installreferrer.api.InstallReferrerClient
+import com.android.installreferrer.api.InstallReferrerStateListener
+
+class InstallReferrer(val context: Context) {
+
+    private val sharedPreference =
+        context.getSharedPreferences("install_referrer", Context.MODE_PRIVATE)
+
+    /**
+     * This function is used to extract the "call_id" value forwarded from the QR code
+     * in our demo flow. The user can be automatically forwarded to the call after
+     * the app is installed from the QR code Google Play link.
+     * Execute this function in the main entry Activity. This function can be executed
+     * on each start - it will only try to read and return the value on first start. Subsequent
+     * calls even after a process kill will be ignored.
+     */
+    fun extractInstallReferrer(callIdCallback: (String) -> Unit) {
+
+        // The Install Referrer will give us the same value repeatedly. Only attempt to read
+        // it on first start.
+        if (sharedPreference.getBoolean(PREF_REFERRER_WAS_READ_BOOLEAN, false)) {
+            return
+        }
+
+        val referrerClient: InstallReferrerClient = InstallReferrerClient.newBuilder(context).build()
+        referrerClient.startConnection(object : InstallReferrerStateListener {
+
+            override fun onInstallReferrerSetupFinished(responseCode: Int) {
+                when (responseCode) {
+                    InstallReferrerClient.InstallReferrerResponse.OK -> {
+                        val referrer: String = referrerClient.installReferrer.installReferrer
+                        val callIdValue = findValue(referrer, "call_id")
+                        if (!callIdValue.isNullOrEmpty()) {
+                            callIdCallback.invoke(callIdValue)
+                        }
+                    }
+                    InstallReferrerClient.InstallReferrerResponse.FEATURE_NOT_SUPPORTED -> {
+                        // API not available on the current Play Store app.
+                    }
+                    InstallReferrerClient.InstallReferrerResponse.SERVICE_UNAVAILABLE -> {
+                        // Connection couldn't be established.
+                    }
+                }
+
+                // close the connection after we got a response (we will not try again)
+                kotlin.runCatching { referrerClient.endConnection() }
+
+                sharedPreference.edit().putBoolean(PREF_REFERRER_WAS_READ_BOOLEAN, true).apply()
+            }
+
+            override fun onInstallReferrerServiceDisconnected() { }
+        })
+    }
+
+    private fun findValue(referrer: String, key: String): String? {
+        referrer.split("&").forEach {
+            val keyValueList = it.split("=")
+            if (keyValueList.size > 1 && keyValueList[0] == key) {
+                return keyValueList[1]
+            }
+        }
+        return null
+    }
+
+    private companion object {
+        const val PREF_REFERRER_WAS_READ_BOOLEAN = "PREF_REFERRER_WAS_READ_BOOLEAN"
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,8 @@ kotlinTestJunit = "1.8.20"
 firebaseBom = "32.1.0"
 firebaseCrashlytics = "2.9.5"
 
+installReferrer = "2.2"
+
 hilt = "2.46.1"
 desugar = "2.0.3"
 leakCanary = "2.11"
@@ -170,6 +172,8 @@ hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", v
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics-ktx" }
 firebase-analyrics = { group = "com.google.firebase", name = "firebase-analytics-ktx" }
+
+play-install-referrer = { group = "com.android.installreferrer", name = "installreferrer", version.ref = "installReferrer" }
 
 robolectric = { group = "org.robolectric", name = "robolectric", version.ref = "robolectric" }
 leakCanary = { group = "com.squareup.leakcanary", name = "leakcanary-android", version.ref = "leakCanary" }


### PR DESCRIPTION
Process the install referrer from demo QR code link (call_id). The goal is to reduce friction when testing the demo flow. Scanning and opening the URL in the QR code will display a banner with instructions and a link to install the app from Google Play. The link also contains a `referrer` value which we use to pass the Call ID. We will then retrieve the value after the app is installed and open the call directly.

Example QR code link that will be opened in the mobile browser:
`https://play.google.com/store/apps/details?id=io.getstream.video.android&referrer=call_id%3Dtest`