### PR TITLE
Use local microphone for volume indicator during call

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 - [ ] Finish usability testing with design team on chat integration (Jaewoong)
 - [ ] Bug: Screensharing on Firefox has some issues when rendering on android (Daniel)
 - [ ] Pagination on query members & query call endpoints (Daniel)
-- [ ] local version of audioLevel(s) for lower latency audio visualizations(Daniel)
+- [X] local version of audioLevel(s) for lower latency audio visualizations(Daniel)
 - [ ] Android SDK development.md cleanup (Daniel)
 - [ ] Livestream tutorial (depends on RTMP support) (Thierry)
 - [ ] Call Analytics stateflow (Thierry)

--- a/stream-video-android-compose/api/stream-video-android-compose.api
+++ b/stream-video-android-compose/api/stream-video-android-compose.api
@@ -811,8 +811,8 @@ public final class io/getstream/video/android/compose/ui/components/call/rendere
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/renderer/ParticipantVideoKt {
-	public static final fun ParticipantLabel (Landroidx/compose/foundation/layout/BoxScope;Lio/getstream/video/android/core/ParticipantState;Landroidx/compose/ui/Alignment;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
-	public static final fun ParticipantLabel (Landroidx/compose/foundation/layout/BoxScope;Ljava/lang/String;Landroidx/compose/ui/Alignment;ZZLjava/util/List;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ParticipantLabel (Landroidx/compose/foundation/layout/BoxScope;Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/ParticipantState;Landroidx/compose/ui/Alignment;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ParticipantLabel (Landroidx/compose/foundation/layout/BoxScope;Ljava/lang/String;Landroidx/compose/ui/Alignment;ZZFLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ParticipantVideo (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/ParticipantState;Landroidx/compose/ui/Modifier;Lio/getstream/video/android/compose/ui/components/call/renderer/VideoRendererStyle;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ParticipantVideoRenderer (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/ParticipantState;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
@@ -1107,7 +1107,7 @@ public final class io/getstream/video/android/compose/ui/components/connection/N
 }
 
 public final class io/getstream/video/android/compose/ui/components/indicator/AudioVolumeIndicatorKt {
-	public static final fun AudioVolumeIndicator (Landroidx/compose/ui/Modifier;Ljava/util/List;Landroidx/compose/runtime/Composer;II)V
+	public static final fun AudioVolumeIndicator (Landroidx/compose/ui/Modifier;FLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/indicator/ComposableSingletons$AudioVolumeIndicatorKt {
@@ -1136,7 +1136,7 @@ public final class io/getstream/video/android/compose/ui/components/indicator/Mi
 }
 
 public final class io/getstream/video/android/compose/ui/components/indicator/SoundIndicatorKt {
-	public static final fun SoundIndicator (Landroidx/compose/ui/Modifier;ZZLjava/util/List;Landroidx/compose/runtime/Composer;II)V
+	public static final fun SoundIndicator (Landroidx/compose/ui/Modifier;ZZFLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/participants/CallParticipantsInfoMenuKt {

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/ScreenShareVideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/ScreenShareVideoRenderer.kt
@@ -67,7 +67,7 @@ public fun ScreenShareVideoRenderer(
             videoScalingType = VideoScalingType.SCALE_ASPECT_FIT,
         )
 
-        ParticipantLabel(screenShareParticipant, labelPosition)
+        ParticipantLabel(call, screenShareParticipant, labelPosition)
 
         if (isShowConnectionQualityIndicator) {
             val connectionQuality by screenShareParticipant.networkQuality.collectAsStateWithLifecycle()

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/indicator/AudioVolumeIndicator.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/indicator/AudioVolumeIndicator.kt
@@ -16,11 +16,6 @@
 
 package io.getstream.video.android.compose.ui.components.indicator
 
-import androidx.compose.animation.core.RepeatMode
-import androidx.compose.animation.core.animateFloat
-import androidx.compose.animation.core.infiniteRepeatable
-import androidx.compose.animation.core.rememberInfiniteTransition
-import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -32,13 +27,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.State
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.video.android.compose.theme.VideoTheme
-import kotlin.random.Random
 
 /**
  * Used to indicate the active sound levels of a given participant.
@@ -49,32 +42,12 @@ import kotlin.random.Random
 @Composable
 public fun AudioVolumeIndicator(
     modifier: Modifier = Modifier,
-    audioLevels: List<Float>,
+    audioLevels: Float,
 ) {
     val activatedColor = VideoTheme.colors.activatedVolumeIndicator
     val deActivatedColor = VideoTheme.colors.deActivatedVolumeIndicator
 
-    if (audioLevels.size < 5) {
-        throw IllegalArgumentException(
-            "audioLevels list must include five audio float (0 ~ 1f) values.",
-        )
-    }
-
-    val infiniteAnimation = rememberInfiniteTransition("AudioVolumeIndicator")
-    val animations = mutableListOf<State<Float>>()
-
-    repeat(5) {
-        val durationMillis = Random.nextInt(500, 1000)
-        animations += infiniteAnimation.animateFloat(
-            initialValue = 0f,
-            targetValue = 1f,
-            animationSpec = infiniteRepeatable(
-                animation = tween(durationMillis),
-                repeatMode = RepeatMode.Reverse,
-            ),
-            label = "Sounds Levels",
-        )
-    }
+    val defaultBarHeight = 0.23f
 
     Row(
         modifier = modifier
@@ -85,32 +58,32 @@ public fun AudioVolumeIndicator(
             VideoTheme.dimens.audioLevelIndicatorBarSeparatorWidth,
         ),
     ) {
-        repeat(5) { index ->
-            if (index % 2 == 0) {
-                val audioLevel = audioLevels[index]
-                val currentSize = animations[index % animations.size].value
-                var barHeightPercent = audioLevel + currentSize
-                if (barHeightPercent > 1.0f) {
-                    val diff = barHeightPercent - 1.0f
-                    barHeightPercent = 1.0f - diff
+        repeat(3) { index ->
+
+            val audioLevel =
+                if (index == 0 || index == 2) {
+                    // Draw "fake" side bars that reach 70% of the middle bar, similar to
+                    // what Google Meet is doing.
+                    audioLevels * 0.7f
+                } else {
+                    audioLevels
                 }
 
-                Spacer(
-                    modifier = Modifier
-                        .width(VideoTheme.dimens.audioLevelIndicatorBarWidth)
-                        .fillMaxHeight(
-                            if (audioLevel == 0f) {
-                                0.23f
-                            } else {
-                                barHeightPercent
-                            },
-                        )
-                        .background(
-                            color = if (audioLevel == 0f) deActivatedColor else activatedColor,
-                            shape = RoundedCornerShape(16.dp),
-                        ),
-                )
-            }
+            Spacer(
+                modifier = Modifier
+                    .width(VideoTheme.dimens.audioLevelIndicatorBarWidth)
+                    .fillMaxHeight(
+                        if (audioLevel == 0f) {
+                            defaultBarHeight
+                        } else {
+                            (audioLevel + defaultBarHeight).coerceAtMost(1f)
+                        },
+                    )
+                    .background(
+                        color = if (audioLevel == 0f) deActivatedColor else activatedColor,
+                        shape = RoundedCornerShape(16.dp),
+                    ),
+            )
         }
     }
 }
@@ -120,8 +93,8 @@ public fun AudioVolumeIndicator(
 private fun ActiveSoundLevelsPreview() {
     VideoTheme {
         Column {
-            AudioVolumeIndicator(audioLevels = listOf(0.86f, 0f, 0.4f, 0f, 0.72f))
-            AudioVolumeIndicator(audioLevels = listOf(0f, 0f, 0f, 0f, 0f))
+            AudioVolumeIndicator(audioLevels = 0f)
+            AudioVolumeIndicator(audioLevels = 0.3f)
         }
     }
 }

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/indicator/SoundIndicator.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/indicator/SoundIndicator.kt
@@ -34,26 +34,21 @@ import io.getstream.video.android.ui.common.R
  * @param modifier Modifier for styling.
  * @param isSpeaking Represents is user speaking or not.
  * @param isAudioEnabled Represents is audio enabled or not.
- * @param audioLevels Indicates the audio levels that will be drawn. This list must contains thee float values (0 ~ 1f).
+ * @param audioLevels Indicates the audio level that will be drawn.
  */
 @Composable
 public fun SoundIndicator(
     modifier: Modifier = Modifier,
     isSpeaking: Boolean,
     isAudioEnabled: Boolean,
-    audioLevels: List<Float>,
+    audioLevel: Float,
 ) {
-    if (isSpeaking && isAudioEnabled) {
+    if (isAudioEnabled && isSpeaking) {
         AudioVolumeIndicator(
             modifier = modifier.padding(end = VideoTheme.dimens.audioLevelIndicatorBarPadding),
-            audioLevels = audioLevels,
+            audioLevels = audioLevel,
         )
-    } else if (isAudioEnabled) {
-        AudioVolumeIndicator(
-            modifier = modifier.padding(end = VideoTheme.dimens.audioLevelIndicatorBarPadding),
-            audioLevels = listOf(0f, 0f, 0f, 0f, 0f),
-        )
-    } else {
+    } else if (!isAudioEnabled) {
         Icon(
             modifier = modifier
                 .size(VideoTheme.dimens.microphoneIndicatorSize)
@@ -73,12 +68,12 @@ private fun SoundIndicatorPreview() {
             SoundIndicator(
                 isSpeaking = true,
                 isAudioEnabled = true,
-                audioLevels = listOf(0.7f, 0f, 0.5f, 0f, 0.9f),
+                audioLevel = 0f,
             )
             SoundIndicator(
                 isSpeaking = false,
                 isAudioEnabled = false,
-                audioLevels = listOf(0.7f, 0f, 0.5f, 0f, 0.9f),
+                audioLevel = 0.5f,
             )
         }
     }

--- a/stream-video-android-compose/src/test/kotlin/io/getstream/video/android/compose/IndicatorsTest.kt
+++ b/stream-video-android-compose/src/test/kotlin/io/getstream/video/android/compose/IndicatorsTest.kt
@@ -26,6 +26,7 @@ import io.getstream.video.android.compose.ui.components.call.renderer.Participan
 import io.getstream.video.android.compose.ui.components.connection.NetworkQualityIndicator
 import io.getstream.video.android.compose.ui.components.indicator.SoundIndicator
 import io.getstream.video.android.core.model.NetworkQuality
+import io.getstream.video.android.mock.mockCall
 import io.getstream.video.android.mock.mockParticipantList
 import org.junit.Rule
 import org.junit.Test
@@ -44,12 +45,12 @@ internal class IndicatorsTest : BaseComposeTest() {
                 SoundIndicator(
                     isSpeaking = true,
                     isAudioEnabled = true,
-                    audioLevels = listOf(0.7f, 0f, 0.5f, 0f, 0.9f),
+                    audioLevel = 0f,
                 )
                 SoundIndicator(
                     isSpeaking = true,
                     isAudioEnabled = false,
-                    audioLevels = listOf(0.7f, 0f, 0.5f, 0f, 0.9f),
+                    audioLevel = 0f,
                 )
             }
         }
@@ -77,6 +78,7 @@ internal class IndicatorsTest : BaseComposeTest() {
         snapshot {
             Box {
                 ParticipantLabel(
+                    call = mockCall,
                     participant = mockParticipantList[1],
                     Alignment.BottomStart,
                 )

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -12,6 +12,7 @@ public final class io/getstream/video/android/core/Call {
 	public final fun getCamera ()Lio/getstream/video/android/core/CameraManager;
 	public final fun getCid ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
+	public final fun getLocalMicrophoneAudioLevel ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getMicrophone ()Lio/getstream/video/android/core/MicrophoneManager;
 	public final fun getMonitor ()Lio/getstream/video/android/core/CallHealthMonitor;
 	public final fun getSessionId ()Ljava/lang/String;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ParticipantState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ParticipantState.kt
@@ -182,6 +182,7 @@ public data class ParticipantState(
             currentAudio[2] = audioLevel
         }
         _audioLevels.value = currentAudio.toList()
+        _audioLevel.value = audioLevel
     }
 
     internal val _roles = MutableStateFlow<List<String>>(emptyList())

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/AudioValuePercentageNormaliser.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/AudioValuePercentageNormaliser.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.utils
+
+import kotlin.math.abs
+
+/**
+ * The normaliser computes the percentage values or value of the provided value.
+ */
+internal object AudioValuePercentageNormaliser {
+
+    /**
+     * -50 is usually considered to be the background noise level - we register anything
+     * above that.
+     */
+    private val valueRange: ClosedRange<Int> = IntRange(-50, 0)
+
+    // / Compute the range between the min and max values
+    internal val delta: Int = valueRange.endInclusive - valueRange.start
+
+    fun normalise(decibelValue: Double): Float {
+        return if (decibelValue < valueRange.start) {
+            0.toFloat()
+        } else if (decibelValue > valueRange.endInclusive) {
+            1f
+        } else {
+            abs((decibelValue - valueRange.start) / delta).toFloat()
+        }
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/SoundInputProcessor.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/SoundInputProcessor.kt
@@ -16,8 +16,9 @@
 
 package io.getstream.video.android.core.call.utils
 
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.math.log10
-import kotlin.math.pow
+import kotlin.math.sqrt
 
 /**
  * The average decibel value is calculated within the last X milliseconds defined
@@ -31,12 +32,15 @@ private const val SAMPLING_TIME_MS = 600
  * beyond this level then the [thresholdCrossedCallback] is invoked.
  * @param thresholdCrossedCallback - invoked when the threshold is met
  */
-internal class DecibelThresholdDetection(
-    private val thresholdInDecibels: Int = 45,
+internal class SoundInputProcessor(
+    private val thresholdInDecibels: Int = -45,
     val thresholdCrossedCallback: () -> Unit,
 ) {
 
     private val decibelSamples = LinkedHashMap<Long, Double>()
+
+    private val _currentAudioLevels = MutableStateFlow(0f)
+    val currentAudioLevel = _currentAudioLevels
 
     /**
      * Forward the input audio data from the microphone to this function.
@@ -44,6 +48,10 @@ internal class DecibelThresholdDetection(
      */
     fun processSoundInput(pcmByteArray: ByteArray) {
         val decibels = calculateAverageDecibelPower(pcmByteArray)
+
+        val normalisedOutput = AudioValuePercentageNormaliser.normalise(decibels)
+        _currentAudioLevels.value = normalisedOutput
+
         if (!decibels.isInfinite()) {
             val average = calculateDecibelAverage(decibels)
             if (average >= thresholdInDecibels) {
@@ -54,26 +62,24 @@ internal class DecibelThresholdDetection(
         }
     }
 
-    private fun calculateAverageDecibelPower(pcmData: ByteArray): Double {
+    private fun calculateAverageDecibelPower(soundData: ByteArray): Double {
         // For code clarity the following code expects the pcmData to be in PCM 16bit format.
         // And this is the default format used by the JavaAudioDeviceModule, so unless someone
         // in this class will override the default value then we are safe.
-
-        val referencePressure = 0.00002 // 20 µPa (reference pressure for 0 dB)
-        val referenceAmplitude = 32767.0 // Maximum amplitude for 16-bit signed PCM
-
-        var totalSquaredAmplitude = 0.0
-
-        for (i in pcmData.indices step 2) {
-            val sample =
-                ((pcmData[i + 1].toInt() shl 8) or (pcmData[i].toInt() and 0xFF)).toDouble()
-            val amplitude = sample / referenceAmplitude
-            totalSquaredAmplitude += amplitude.pow(2)
+        val samples = ShortArray(soundData.size / 2) { i ->
+            ((soundData[i * 2 + 1].toInt() and 0xFF) shl 8 or (soundData[i * 2].toInt() and 0xFF)).toShort()
         }
 
-        val rmsAmplitude = kotlin.math.sqrt(totalSquaredAmplitude / (pcmData.size / 2))
-        val pressureRatio = rmsAmplitude / referencePressure
-        return 10 * log10(pressureRatio.pow(2))
+        // Calculate RMS value
+        var sumSquared = 0.0
+        for (sample in samples) {
+            val sampleValue = sample.toDouble() / Short.MAX_VALUE
+            sumSquared += sampleValue * sampleValue
+        }
+        val rmsValue = sqrt(sumSquared / samples.size)
+
+        // Calculate decibel value (assumes a reference level of 1.0)
+        return 20 * log10(rmsValue)
     }
 
     private fun calculateDecibelAverage(decibels: Double): Double {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/RampValueUpAndDownHelper.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/RampValueUpAndDownHelper.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.coroutineContext
+
+private const val FREEZE_AT_TOP_TIME_MS = 50L
+
+/**
+ * Helper class that will gradually ram-up from 0 to the value supplied through [rampToValue] and
+ * then will return gradually back to 0.
+ */
+internal class RampValueUpAndDownHelper(private val durationMillis: Long = 250L) {
+
+    private val _value: MutableStateFlow<Float> = MutableStateFlow(0f)
+    private var currentJob: Job? = null
+    private var totalSteps = 0
+
+    val currentLevel = _value.asStateFlow()
+
+    /***
+     * Sending a value will trigger update to the [currentLevel] StateFlow. The value will gradually
+     * go from 0 to [targetValue] and then back to 0 over the duration time defined in [durationMillis].
+     * Calling the function again while the job is running will only have an effect if the
+     * new value is bigger than the previous one - in that case the output values will grow faster
+     * to reach the new [targetValue] and go back again to 0.
+     */
+    suspend fun rampToValue(targetValue: Float) {
+        // Check if we are not animating already. If yes then only change
+        // change the animation if the new value is bigger. Otherwise the current
+        // value will just ramp down after [durationMillis]
+        if (totalSteps != 0) {
+            if (targetValue == 0f || targetValue < currentLevel.value) {
+                return
+            }
+        }
+
+        currentJob?.cancel()
+        val startValue = _value.value
+
+        currentJob = CoroutineScope(coroutineContext).launch {
+            totalSteps = 0
+            rampValueInternal(startValue, targetValue)
+            // stay a short while at the top value
+            delay(FREEZE_AT_TOP_TIME_MS)
+            rampValueInternal(targetValue, 0f) // Ramp down to zero
+            // make sure we end up exactly at 0 again
+            _value.value = 0f
+        }
+    }
+
+    private suspend fun rampValueInternal(startValue: Float, targetValue: Float) {
+        // Number of steps for the ramp
+        val steps = 50
+        val stepDuration = (durationMillis - FREEZE_AT_TOP_TIME_MS) / steps / 2
+
+        for (i in 0..steps) {
+            totalSteps += 1
+            val value = startValue + (i * (targetValue - startValue) / steps)
+            _value.value = value
+            delay(stepDuration)
+        }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/RampValueUpAndDownHelperTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/RampValueUpAndDownHelperTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.utils
+
+import io.getstream.video.android.core.base.IntegrationTestBase
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+class RampValueUpAndDownHelperTest : IntegrationTestBase(connectCoordinatorWS = false) {
+
+    @Test
+    fun `values returns to zero`() = runTest {
+        val totalDuration = 1000L
+        val rampValueUpAndDownHelper = RampValueUpAndDownHelper(totalDuration)
+        rampValueUpAndDownHelper.rampToValue(100f)
+        advanceTimeBy(totalDuration)
+
+        assertEquals(rampValueUpAndDownHelper.currentLevel.value, 0f)
+    }
+
+    @Test
+    fun `value returns to zero even if multiple invocation`() = runTest {
+        val totalDuration = 1000L
+        val rampValueUpAndDownHelper = RampValueUpAndDownHelper(totalDuration)
+        rampValueUpAndDownHelper.rampToValue(100f)
+        rampValueUpAndDownHelper.rampToValue(100f)
+        rampValueUpAndDownHelper.rampToValue(100f)
+        advanceTimeBy(totalDuration)
+
+        assertEquals(rampValueUpAndDownHelper.currentLevel.value, 0f)
+    }
+
+    @Test
+    fun `value in middle of duration is close to targettarget value`() = runTest {
+        val totalDuration = 1000L
+        val rampValueUpAndDownHelper = RampValueUpAndDownHelper(totalDuration)
+
+        rampValueUpAndDownHelper.rampToValue(100f)
+
+        // advance time into the middle of the duration - the value now should be at the top
+        advanceTimeBy(totalDuration / 2)
+
+        assert(rampValueUpAndDownHelper.currentLevel.value >= (95f))
+    }
+
+    @Test
+    fun `submitting a larger value will result in new target value`() = runTest {
+        val totalDuration = 1000L
+        val rampValueUpAndDownHelper = RampValueUpAndDownHelper(totalDuration)
+
+        rampValueUpAndDownHelper.rampToValue(100f)
+        rampValueUpAndDownHelper.rampToValue(200f)
+
+        // advance time into the middle of the duration - the value now should be at the top
+        advanceTimeBy(totalDuration / 2)
+
+        assert(rampValueUpAndDownHelper.currentLevel.value >= 195f)
+
+        // and also verify that the value goes back to 0
+        advanceTimeBy(totalDuration / 2)
+
+        assertEquals(rampValueUpAndDownHelper.currentLevel.value, 0f)
+    }
+}


### PR DESCRIPTION
The `audioLevelChanged` events are too slow for displaying the local participant (user) volume. For this case (same like on iOS) we will use a the local microphone for getting the audio level without a delay.

I refactored the code so that the `Call` object will now have a `localMicrophoneAudioLevel` StateFlow which can be observed to get this value. But it is not necessary if you use the SDK Compose views - the `ParticipantVideo` drawn by the `CallContent` will already use this local audio level automatically.

I added a `RampValueUpAndDownHelper` class which smoothes out the audio levels and gradually ramps up the audio level to the new value and then goes back to 0. This greatly simplifies the UI part - you can now just observe the value and draw the indicator directly (the value is 0.0 - 1.0f, so you can just use it as height percent) without having to create custom animations. 

And similar like iOS we have now disabled the audio levels for other participants due to the lag (until we have a fix).

Note: We will need to make a separate task for adding this volume indicator to the pre-join view. At this point the `Call.localMicrophoneAudioLevel` will be returning 0f because the call isn't connected yet and WebRTC isn't yet capturing the mic. We will probably need to attach the mic and then detach it - just for the sake of the volume indicator.