### PR TITLE
AVS-63 Ignore binary compatability validator to check BuildConfig classes

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -1,11 +1,3 @@
-public final class io/getstream/video/android/core/BuildConfig {
-	public static final field BUILD_TYPE Ljava/lang/String;
-	public static final field DEBUG Z
-	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
-	public static final field STREAM_VIDEO_VERSION Ljava/lang/String;
-	public fun <init> ()V
-}
-
 public final class io/getstream/video/android/core/Call {
 	public fun <init> (Lio/getstream/video/android/core/StreamVideo;Ljava/lang/String;Ljava/lang/String;Lio/getstream/video/android/model/User;)V
 	public final fun accept (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -18,7 +10,6 @@ public final class io/getstream/video/android/core/Call {
 	public final fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getCamera ()Lio/getstream/video/android/core/CameraManager;
 	public final fun getCid ()Ljava/lang/String;
-	public final fun getDebug ()Lio/getstream/video/android/core/Call$Debug;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getMicrophone ()Lio/getstream/video/android/core/MicrophoneManager;
 	public final fun getMonitor ()Lio/getstream/video/android/core/CallHealthMonitor;
@@ -68,14 +59,6 @@ public final class io/getstream/video/android/core/Call {
 	public final fun update (Ljava/util/Map;Lorg/openapitools/client/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lio/getstream/video/android/core/Call;Ljava/util/Map;Lorg/openapitools/client/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun updateMembers (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class io/getstream/video/android/core/Call$Debug {
-	public fun <init> (Lio/getstream/video/android/core/Call;)V
-	public final fun getCall ()Lio/getstream/video/android/core/Call;
-	public final fun restartPublisherIce ()V
-	public final fun restartSubscriberIce ()V
-	public final fun switchSfu ()V
 }
 
 public final class io/getstream/video/android/core/CallHealthMonitor {
@@ -2415,7 +2398,6 @@ public final class io/getstream/video/android/core/utils/CallClientUtilsKt {
 }
 
 public final class io/getstream/video/android/core/utils/DomainUtilsKt {
-	public static final synthetic fun toCallUser (Lio/getstream/video/android/core/ParticipantState;)Lio/getstream/video/android/core/model/CallUser;
 }
 
 public final class io/getstream/video/android/core/utils/LatencyResult {
@@ -2442,7 +2424,6 @@ public final class io/getstream/video/android/core/utils/LatencyUtilsKt {
 }
 
 public final class io/getstream/video/android/core/utils/ListUtilsKt {
-	public static final fun updateValue (Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ljava/util/List;
 }
 
 public final class io/getstream/video/android/core/utils/MediaStream {

--- a/stream-video-android-core/build.gradle.kts
+++ b/stream-video-android-core/build.gradle.kts
@@ -46,6 +46,21 @@ wire {
 
 generateRPCServices {}
 
+apiValidation {
+    /**
+     * Classes (fully qualified) that are excluded from public API dumps even if they
+     * contain public API.
+     */
+    ignoredClasses.add("io.getstream.video.android.core.BuildConfig")
+
+    /**
+     * Set of annotations that exclude API from being public.
+     * Typically, it is all kinds of `@InternalApi` annotations that mark
+     * effectively private API that cannot be actually private for technical reasons.
+     */
+    nonPublicMarkers.add("io.getstream.video.android.core.internal.InternalStreamVideoApi")
+}
+
 android {
     namespace = "io.getstream.video.android.core"
     compileSdk = Configuration.compileSdk


### PR DESCRIPTION
AVS-63 Ignore binary compatability validator to check BuildConfig classes.

This PR will fix breaking GitHub Actions.