### PR TITLE
Don't disconnect Coordinator WS if in active call

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -303,7 +303,10 @@ internal class StreamVideoImpl internal constructor(
 
                 override fun stopped() {
                     // We should only disconnect if we were previously connected
-                    if (connectionModule.coordinatorSocket.connectionState.value != SocketState.NotConnected) {
+                    // Also don't disconnect the socket if we are in an active call
+                    if (connectionModule.coordinatorSocket.connectionState.value != SocketState.NotConnected &&
+                        state.activeCall.value == null
+                    ) {
                         connectionModule.coordinatorSocket.disconnect()
                     }
                 }


### PR DESCRIPTION
There is no reason to disconnect the Coordinator WS while the app is in background and there is an active call. This can cause various other issues and we will stop getting messages related to the call. 