### PR TITLE
Prevent flicker in CallJoinScreen (frequent loading state emit)

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/login/LoginViewModel.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/login/LoginViewModel.kt
@@ -86,9 +86,9 @@ class LoginViewModel @Inject constructor(
 
     fun sigInInIfValidUserExist() {
         viewModelScope.launch {
+            handleUiEvent(LoginEvent.Loading)
             dataStore.user.collectLatest { user ->
                 if (user != null && user.isValid() && !BuildConfig.BENCHMARK) {
-                    handleUiEvent(LoginEvent.Loading)
                     delay(10)
                     handleUiEvent(LoginEvent.SignInInSuccess(userId = user.id))
                 }


### PR DESCRIPTION
Small UI fix - we shoudln't be emitting the Loading state every time a value from the datastore is delivered. We need to only emit it once before we start loading. This prevents UI flicker.