### PR TITLE
AVS-58 Incoming call intents have a wrong action

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
@@ -24,7 +24,6 @@ import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
-import androidx.core.app.NotificationManagerCompat
 import androidx.lifecycle.lifecycleScope
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.call.activecall.CallContent
@@ -48,10 +47,6 @@ class IncomingCallActivity : ComponentActivity() {
         // release the lock, turn on screen, and keep the device awake.
         showWhenLockedAndTurnScreenOn()
         window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-
-        // TODO: Should we also add a cancel function to the NotificationHandler interface?
-        NotificationManagerCompat.from(application)
-            .cancel(NotificationHandler.INCOMING_CALL_NOTIFICATION_ID)
 
         val callId = intent.streamCallId(NotificationHandler.INTENT_EXTRA_CALL_CID)!!
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -202,8 +202,11 @@ public open class DefaultNotificationHandler(
         notificationId: Int,
         flags: Int = PENDING_INTENT_FLAG,
     ): PendingIntent {
+        val baseIntentAction =
+            requireNotNull(baseIntent.action) { logger.e { "Developer error. Intent action must be set" } }
         val dismissIntent = DismissNotificationActivity
-            .createIntent(application, notificationId)
+            .createIntent(application, notificationId, baseIntentAction)
+
         return PendingIntent.getActivities(
             application,
             0,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/DismissNotificationActivity.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/DismissNotificationActivity.kt
@@ -32,10 +32,20 @@ internal class DismissNotificationActivity : Activity() {
 
     companion object {
         private const val KEY_NOTIFICATION_ID = "KEY_NOTIFICATION_ID"
-        fun createIntent(context: Context, notificationId: Int): Intent =
+
+        /**
+         * @param baseIntentAction - Important - the action must be set. We are creating multiple
+         * dismiss intents (accept, reject, ...) and the system will "think" the Pending intents
+         * we create in [DefaultNotificationHandler.getActivityForIntent] are identical. This can
+         * lead to a reused intent with a wrong action.
+         * See documentation of [PendingIntent.getActivities] - the last intent in the list is the key.
+         *
+         */
+        fun createIntent(context: Context, notificationId: Int, baseIntentAction: String): Intent =
             Intent(context, DismissNotificationActivity::class.java)
                 .apply {
                     putExtra(KEY_NOTIFICATION_ID, notificationId)
+                    action = baseIntentAction
                 }
     }
 }


### PR DESCRIPTION
The incoming call intents were not created correctly. All PendingIntents had the same "key" which was determined by the last Intent in `PendingIntent.getActivities` and in our case this created always the same `Intent(context, DismissNotificationActivity::class.java)`. The system would then reuse existing PendingIntents and deliver an intent with the wrong action. For example instead of getting `INCOMING_CALL` we would get `ACCEPT_CALL`.

For more information look at the docs of `PendingIntent.getActivities()`. Especially the part about the last intent being the key.

How to reproduce the bug:
1. Start dogfooding application
2. Call application from other device (e.g. iOS)
3. Click on the notification body (not Answer or Reject). And check in `IncomingCallActivity` that the `intent.action` is incorrect. It's `ACCEPT_CALL` instead of `INCOMING_CALL`.