### PR TITLE
Fix back button behaviour in demo app

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
@@ -167,7 +167,13 @@ fun CallScreen(
                 )
             },
             updateUnreadCount = { unreadCount = it },
-            onDismissed = { scope.launch { chatState.hide() } },
+            onDismissed = {
+                if (chatState.currentValue == ModalBottomSheetValue.Expanded) {
+                    scope.launch { chatState.hide() }
+                } else {
+                    onLeaveCall.invoke()
+                }
+            },
         )
 
         if (speakingWhileMuted) {


### PR DESCRIPTION
Back button was not working during call in demo app because the Chat was capturing the `onBackPressed` event.