### PR TITLE
Don't crash if PiP fails

### DIFF
--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/lifecycle/MediaPiPLifecycle.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/lifecycle/MediaPiPLifecycle.kt
@@ -72,14 +72,14 @@ public fun MediaPiPLifecycle(
                 call.camera.pause(fromUser = false)
                 call.microphone.pause(fromUser = false)
             } else if (!isInPictureInPicture) {
-                // TODO: There's not way to onUserLeaveHint in Compose for now.
-                // https://developer.android.com/reference/android/app/Activity#onUserLeaveHint()
-                try {
-                    Handler(Looper.getMainLooper()).post {
+                Handler(Looper.getMainLooper()).post {
+                    try {
+                        // TODO: There's not way to onUserLeaveHint in Compose for now.
+                        // https://developer.android.com/reference/android/app/Activity#onUserLeaveHint()
                         enterPictureInPicture(context = context, call = call)
+                    } catch (e: Exception) {
+                        StreamLog.d("MediaPiPLifecycle") { e.stackTraceToString() }
                     }
-                } catch (e: Exception) {
-                    StreamLog.d("MediaPiPLifecycle") { e.stackTraceToString() }
                 }
             }
         }


### PR DESCRIPTION
The try/catch needs to be inside the Handler to catch the Exception. Eventually we will need to fix the cause of the crash - we are enabling PiP too late in onPause, it should be done in `onUserLeaveHint()` - but we don't have that callback in Compose.