### PR TITLE
Fix PiP mode in gesture navigation

### DIFF
--- a/stream-video-android-compose/api/stream-video-android-compose.api
+++ b/stream-video-android-compose/api/stream-video-android-compose.api
@@ -3,7 +3,7 @@ public final class io/getstream/video/android/compose/lifecycle/CallLifecycleKt 
 }
 
 public final class io/getstream/video/android/compose/lifecycle/MediaPiPLifecycleKt {
-	public static final fun MediaPiPLifecycle (Lio/getstream/video/android/core/Call;ZJLandroidx/compose/runtime/Composer;II)V
+	public static final fun MediaPiPLifecycle (Lio/getstream/video/android/core/Call;ZLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/video/android/compose/permission/CallPermissionsKt {

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
@@ -134,7 +134,7 @@ public fun CallLobby(
 
     DefaultPermissionHandler(videoPermission = permissions)
 
-    MediaPiPLifecycle(call = call, pipEnteringDuration = 0)
+    MediaPiPLifecycle(call = call)
 
     Column(modifier = modifier) {
         Box(


### PR DESCRIPTION
This should fix the PiP issues on devices with gesture navigation. The lifecycle onPause() event is called too late. We need to listen to the Activity's onPause() event and then enter PiP. Ideally we should do it in `Activity.onUserLeaveHint` ([link](https://developer.android.com/reference/android/app/Activity#onUserLeaveHint())), but we haven't found a way how to get this callback into our `MediaPiPLifecycle` composable without asking the developers to forward us those events. 