### PR TITLE
AVS-61 Mark core/general models with Stable annotations to improve Compose performance

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ buildscript {
         google()
         mavenCentral()
         maven("https://plugins.gradle.org/m2/")
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,19 +44,6 @@ subprojects {
             )
         }
     }
-
-    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
-        kotlinOptions.freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
-                    project.buildDir.absolutePath + "/compose_metrics"
-        )
-        kotlinOptions.freeCompilerArgs += listOf(
-            "-P",
-            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
-                    project.buildDir.absolutePath + "/compose_metrics"
-        )
-    }
 }
 
 tasks.register("clean")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ buildscript {
         google()
         mavenCentral()
         maven("https://plugins.gradle.org/m2/")
-        maven("https://oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,19 @@ subprojects {
             )
         }
     }
+
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
+        kotlinOptions.freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                    project.buildDir.absolutePath + "/compose_metrics"
+        )
+        kotlinOptions.freeCompilerArgs += listOf(
+            "-P",
+            "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                    project.buildDir.absolutePath + "/compose_metrics"
+        )
+    }
 }
 
 tasks.register("clean")

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,7 @@ androidxComposeCompiler = "1.4.4"
 androidxComposeTracing = "1.0.0-alpha03"
 androidxHiltNavigation = "1.0.0"
 androidxComposeNavigation = "2.5.3"
-composeStableMarker = "1.0.1-SNAPSHOT"
+composeStableMarker = "1.0.0"
 
 coil = "2.2.2"
 landscapist = "2.1.9"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ androidxComposeCompiler = "1.4.4"
 androidxComposeTracing = "1.0.0-alpha03"
 androidxHiltNavigation = "1.0.0"
 androidxComposeNavigation = "2.5.3"
+composeStableMarker = "1.0.1-SNAPSHOT"
 
 coil = "2.2.2"
 landscapist = "2.1.9"
@@ -101,6 +102,7 @@ androidx-compose-ui = { group = "androidx.compose.ui", name = "ui" }
 androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-tracing = { group = "androidx.compose.runtime", name = "runtime-tracing", version.ref = "androidxComposeTracing" }
+compose-stable-marker = { group = "com.github.skydoves", name = "compose-stable-marker", version.ref = "composeStableMarker" }
 
 coil = { group = "io.coil-kt", name = "coil", version.ref = "coil" }
 desugar = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugar" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,7 +8,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven("https://oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 dependencyResolutionManagement {
