### PR TITLE
Wait for connectionId before doing API requests

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -2349,11 +2349,12 @@ public class io/getstream/video/android/core/socket/PersistentSocket : okhttp3/W
 	public final fun createSocket ()Lokhttp3/WebSocket;
 	public final fun disconnect ()V
 	public final fun getConnected ()Lkotlinx/coroutines/CancellableContinuation;
-	public final fun getConnectionId ()Ljava/lang/String;
+	public final fun getConnectionId ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getErrors ()Lkotlinx/coroutines/flow/MutableSharedFlow;
 	public final fun getEvents ()Lkotlinx/coroutines/flow/MutableSharedFlow;
 	public final fun getReconnectTimeout ()J
+	public final fun get_connectionId ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun get_connectionState ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public fun onClosed (Lokhttp3/WebSocket;ILjava/lang/String;)V
 	public fun onClosing (Lokhttp3/WebSocket;ILjava/lang/String;)V
@@ -2366,7 +2367,6 @@ public class io/getstream/video/android/core/socket/PersistentSocket : okhttp3/W
 	public final fun reconnect (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun reconnect$default (Lio/getstream/video/android/core/socket/PersistentSocket;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setConnected (Lkotlinx/coroutines/CancellableContinuation;)V
-	public final fun setConnectionId (Ljava/lang/String;)V
 	public final fun setReconnectTimeout (J)V
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -90,7 +90,8 @@ public open class PersistentSocket<T>(
     val connectionState: StateFlow<SocketState> = _connectionState
 
     /** the connection id */
-    var connectionId: String = ""
+    val _connectionId: MutableStateFlow<String?> = MutableStateFlow(null)
+    val connectionId: StateFlow<String?> = _connectionId
 
     /** Continuation if the socket successfully connected and we've authenticated */
     lateinit var connected: CancellableContinuation<T>
@@ -146,7 +147,7 @@ public open class PersistentSocket<T>(
         continuationCompleted = false
         _connectionState.value = SocketState.DisconnectedByRequest
         socket?.close(CODE_CLOSE_SOCKET_FROM_CLIENT, "Connection close by client")
-        connectionId = ""
+        _connectionId.value = null
         healthMonitor.stop()
         networkStateProvider.unsubscribe(networkStateListener)
     }
@@ -233,7 +234,7 @@ public open class PersistentSocket<T>(
 
             // TODO: This logic is specific to the Coordinator socket, move it
             if (processedEvent is ConnectedEvent) {
-                connectionId = processedEvent.connectionId
+                _connectionId.value = processedEvent.connectionId
                 _connectionState.value = SocketState.Connected(processedEvent)
                 if (!continuationCompleted) {
                     continuationCompleted = true

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/SocketTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/SocketTest.kt
@@ -149,7 +149,7 @@ class CoordinatorSocketTest : SocketTestBase() {
         val connectionStateItem = connectionState.awaitItem()
 
         assertThat(connectionStateItem).isInstanceOf(Connected::class.java)
-        assertThat(socket.connectionId).isNotEmpty()
+        assertThat(socket.connectionId.value).isNotEmpty()
     }
 
     @Test


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/4

The API calls can sometimes "outrun" the Coordinator WS connection. This is the case for example in the demo app when it's not running and you join a call from a deeplink (QR code) - we jump into the call and do not wait for the connectionId. This creates problems because the Coordinator WS connection will then not receive call related events. 

In worst case we will wait for 5 seconds and then proceed with a null connection id. In next changes we will add a `queryCalls()` call after the Coordinator WS reconnects and this will then make sure that backend learns about the new connection ID. 