### PR TITLE
Disable mic in demo app if call opened directly after install

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
@@ -77,6 +77,7 @@ class DeeplinkingActivity : ComponentActivity() {
                 val intent = CallActivity.createIntent(
                     context = this@DeeplinkingActivity,
                     callId = callId,
+                    disableMicOverride = intent.getBooleanExtra(EXTRA_DISABLE_MIC_OVERRIDE, false),
                 ).apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
@@ -88,13 +89,24 @@ class DeeplinkingActivity : ComponentActivity() {
 
     companion object {
 
+        private const val EXTRA_DISABLE_MIC_OVERRIDE = "disableMic"
+
+        /**
+         * @param callId the Call ID you want to join
+         * @param disableMicOverride optional parameter if you want to override the users setting
+         * and disable the microphone.
+         */
         @JvmStatic
         fun createIntent(
             context: Context,
             callId: String,
+            disableMicOverride: Boolean = false,
         ): Intent {
             return Intent(context, DeeplinkingActivity::class.java).apply {
-                data = Uri.Builder().appendQueryParameter("id", callId).build()
+                data = Uri.Builder()
+                    .appendQueryParameter("id", callId)
+                    .build()
+                putExtra(EXTRA_DISABLE_MIC_OVERRIDE, disableMicOverride)
             }
         }
     }

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/MainActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : ComponentActivity() {
         @Suppress("KotlinConstantConditions")
         if (BuildConfig.FLAVOR == "production") {
             InstallReferrer(this).extractInstallReferrer { callId: String ->
-                startActivity(DeeplinkingActivity.createIntent(this, callId))
+                startActivity(DeeplinkingActivity.createIntent(this, callId, true))
             }
         }
 

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallActivity.kt
@@ -52,6 +52,11 @@ class CallActivity : ComponentActivity() {
             ?: throw IllegalArgumentException("call type and id is invalid!")
         val call = streamVideo.call(type = cid.type, id = cid.id)
 
+        // optional - call settings. We disable the mic if coming from QR code demo
+        if (intent.getBooleanExtra(EXTRA_DISABLE_MIC_BOOLEAN, false)) {
+            call.microphone.disable(true)
+        }
+
         // step 2 - join a call
         lifecycleScope.launch {
             val result = call.join(create = true)
@@ -103,14 +108,22 @@ class CallActivity : ComponentActivity() {
 
     companion object {
         const val EXTRA_CID: String = "EXTRA_CID"
+        const val EXTRA_DISABLE_MIC_BOOLEAN: String = "EXTRA_DISABLE_MIC"
 
+        /**
+         * @param callId the Call ID you want to join
+         * @param disableMicOverride optional parameter if you want to override the users setting
+         * and disable the microphone.
+         */
         @JvmStatic
         fun createIntent(
             context: Context,
             callId: StreamCallId,
+            disableMicOverride: Boolean = false,
         ): Intent {
             return Intent(context, CallActivity::class.java).apply {
                 putExtra(EXTRA_CID, callId)
+                putExtra(EXTRA_DISABLE_MIC_BOOLEAN, disableMicOverride)
             }
         }
     }


### PR DESCRIPTION
For better UX we will disable the microphone in the demo app if you install the app from QR code and you are directly connected to a call (skipping the Lobby screen which gives you the option to enable/disable mic and video).