### PR TITLE
Fix aspect ratio not working for VideoContent

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,7 @@ threetenAbp = "1.4.6"
 tink = "1.9.0"
 turbine = "0.13.0"
 
-streamWebRTC = "1.0.2"
+streamWebRTC = "1.0.3"
 streamResult = "1.1.0"
 streamChat = "6.0.0-beta1"
 streamLog = "1.1.4"

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
@@ -20,6 +20,7 @@ import android.view.View
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -70,7 +71,7 @@ public fun VideoRenderer(
     call: Call,
     video: ParticipantState.Media?,
     modifier: Modifier = Modifier,
-    videoScalingType: VideoScalingType = VideoScalingType.SCALE_ASPECT_BALANCED,
+    videoScalingType: VideoScalingType = VideoScalingType.SCALE_ASPECT_FILL,
     videoFallbackContent: @Composable (Call) -> Unit = {
         DefaultMediaTrackFallbackContent(
             modifier,
@@ -112,24 +113,26 @@ public fun VideoRenderer(
         }
 
         if (mediaTrack != null) {
-            AndroidView(
-                factory = { context ->
-                    StreamVideoTextureViewRenderer(context).apply {
-                        call.initRenderer(
-                            videoRenderer = this,
-                            sessionId = sessionId,
-                            trackType = trackType,
-                            onRendered = onRendered,
-                        )
-                        setScalingType(scalingType = videoScalingType.toCommonScalingType())
-                        setupVideo(mediaTrack, this)
+            Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                AndroidView(
+                    factory = { context ->
+                        StreamVideoTextureViewRenderer(context).apply {
+                            call.initRenderer(
+                                videoRenderer = this,
+                                sessionId = sessionId,
+                                trackType = trackType,
+                                onRendered = onRendered,
+                            )
+                            setScalingType(scalingType = videoScalingType.toCommonScalingType())
+                            setupVideo(mediaTrack, this)
 
-                        view = this
-                    }
-                },
-                update = { v -> setupVideo(mediaTrack, v) },
-                modifier = modifier.testTag("video_renderer"),
-            )
+                            view = this
+                        }
+                    },
+                    update = { v -> setupVideo(mediaTrack, v) },
+                    modifier = modifier.testTag("video_renderer"),
+                )
+            }
         } else {
             // fallback when the video is available but the track didn't load yet
             videoFallbackContent.invoke(call)


### PR DESCRIPTION
Changing the `VideoScalingType` didn't have an effect because of a bug in webrtc-android (https://github.com/GetStream/webrtc-android/pull/46). 

Issue originally reported here: https://github.com/GetStream/stream-video-android/issues/679 

Notice that I changed the aspect ration from BALANCED to FILL because that's what we actually want. It looks the same as before. Our VideoContent wasn't actually using BALANCED scale type - it was ignored due to the bug. 