@@ -17,7 +16,6 @@ dependencyResolutionManagement {
         google()
         mavenCentral()
         maven(url = "https://plugins.gradle.org/m2/")
-        maven("https://oss.sonatype.org/content/repositories/snapshots/")
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,20 +3,22 @@
 import com.github.burrunan.s3cache.AwsS3BuildCache
 
 pluginManagement {
-  includeBuild("build-logic")
-  repositories {
-    gradlePluginPortal()
-    google()
-    mavenCentral()
-  }
+    includeBuild("build-logic")
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
 }
 dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
-  repositories {
-    google()
-    mavenCentral()
-    maven(url = "https://plugins.gradle.org/m2/")
-  }
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven(url = "https://plugins.gradle.org/m2/")
+        maven("https://oss.sonatype.org/content/repositories/snapshots/")
+    }
 }
 
 plugins {
@@ -55,11 +57,16 @@ buildCache {
     if (file.exists()) {
         file.inputStream().use { localProperties.load(it) }
     }
-    val streamAWSRegion = (localProperties["buildCache.AWSRegion"] as? String) ?: System.getenv("BUILD_CACHE_AWS_REGION") ?: ""
-    val streamAWSBucket = (localProperties["buildCache.AWSBucket"] as? String) ?: System.getenv("BUILD_CACHE_AWS_BUCKET") ?: ""
-    val streamAWSAccessKeyId = (localProperties["buildCache.AWSAccessKeyId"] as? String) ?: System.getenv("BUILD_CACHE_AWS_ACCESS_KEY_ID") ?: ""
-    val streamAWSSecretKey = (localProperties["buildCache.AWSSecretKey"] as? String) ?: System.getenv("BUILD_CACHE_AWS_SECRET_KEY") ?: ""
-    val streamBuildCacheDisabled = (localProperties.get("buildCache.disabled") as? String).toBoolean()
+    val streamAWSRegion = (localProperties["buildCache.AWSRegion"] as? String)
+        ?: System.getenv("BUILD_CACHE_AWS_REGION") ?: ""
+    val streamAWSBucket = (localProperties["buildCache.AWSBucket"] as? String)
+        ?: System.getenv("BUILD_CACHE_AWS_BUCKET") ?: ""
+    val streamAWSAccessKeyId = (localProperties["buildCache.AWSAccessKeyId"] as? String)
+        ?: System.getenv("BUILD_CACHE_AWS_ACCESS_KEY_ID") ?: ""
+    val streamAWSSecretKey = (localProperties["buildCache.AWSSecretKey"] as? String)
+        ?: System.getenv("BUILD_CACHE_AWS_SECRET_KEY") ?: ""
+    val streamBuildCacheDisabled =
+        (localProperties.get("buildCache.disabled") as? String).toBoolean()
     if (!streamBuildCacheDisabled &&
         streamAWSRegion.isNotBlank() &&
         streamAWSBucket.isNotBlank() &&

--- a/stream-video-android-compose/build.gradle.kts
+++ b/stream-video-android-compose/build.gradle.kts
@@ -55,7 +55,6 @@ dependencies {
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.accompanist.permission)
-    implementation(libs.compose.stable.marker)
 
     // image loading
     implementation(libs.landscapist.coil)

--- a/stream-video-android-compose/build.gradle.kts
+++ b/stream-video-android-compose/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     implementation(libs.androidx.compose.material.iconsExtended)
     implementation(libs.androidx.lifecycle.runtime.compose)
     implementation(libs.accompanist.permission)
+    implementation(libs.compose.stable.marker)
 
     // image loading
     implementation(libs.landscapist.coil)

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/state/ui/participants/ParticipantInfoAction.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/state/ui/participants/ParticipantInfoAction.kt
@@ -16,11 +16,13 @@
 
 package io.getstream.video.android.compose.state.ui.participants
 
+import androidx.compose.runtime.Stable
 import io.getstream.video.android.model.User
 
 /**
  * Actions which can be taken in the participants info UI in a call.
  */
+@Stable
 public sealed interface ParticipantInfoAction
 
 /**
@@ -28,6 +30,7 @@ public sealed interface ParticipantInfoAction
  *
  * @param isEnabled If the microphone is enabled or not.
  */
+@Stable
 public data class ChangeMuteState(
     val isEnabled: Boolean
 ) : ParticipantInfoAction
@@ -37,4 +40,5 @@ public data class ChangeMuteState(
  *
  * @param users The users to invite.
  */
+@Stable
 public data class InviteUsers(val users: List<User>) : ParticipantInfoAction

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -1,5 +1,6 @@
 public final class io/getstream/video/android/core/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field CORE_VIDEO_DOMAIN Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
 	public static final field STREAM_VIDEO_VERSION Ljava/lang/String;

--- a/stream-video-android-core/build.gradle.kts
+++ b/stream-video-android-core/build.gradle.kts
@@ -134,7 +134,7 @@ dependencies {
     api(libs.threentenabp2)
 
     // stable marker annotations
-    implementation(libs.compose.stable.marker)
+    compileOnly(libs.compose.stable.marker)
 
     // Stream
     api(libs.stream.result)

--- a/stream-video-android-core/build.gradle.kts
+++ b/stream-video-android-core/build.gradle.kts
@@ -130,9 +130,11 @@ dependencies {
     implementation(libs.moshi)
     implementation(libs.moshi.kotlin)
     implementation(libs.moshi.adapters)
-    //implementation(libs.desugar)
 
     api(libs.threentenabp2)
+
+    // stable marker annotations
+    implementation(libs.compose.stable.marker)
 
     // Stream
     api(libs.stream.result)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ParticipantState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ParticipantState.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core
 
+import androidx.compose.runtime.Stable
 import io.getstream.result.Result
 import io.getstream.video.android.core.model.AudioTrack
 import io.getstream.video.android.core.model.MediaTrack
@@ -220,6 +221,7 @@ public data class ParticipantState(
         _reactions.value = newReactions
     }
 
+    @Stable
     public sealed class Media(
         public open val sessionId: String,
         public open val track: MediaTrack?,
@@ -227,6 +229,7 @@ public data class ParticipantState(
         public val type: TrackType = TrackType.TRACK_TYPE_UNSPECIFIED,
     )
 
+    @Stable
     public data class Video(
         public override val sessionId: String,
         public override val track: VideoTrack?,
@@ -238,6 +241,7 @@ public data class ParticipantState(
         type = TrackType.TRACK_TYPE_VIDEO
     )
 
+    @Stable
     public data class Audio(
         public override val sessionId: String,
         public override val track: AudioTrack?,
@@ -249,6 +253,7 @@ public data class ParticipantState(
         type = TrackType.TRACK_TYPE_AUDIO
     )
 
+    @Stable
     public data class ScreenSharing(
         public override val sessionId: String,
         public override val track: VideoTrack?,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallData.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallData.kt
@@ -16,8 +16,10 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import io.getstream.video.android.model.User
 
+@Stable
 public data class CallData(
     public val blockedUsers: List<User>,
     public val call: CallInfo,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallEventType.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallEventType.kt
@@ -16,11 +16,14 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
+
 /**
  * Represents the type of events we can send around calls.
  *
  * @param eventType The type required by the BE.
  */
+@Stable
 public enum class CallEventType(
     public val eventType: String
 ) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallRecordingData.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallRecordingData.kt
@@ -16,6 +16,8 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
+
 /**
  * Represents a single call recording with its metadata.
  *
@@ -24,6 +26,7 @@ package io.getstream.video.android.core.model
  * @param start The start time in epoch.
  * @param end The end time in epoch.
  */
+@Stable
 public data class CallRecordingData(
     val fileName: String,
     val url: String,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallStatus.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/CallStatus.kt
@@ -16,8 +16,17 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
+
+@Stable
 public sealed interface CallStatus {
+
+    @Stable
     public object Incoming : CallStatus
+
+    @Stable
     public object Outgoing : CallStatus
+
+    @Stable
     public data class Calling(public val duration: String) : CallStatus
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/EdgeData.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/EdgeData.kt
@@ -16,6 +16,8 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
+
 /**
  * Represents the information about an Edge center in our network.
  *
@@ -24,6 +26,7 @@ package io.getstream.video.android.core.model
  * @param latitude The latitude of the server location.
  * @param longitude The longitude of the server location.
  */
+@Stable
 public data class EdgeData(
     val id: String,
     val latencyTestUrl: String,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/IceCandidate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/IceCandidate.kt
@@ -16,8 +16,10 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import org.webrtc.IceCandidate as RtcIceCandidate
 
+@Stable
 @kotlinx.serialization.Serializable
 public data class IceCandidate(
     internal val sdpMid: String,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/IceServer.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/IceServer.kt
@@ -16,9 +16,11 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import org.openapitools.client.models.ICEServer
 import java.io.Serializable
 
+@Stable
 public data class IceServer(
     val urls: List<String>,
     val username: String,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/Ingress.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/Ingress.kt
@@ -16,6 +16,10 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
+
+@Stable
 data class Ingress(var rtmp: RTMP)
 
+@Stable
 data class RTMP(var address: String, var streamKey: String)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/MediaTrack.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/MediaTrack.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
+
+@Stable
 public sealed class MediaTrack(
     public open val streamId: String
 ) {
@@ -36,11 +39,13 @@ public sealed class MediaTrack(
     }
 }
 
+@Stable
 public data class VideoTrack(
     public override val streamId: String,
     public val video: org.webrtc.VideoTrack
 ) : MediaTrack(streamId)
 
+@Stable
 public data class AudioTrack(
     public override val streamId: String,
     public val audio: org.webrtc.AudioTrack

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/MuteUsersData.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/MuteUsersData.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import org.openapitools.client.models.MuteUsersRequest
 
 /**
@@ -27,6 +28,7 @@ import org.openapitools.client.models.MuteUsersRequest
  * @param video If the video should be muted.
  * @param users List of users to apply the mute change to.
  */
+@Stable
 public data class MuteUsersData(
     public val users: List<String>? = null,
     public val muteAllUsers: Boolean? = null,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/NetworkQuality.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/NetworkQuality.kt
@@ -16,25 +16,31 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import stream.video.sfu.models.ConnectionQuality
 
 /**
  * Represents the network connection quality of a video call.
  */
+@Stable
 public sealed class NetworkQuality(public open val quality: Float) {
 
+    @Stable
     public data class UnSpecified(
         public override val quality: Float = 0f
     ) : NetworkQuality(quality)
 
+    @Stable
     public data class Poor(
         public override val quality: Float = 0.33f
     ) : NetworkQuality(quality)
 
+    @Stable
     public data class Good(
         public override val quality: Float = 0.66f
     ) : NetworkQuality(quality)
 
+    @Stable
     public data class Excellent(
         public override val quality: Float = 1.0f
     ) : NetworkQuality(quality)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/QueriedCalls.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/QueriedCalls.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
+
+@Stable
 public data class QueriedCalls(
     public val calls: List<CallData>,
     public val next: String?,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/Reaction.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/Reaction.kt
@@ -16,8 +16,10 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import org.openapitools.client.models.ReactionResponse
 
+@Stable
 public data class Reaction(
     val id: String,
     val response: ReactionResponse,
@@ -25,9 +27,12 @@ public data class Reaction(
     var isConsumed: Boolean = false
 )
 
+@Stable
 public sealed interface ReactionState {
 
+    @Stable
     public object Nothing : ReactionState
 
+    @Stable
     public object Running : ReactionState
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/ReactionData.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/ReactionData.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import io.getstream.video.android.model.User
 
 /**
@@ -26,6 +27,7 @@ import io.getstream.video.android.model.User
  * @param emoji Code of the emoji, if it exists.
  * @param custom Custom extra data to enrich the reaction.
  */
+@Stable
 public data class ReactionData(
     public val type: String,
     public val user: User,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/ScreenSharingSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/ScreenSharingSession.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import io.getstream.video.android.core.ParticipantState
 
 /**
@@ -23,6 +24,7 @@ import io.getstream.video.android.core.ParticipantState
  *
  * @param participant The person that's sharing the screen.
  */
+@Stable
 public data class ScreenSharingSession(
     public val participant: ParticipantState
 )

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/SortData.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/SortData.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import org.openapitools.client.models.SortParamRequest
 
 /**
@@ -25,13 +26,19 @@ import org.openapitools.client.models.SortParamRequest
  * @param sortField The property by which to apply sorting. Options depend on the object you're
  * querying.
  */
+@Stable
 public data class SortData(
     public val direction: Int = DEFAULT_SORT_DIRECTION,
     public val sortField: String
 )
 
+@Stable
 public sealed class SortField(public val field: String, public val ascending: Boolean = true) {
+
+    @Stable
     public class Asc(field: String) : SortField(field, true)
+
+    @Stable
     public class Desc(field: String) : SortField(field, false)
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/StreamPeerType.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/StreamPeerType.kt
@@ -16,12 +16,14 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import stream.video.sfu.models.PeerType
 
 /**
  * The type of peer connections, either a [PUBLISHER] that sends data to the call or a [SUBSCRIBER]
  * that receives and decodes the data from the server.
  */
+@Stable
 public enum class StreamPeerType {
     PUBLISHER,
     SUBSCRIBER

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/UpdateUserPermissionsData.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/UpdateUserPermissionsData.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import org.openapitools.client.models.UpdateUserPermissionsRequest
 
 /**
@@ -25,6 +26,7 @@ import org.openapitools.client.models.UpdateUserPermissionsRequest
  * @param grantedPermissions Permissions which the user should be granted.
  * @param revokedPermissions Permissions which we should revoke for the user.
  */
+@Stable
 public data class UpdateUserPermissionsData(
     public val userId: String,
     public val grantedPermissions: List<String>? = null,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/VideoModel.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/VideoModel.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.model
 
+import androidx.compose.runtime.Stable
 import io.getstream.video.android.core.utils.toCallUser
 import org.openapitools.client.models.CallResponse
 import org.openapitools.client.models.MemberResponse
@@ -23,6 +24,7 @@ import org.openapitools.client.models.OwnCapability
 import java.io.Serializable
 import java.util.Date
 
+@Stable
 public data class CallUser(
     val id: String,
     val name: String,
@@ -34,6 +36,7 @@ public data class CallUser(
     val updatedAt: Date?
 ) : Serializable
 
+@Stable
 public data class CallUserState(
     val trackIdPrefix: String,
     val online: Boolean,
@@ -41,6 +44,7 @@ public data class CallUserState(
     val video: Boolean
 )
 
+@Stable
 public data class CallMember(
     val callCid: String,
     val role: String,
@@ -49,6 +53,7 @@ public data class CallMember(
     val updatedAt: Date?
 ) : Serializable
 
+@Stable
 public data class CallInfo(
     val cid: String,
     val type: String,
@@ -62,12 +67,14 @@ public data class CallInfo(
     val custom: Map<String, Any?>
 ) : Serializable
 
+@Stable
 public data class CallDetails(
     val memberUserIds: List<String>,
     val members: Map<String, CallUser>,
     val ownCapabilities: List<OwnCapability>
 ) : Serializable
 
+@Stable
 public data class CallEgress(
     val broadcastEgress: String,
     val recordEgress: String
@@ -113,6 +120,7 @@ public infix fun Map<String, CallUser>.merge(that: CallUser): Map<String, CallUs
         true -> this.map { (userId, user) ->
             userId to user.merge(that)
         }.toMap()
+
         else -> this.toMutableMap().also {
             it[that.id] = that
         }
@@ -142,6 +150,7 @@ public infix fun CallUserState?.merge(that: CallUserState?): CallUserState? = wh
     this != null && that != null -> that.copy(
         trackIdPrefix = that.trackIdPrefix.ifEmpty { this.trackIdPrefix },
     )
+
     this == null -> that
     else -> this
 }

--- a/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/ReactionResponse.kt
+++ b/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/ReactionResponse.kt
@@ -23,18 +23,9 @@
 
 package org.openapitools.client.models
 
-import org.openapitools.client.models.UserResponse
 
-
-
-
-import com.squareup.moshi.FromJson
+import androidx.compose.runtime.Stable
 import com.squareup.moshi.Json
-import com.squareup.moshi.JsonAdapter
-import com.squareup.moshi.JsonReader
-import com.squareup.moshi.JsonWriter
-import com.squareup.moshi.ToJson
-import org.openapitools.client.infrastructure.Serializer
 
 /**
  *
@@ -46,7 +37,8 @@ import org.openapitools.client.infrastructure.Serializer
  */
 
 
-data class ReactionResponse (
+@Stable
+data class ReactionResponse(
 
     @Json(name = "type")
     val type: kotlin.String,

--- a/stream-video-android-model/build.gradle.kts
+++ b/stream-video-android-model/build.gradle.kts
@@ -44,5 +44,8 @@ android {
 dependencies {
     api(libs.threentenabp2)
 
+    // stable marker annotations
+    implementation(libs.compose.stable.marker)
+
     implementation(libs.kotlinx.serialization.json)
 }

--- a/stream-video-android-model/build.gradle.kts
+++ b/stream-video-android-model/build.gradle.kts
@@ -45,7 +45,7 @@ dependencies {
     api(libs.threentenabp2)
 
     // stable marker annotations
-    implementation(libs.compose.stable.marker)
+    compileOnly(libs.compose.stable.marker)
 
     implementation(libs.kotlinx.serialization.json)
 }

--- a/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/Device.kt
+++ b/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/Device.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.video.android.model
 
+import androidx.compose.runtime.Stable
+
+@Stable
 @kotlinx.serialization.Serializable
 public data class Device(
     val id: String,

--- a/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/StreamCallId.kt
+++ b/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/StreamCallId.kt
@@ -19,6 +19,7 @@ package io.getstream.video.android.model
 import android.content.Intent
 import android.os.Build
 import android.os.Parcelable
+import androidx.compose.runtime.Stable
 import io.getstream.video.android.model.mapper.toTypeAndId
 import kotlinx.parcelize.Parcelize
 import kotlinx.serialization.Serializable
@@ -31,6 +32,7 @@ import kotlinx.serialization.Serializable
  * @param cid A cid, which consists of the [type] and [id]. For instance, `default:123`
  * @param isValid Represents is the [cid] is valid or not.
  */
+@Stable
 @Parcelize
 @Serializable
 public data class StreamCallId constructor(

--- a/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/User.kt
+++ b/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/User.kt
@@ -18,6 +18,7 @@
 
 package io.getstream.video.android.model
 
+import androidx.compose.runtime.Stable
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -55,6 +56,7 @@ public object OffsetDateTimeSerializer : KSerializer<OffsetDateTime> {
     }
 }
 
+@Stable
 @Serializable
 public data class User(
     /** ID is required, the rest is optional */

--- a/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/UserAudioLevel.kt
+++ b/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/UserAudioLevel.kt
@@ -16,9 +16,12 @@
 
 package io.getstream.video.android.model
 
+import androidx.compose.runtime.Stable
+
 /**
  * Represents the audio level and if a user is speaking.
  */
+@Stable
 public data class UserAudioLevel(
     val userId: String,
     val isSpeaking: Boolean,

--- a/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/UserDevices.kt
+++ b/stream-video-android-model/src/main/kotlin/io/getstream/video/android/model/UserDevices.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.video.android.model
 
+import androidx.compose.runtime.Stable
+
+@Stable
 @kotlinx.serialization.Serializable
 public data class UserDevices(
     val devices: List<Device> = emptyList()


### PR DESCRIPTION
Mark core/general models with Stable annotations to improve Compose recomposition performance.

Before:

```
restartable scheme("[androidx.compose.ui.UiComposable, [androidx.compose.ui.UiComposable]]") fun UserAvatar(
  unstable user: User <------------ unstable, this makes unskippable
  stable modifier: Modifier? = @static Companion
  stable shape: Shape? = @dynamic VideoTheme.shapes.avatar
  stable textStyle: TextStyle? = @dynamic VideoTheme.typography.title3Bold
  stable contentScale: ContentScale? = @static Companion.Crop
  stable contentDescription: String? = @static null
  stable requestSize: IntSize = @static IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE)
  stable previewPlaceholder: Int = @dynamic 
```

After

```
restartable **skippable** scheme("[androidx.compose.ui.UiComposable, [androidx.compose.ui.UiComposable]]") fun UserAvatar(
  stable user: User <------------ unstable, now it's skippable
  stable modifier: Modifier? = @static Companion
  stable shape: Shape? = @dynamic VideoTheme.shapes.avatar
  stable textStyle: TextStyle? = @dynamic VideoTheme.typography.title3Bold
  stable contentScale: ContentScale? = @static Companion.Crop
  stable contentDescription: String? = @static null
  stable requestSize: IntSize = @static IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE)
  stable previewPlaceholder: Int = @dynamic 
```

For now, this PR uses the SNAPSHOT version of the compose-stable-marker, and it will use the stable release soon.