### PR TITLE
Load mic and camera defaults in lobby screen

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
@@ -195,16 +195,16 @@ private fun CallLobbyBody(
 
         Spacer(modifier = Modifier.height(20.dp))
 
-        val localInspectionMode = LocalInspectionMode.current
         val isCameraEnabled: Boolean by if (LocalInspectionMode.current) {
             remember { mutableStateOf(true) }
         } else {
-            call.camera.isEnabled.collectAsState()
+            callLobbyViewModel.cameraEnabled.collectAsState(initial = false)
         }
+
         val isMicrophoneEnabled by if (LocalInspectionMode.current) {
             remember { mutableStateOf(true) }
         } else {
-            call.microphone.isEnabled.collectAsState()
+            callLobbyViewModel.microphoneEnabled.collectAsState(initial = false)
         }
 
         // turn on camera and microphone by default
@@ -213,9 +213,6 @@ private fun CallLobbyBody(
             if (BuildConfig.BENCHMARK.toBoolean()) {
                 callLobbyViewModel.call.camera.disable()
                 callLobbyViewModel.call.microphone.disable()
-            } else if (!localInspectionMode) {
-                callLobbyViewModel.call.camera.enable()
-                callLobbyViewModel.call.microphone.enable()
             }
         }
 
@@ -233,13 +230,19 @@ private fun CallLobbyBody(
             },
         )
 
-        LobbyDescription(callLobbyViewModel = callLobbyViewModel)
+        LobbyDescription(
+            callLobbyViewModel = callLobbyViewModel,
+            cameraEnabled = isCameraEnabled,
+            microphoneEnabled = isMicrophoneEnabled,
+        )
     }
 }
 
 @Composable
 private fun LobbyDescription(
     callLobbyViewModel: CallLobbyViewModel,
+    cameraEnabled: Boolean,
+    microphoneEnabled: Boolean,
 ) {
     val session by callLobbyViewModel.call.state.session.collectAsState()
 
@@ -267,7 +270,14 @@ private fun LobbyDescription(
                 .clip(RoundedCornerShape(12.dp))
                 .testTag("start_call"),
             text = stringResource(id = R.string.join_call),
-            onClick = { callLobbyViewModel.handleUiEvent(CallLobbyEvent.JoinCall) },
+            onClick = {
+                callLobbyViewModel.handleUiEvent(
+                    CallLobbyEvent.JoinCall(
+                        cameraEnabled = cameraEnabled,
+                        microphoneEnabled = microphoneEnabled,
+                    ),
+                )
+            },
         )
     }
 }

--- a/stream-video-android-compose/api/stream-video-android-compose.api
+++ b/stream-video-android-compose/api/stream-video-android-compose.api
@@ -754,7 +754,7 @@ public final class io/getstream/video/android/compose/ui/components/call/lobby/C
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/lobby/LobbyControlsActionsKt {
-	public static final fun buildDefaultLobbyControlActions (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)Ljava/util/List;
+	public static final fun buildDefaultLobbyControlActions (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function1;ZZLandroidx/compose/runtime/Composer;II)Ljava/util/List;
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/renderer/ComposableSingletons$FloatingParticipantVideoKt {

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
@@ -125,6 +125,8 @@ public fun CallLobby(
             actions = buildDefaultLobbyControlActions(
                 call = call,
                 onCallAction = onCallAction,
+                isCameraEnabled = isCameraEnabled,
+                isMicrophoneEnabled = isMicrophoneEnabled,
             ),
             spaceBy = VideoTheme.dimens.lobbyControlActionsItemSpaceBy,
         )

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/LobbyControlsActions.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/LobbyControlsActions.kt
@@ -20,12 +20,9 @@ import android.content.res.Configuration
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleCameraAction
 import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleMicrophoneAction
@@ -42,6 +39,16 @@ import io.getstream.video.android.core.call.state.CallAction
 public fun buildDefaultLobbyControlActions(
     call: Call,
     onCallAction: (CallAction) -> Unit,
+    isCameraEnabled: Boolean = if (LocalInspectionMode.current) {
+        true
+    } else {
+        call.camera.isEnabled.value
+    },
+    isMicrophoneEnabled: Boolean = if (LocalInspectionMode.current) {
+        true
+    } else {
+        call.microphone.isEnabled.value
+    },
 ): List<@Composable () -> Unit> {
     val orientation = LocalConfiguration.current.orientation
 
@@ -49,17 +56,6 @@ public fun buildDefaultLobbyControlActions(
         Modifier.size(VideoTheme.dimens.controlActionsButtonSize)
     } else {
         Modifier.size(VideoTheme.dimens.landscapeControlActionsButtonSize)
-    }
-
-    val isCameraEnabled by if (LocalInspectionMode.current) {
-        remember { mutableStateOf(true) }
-    } else {
-        call.camera.isEnabled.collectAsStateWithLifecycle()
-    }
-    val isMicrophoneEnabled by if (LocalInspectionMode.current) {
-        remember { mutableStateOf(true) }
-    } else {
-        call.microphone.isEnabled.collectAsStateWithLifecycle()
     }
 
     return listOf(


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/7

Observe and load the default call settings for mic and camera in lobby screen and then submit them to the SDK as user-selected values once Join Call is clicked. We leave this decision to the SDK clients but the demo app will take the server settings if no user selection has been made yet.