### PR TITLE
Fix encryption failing after restore

### DIFF
--- a/stream-video-android-datastore/src/main/kotlin/io/getstream/video/android/datastore/delegate/StreamUserDataStore.kt
+++ b/stream-video-android-datastore/src/main/kotlin/io/getstream/video/android/datastore/delegate/StreamUserDataStore.kt
@@ -25,6 +25,7 @@ import com.google.crypto.tink.KeyTemplates
 import com.google.crypto.tink.aead.AeadConfig
 import com.google.crypto.tink.integration.android.AndroidKeysetManager
 import io.getstream.log.StreamLog
+import io.getstream.log.taggedLogger
 import io.getstream.video.android.datastore.model.StreamUserPreferences
 import io.getstream.video.android.datastore.serializer.UserSerializer
 import io.getstream.video.android.datastore.serializer.encrypted
@@ -34,6 +35,7 @@ import io.getstream.video.android.model.User
 import io.getstream.video.android.model.UserToken
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import java.security.KeyStore
 
 /**
  * A DataStore managers to persist Stream user login data safely, consistently, and transactionally.
@@ -117,6 +119,12 @@ public class StreamUserDataStore constructor(
         data.map { it?.userDevice }
 
     public companion object {
+
+        private val logger by taggedLogger("StreamUserDataStore")
+        private const val MASTER_KEY_PREFERENCE_FILE = "master_key_preference"
+        private const val USER_PROTO_FILE = "proto_stream_video_user.pb"
+        private const val MASTER_KEY_NAME = "master_key"
+
         /**
          * Represents if [StreamUserDataStore] is already installed or not.
          * Lets you know if the internal [StreamUserDataStore] instance is being used as the
@@ -167,20 +175,22 @@ public class StreamUserDataStore constructor(
 
                 val dataStore = if (isEncrypted) {
                     AeadConfig.register()
-                    val aead = AndroidKeysetManager.Builder()
-                        .withSharedPref(context, "master_keyset", "master_key_preference")
-                        .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
-                        .withMasterKeyUri("android-keystore://master_key")
-                        .build()
-                        .keysetHandle
-                        .getPrimitive(Aead::class.java)
 
+                    val aead = try {
+                        createAead(context)
+                    } catch (e: Exception) {
+                        // The client application is most likely using allowBack="true" in manifest
+                        // and our encrypted datastore can't be restored. We need to clear it.
+                        logger.e(e) { "Failed to decrypt the datastore - clearing data" }
+                        deleteEncryptionKeysAndData(context)
+                        createAead(context)
+                    }
                     DataStoreFactory.create(serializer = UserSerializer().encrypted(aead)) {
-                        context.dataStoreFile("proto_stream_video_user.pb")
+                        context.dataStoreFile(USER_PROTO_FILE)
                     }
                 } else {
                     DataStoreFactory.create(serializer = UserSerializer()) {
-                        context.dataStoreFile("proto_stream_video_user.pb")
+                        context.dataStoreFile(USER_PROTO_FILE)
                     }
                 }
 
@@ -189,6 +199,36 @@ public class StreamUserDataStore constructor(
                 internalStreamUserDataStore = userDataStore
                 return userDataStore
             }
+        }
+
+        private fun createAead(context: Context) =
+            AndroidKeysetManager.Builder()
+                .withSharedPref(context, "master_keyset", MASTER_KEY_PREFERENCE_FILE)
+                .withKeyTemplate(KeyTemplates.get("AES256_GCM"))
+                .withMasterKeyUri("android-keystore://${MASTER_KEY_NAME}")
+                .build()
+                .keysetHandle
+                .getPrimitive(Aead::class.java)
+
+        private fun deleteEncryptionKeysAndData(context: Context) {
+            // Remove the preference file
+            context.getSharedPreferences(MASTER_KEY_PREFERENCE_FILE, Context.MODE_PRIVATE)
+                .edit()
+                .clear()
+                .apply()
+
+            // Delete the master key
+            val keyStore = KeyStore.getInstance("AndroidKeyStore")
+            try {
+                keyStore.load(null)
+                keyStore.deleteEntry(MASTER_KEY_NAME)
+            } catch (e: Exception) {
+                logger.e(e) { "Failed to delete the master key" }
+                // Let's try to proceed anyway
+            }
+
+            // Delete stored data
+            context.dataStoreFile(USER_PROTO_FILE).delete()
         }
 
         /**


### PR DESCRIPTION
Client applications that use `allowBackup=true` (such us our demo app) will also back up files and preferences created by the Video SDK. If encryption is enabled (`encryptPreferences` is set to true in `StreamVideoBuilder`) then our encrypted data is backed up and we won't be able to decrypt them on restore (by definition - since it's encrypted with device keys). In this case the only thing we can do is to remove any local data and reinitialise the Datastore again. 

**How to test:**
You can run the script from https://developer.android.com/guide/topics/data/testingbackup#Preparing to back up the application, uninstall it and restore it. Our current develop will fail with:

```
Fatal Exception: java.security.InvalidKeyException: Keystore cannot load the key with ID: master_key
       at com.google.crypto.tink.integration.android.AndroidKeystoreAesGcm.<init>(AndroidKeystoreAesGcm.java:61)
       at com.google.crypto.tink.integration.android.AndroidKeystoreKmsClient.getAead(AndroidKeystoreKmsClient.java:179)
       at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.readMasterkeyDecryptAndParseKeyset(AndroidKeysetManager.java:366)
       at com.google.crypto.tink.integration.android.AndroidKeysetManager$Builder.build(AndroidKeysetManager.java:298)
       at io.getstream.video.android.datastore.delegate.StreamUserDataStore$Companion.install(StreamUserDataStore.kt:174)
       at io.getstream.video.android.datastore.delegate.StreamUserDataStore$Companion.install$default(StreamUserDataStore.kt:155)
       at io.getstream.video.android.core.notifications.internal.VideoPushDelegate$userDataStore$2.invoke(VideoPushDelegate.kt:46)
       at io.getstream.video.android.core.notifications.internal.VideoPushDelegate$userDataStore$2.invoke(VideoPushDelegate.kt:45)
```