### PR TITLE
Do full call reconnect in case SFU signalling WS goes down

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallActivity.kt
@@ -35,6 +35,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.onSuccessSuspend
 import io.getstream.chat.android.state.extensions.globalState
 import io.getstream.result.Result
+import io.getstream.video.android.MainActivity
 import io.getstream.video.android.core.BuildConfig
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.model.StreamCallId
@@ -81,6 +82,7 @@ class CallActivity : ComponentActivity() {
                 onLeaveCall = {
                     call.leave()
                     finish()
+                    startActivity(Intent(this, MainActivity::class.java))
                 },
             )
 

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
@@ -18,6 +18,7 @@
 
 package io.getstream.video.android.ui.call
 
+import android.widget.Toast
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -28,6 +29,7 @@ import androidx.compose.material.Snackbar
 import androidx.compose.material.Text
 import androidx.compose.material.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -49,6 +51,7 @@ import io.getstream.video.android.compose.ui.components.call.controls.actions.Se
 import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleCameraAction
 import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleMicrophoneAction
 import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.RealtimeConnection
 import io.getstream.video.android.mock.StreamMockUtils
 import io.getstream.video.android.mock.mockCall
 import kotlinx.coroutines.launch
@@ -59,6 +62,7 @@ fun CallScreen(
     showDebugOptions: Boolean = false,
     onLeaveCall: () -> Unit = {},
 ) {
+    val context = LocalContext.current
     val isCameraEnabled by call.camera.isEnabled.collectAsState()
     val isMicrophoneEnabled by call.microphone.isEnabled.collectAsState()
     val speakingWhileMuted by call.state.speakingWhileMuted.collectAsState()
@@ -70,6 +74,21 @@ fun CallScreen(
         skipHalfExpanded = true,
     )
     val scope = rememberCoroutineScope()
+
+    val callState by call.state.connection.collectAsState()
+
+    LaunchedEffect(key1 = callState) {
+        if (callState == RealtimeConnection.Disconnected) {
+            onLeaveCall.invoke()
+        } else if (callState is RealtimeConnection.Failed) {
+            Toast.makeText(
+                context,
+                "Call connection failed (${(callState as RealtimeConnection.Failed).error}",
+                Toast.LENGTH_LONG,
+            ).show()
+            onLeaveCall.invoke()
+        }
+    }
 
     VideoTheme {
         ChatDialog(

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/login/LoginScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/login/LoginScreen.kt
@@ -296,6 +296,10 @@ private fun HandleLoginUiStates(
                 navigateToCallJoin.invoke()
             }
 
+            is LoginUiState.AlreadyLoggedIn -> {
+                navigateToCallJoin.invoke()
+            }
+
             is LoginUiState.SignInFailure -> {
                 Toast.makeText(
                     context,

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -88,6 +88,10 @@ public final class io/getstream/video/android/core/CallHealthMonitor {
 	public final fun stop ()V
 }
 
+public final class io/getstream/video/android/core/CallKt {
+	public static final field sfuReconnectTimeoutMillis I
+}
+
 public final class io/getstream/video/android/core/CallState {
 	public fun <init> (Lio/getstream/video/android/core/StreamVideo;Lio/getstream/video/android/core/Call;Lio/getstream/video/android/model/User;Lkotlinx/coroutines/CoroutineScope;)V
 	public final fun clearParticipants ()V
@@ -2347,7 +2351,8 @@ public class io/getstream/video/android/core/socket/PersistentSocket : okhttp3/W
 	public final fun connect (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun connect$default (Lio/getstream/video/android/core/socket/PersistentSocket;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun createSocket ()Lokhttp3/WebSocket;
-	public final fun disconnect ()V
+	public final fun disconnect (Ljava/lang/Throwable;)V
+	public static synthetic fun disconnect$default (Lio/getstream/video/android/core/socket/PersistentSocket;Ljava/lang/Throwable;ILjava/lang/Object;)V
 	public final fun getConnected ()Lkotlinx/coroutines/CancellableContinuation;
 	public final fun getConnectionId ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;
@@ -2364,8 +2369,8 @@ public class io/getstream/video/android/core/socket/PersistentSocket : okhttp3/W
 	public fun onMessage (Lokhttp3/WebSocket;Ljava/lang/String;)V
 	public fun onMessage (Lokhttp3/WebSocket;Lokio/ByteString;)V
 	public fun onOpen (Lokhttp3/WebSocket;Lokhttp3/Response;)V
-	public final fun reconnect (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun reconnect$default (Lio/getstream/video/android/core/socket/PersistentSocket;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun reconnect (JLjava/lang/Throwable;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun reconnect$default (Lio/getstream/video/android/core/socket/PersistentSocket;JLjava/lang/Throwable;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun setConnected (Lkotlinx/coroutines/CancellableContinuation;)V
 	public final fun setReconnectTimeout (J)V
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallHealthMonitor.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallHealthMonitor.kt
@@ -120,6 +120,9 @@ public class CallHealthMonitor(val call: Call, val callScope: CoroutineScope) {
         reconnectInProgress = true
         reconnectionAttempts++
 
+        // TODO: Limit number of SFU peer connection retries - othwerwise the call can get stuck in
+        // reconnection and will never full-reconnect.
+
         val now = OffsetDateTime.now()
 
         val timeDifference = if (lastReconnectAt != null) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -412,7 +412,7 @@ internal class StreamVideoImpl internal constructor(
                     dataStore.updateUserToken(newToken)
                     connectionModule.updateToken(newToken)
                     // quickly reconnect with the new token
-                    socketImpl.reconnect(0)
+                    socketImpl.reconnect(0, e)
                     Failure(Error.GenericError("initialize error. trying to reconnect."))
                 } else {
                     throw e

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -608,6 +608,9 @@ public class RtcSession internal constructor(
         logger.i { "[cleanup] #sfu; no args" }
         supervisorJob.cancel()
 
+        // disconnect the socket and clean it up
+        sfuConnectionModule.sfuSocket.cleanup()
+
         // cleanup the publisher and subcriber peer connections
         subscriber?.connection?.close()
         publisher?.connection?.close()
@@ -627,9 +630,6 @@ public class RtcSession internal constructor(
         tracks.clear()
 
         trackDimensions.value = emptyMap()
-
-        // disconnect the socket and clean it up
-        sfuConnectionModule.sfuSocket.cleanup()
     }
 
     internal val muteState = MutableStateFlow(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -104,11 +104,21 @@ public open class PersistentSocket<T>(
     // we don't raise errors if you're closing the connection yourself
     private var closedByClient: Boolean = false
 
+    // True if cleanup was called and socket is completely destroyed (intentionally).
+    // You need to create a new instance (this is mainly used for the SfuSocket which is tied
+    // to a Subscriber SDP and needs to be recreated from scratch on WebRTC session clean up).
+    private var destroyed: Boolean = false
+
     /**
      * Connect the socket, authenticate, start the healthmonitor and see if the network is online
      */
-    suspend fun connect(invocation: (CancellableContinuation<T>) -> Unit = {}) =
-        suspendCancellableCoroutine { connectedContinuation ->
+    suspend fun connect(invocation: (CancellableContinuation<T>) -> Unit = {}): T? {
+        if (destroyed) {
+            logger.d { "[connect] Can't connect socket - it was already destroyed" }
+            return null
+        }
+
+        return suspendCancellableCoroutine { connectedContinuation ->
             logger.i { "[connect]" }
             connected = connectedContinuation
 
@@ -133,20 +143,31 @@ public open class PersistentSocket<T>(
                 invocation.invoke(connectedContinuation)
             }
         }
+    }
 
     fun cleanup() {
+        destroyed = true
         disconnect()
     }
 
     /**
      * Disconnect the socket
      */
-    fun disconnect() {
+    fun disconnect(reconnectReason: Throwable? = null) {
         logger.i { "[disconnect]" }
+
         closedByClient = true
         continuationCompleted = false
-        _connectionState.value = SocketState.DisconnectedByRequest
+
+        // If we are already DisconnectedByRequest then do not change the state to DisconnectedTemporarily.
+        // This prevents cases where reconnect() will overwrite the original state.
+        if (reconnectReason != null && _connectionState.value != SocketState.DisconnectedByRequest) {
+            _connectionState.value = SocketState.DisconnectedTemporarily(reconnectReason)
+        } else {
+            _connectionState.value = SocketState.DisconnectedByRequest
+        }
         socket?.close(CODE_CLOSE_SOCKET_FROM_CLIENT, "Connection close by client")
+        socket = null
         _connectionId.value = null
         healthMonitor.stop()
         networkStateProvider.unsubscribe(networkStateListener)
@@ -155,17 +176,23 @@ public open class PersistentSocket<T>(
     /**
      * Increment the reconnection attempts, disconnect and reconnect
      */
-    suspend fun reconnect(timeout: Long = reconnectTimeout) {
+    suspend fun reconnect(timeout: Long = reconnectTimeout, reconnectReason: Throwable?) {
         logger.i { "[reconnect] reconnectionAttempts: $reconnectionAttempts" }
         if (connectionState.value == SocketState.Connecting) {
             logger.i { "[reconnect] already connecting" }
             return
         }
-        _connectionState.value = SocketState.Connecting
+
+        if (destroyed) {
+            logger.d { "[reconnect] Can't reconnect socket - it was already destroyed" }
+            return
+        }
+
         reconnectionAttempts++
-        disconnect()
+        disconnect(reconnectReason = reconnectReason)
         // reconnect after the timeout
         delay(timeout)
+
         connect()
     }
 
@@ -177,7 +204,8 @@ public open class PersistentSocket<T>(
         logger.i { "[onNetworkConnected] state: $state" }
         if (state is SocketState.DisconnectedTemporarily || state == SocketState.NetworkDisconnected) {
             // reconnect instantly when the internet is back
-            reconnect(0)
+            val throwable = if (state is SocketState.DisconnectedTemporarily) state.error else null
+            reconnect(0, throwable)
         }
     }
 
@@ -344,7 +372,7 @@ public open class PersistentSocket<T>(
             logger.w { "[handleError] temporary error: $error" }
             _connectionState.value = SocketState.DisconnectedTemporarily(error)
             if (_connectionState.value != SocketState.Connecting) {
-                scope.launch { reconnect(reconnectTimeout) }
+                scope.launch { reconnect(reconnectTimeout, error) }
             }
         }
     }
@@ -377,15 +405,7 @@ public open class PersistentSocket<T>(
      */
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         logger.d { "[onFailure] t: $t, response: $response" }
-
-        if (_connectionState.value == SocketState.DisconnectedByRequest) {
-            // Do not handle failures after we are disconnected by request (intentionally)
-            // The websocket can sometimes throw an EOFException after we disconnected and this
-            // would be handled as recoverable error and we would reconnect.
-            logger.d { "[onFailure] Ignoring the error - already disconnect. t: $t" }
-        } else {
-            handleError(t)
-        }
+        handleError(t)
     }
 
     internal fun sendHealthCheck() {
@@ -400,7 +420,7 @@ public open class PersistentSocket<T>(
                 logger.i { "health monitor triggered a reconnect" }
                 val state = connectionState.value
                 if (state is SocketState.DisconnectedTemporarily) {
-                    this@PersistentSocket.reconnect()
+                    this@PersistentSocket.reconnect(reconnectReason = state.error)
                 }
             }
 


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/14

The Android implementation was missing a full reconnect flow in case the SFU signalling WS (`SfuSocket`) goes completely down. In this case a standard ICE restart will not usually help. The implementation is similar to iOS and React. We should also limit the amount of ICE restarts (currently it's not limited) - in a separate PR. 