### PR TITLE
Fix crash if same call is rejoined

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -390,6 +390,7 @@ public class Call(
         state._connection.value = RealtimeConnection.Disconnected
         client.state.removeActiveCall()
         client.state.removeRingingCall()
+        (client as StreamVideoImpl).onCallCleanUp(this)
         camera.disable()
         microphone.disable()
         cleanup()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -149,7 +149,13 @@ internal class StreamVideoImpl internal constructor(
 
     val socketImpl = connectionModule.coordinatorSocket
 
+    fun onCallCleanUp(call: Call) {
+        calls.remove(call.cid)
+    }
+
     override fun cleanup() {
+        // remove all cached calls
+        calls.clear()
         debugInfo.stop()
         // stop all running coroutines
         scope.cancel()


### PR DESCRIPTION
The `StreamVideoImpl` is keeping a list of calls we created / joined. The problem is that we never remove calls from the list once we leave/close them. This causes an exception if you re-join the same call again while the application is running.