### PR TITLE
Use dark theme for demo app

### DIFF
--- a/dogfooding/src/main/res/values/themes.xml
+++ b/dogfooding/src/main/res/values/themes.xml
@@ -16,7 +16,7 @@
 -->
 <resources>
 
-    <style name="Dogfooding" parent="Theme.AppCompat.Light.NoActionBar">
+    <style name="Dogfooding" parent="Theme.AppCompat.NoActionBar">
         <item name="android:statusBarColor">@color/stream_video_primary_accent</item>
     </style>
 </resources>


### PR DESCRIPTION
The demo/dogfooding apps are dark and the theme should be dark too - it's noticable when you start the app and the screen is white and then switches to dark background once the MainActivity is drawn. This makes the app start animation a bit more pleasing.