### PR TITLE
Fix initial microphone state (don't publish if muted)

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -820,8 +820,6 @@ public final class io/getstream/video/android/core/call/RtcSession {
 	public final fun handleEvent (Lorg/openapitools/client/models/VideoEvent;)V
 	public final fun handleIceTrickle (Lio/getstream/video/android/core/events/ICETrickleEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun handleSubscriberOffer (Lio/getstream/video/android/core/events/SubscriberOfferEvent;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun initializeVideoTransceiver ()V
-	public final fun listenToMediaChanges (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun mangleSdp (Lorg/webrtc/SessionDescription;)Lorg/webrtc/SessionDescription;
 	public final fun onNegotiationNeeded (Lio/getstream/video/android/core/call/connection/StreamPeerConnection;Lio/getstream/video/android/core/model/StreamPeerType;)V
 	public final fun reconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/18

We need to only publish the audio track if the microphone is unmuted. Currently we publish it and then we mute it immediately - but that doesn't work correctly because the mute request is faster than the track creation (it happens before `TrackPublishedEvent`. 
This is useful in following scenario:
- in lobby screen you mute the mic
- then you join the call

We would previously create the audio track and then mute it after that. This "worked" - but other participants would see you as "unmuted" even though locally the microphone was disabled, but the mute request (`RtcSession.setMuteState()`) was called too soon and didn't have an effect. 

This change now also allows us to remove the "hotfix" we had in the `TrackPublishedEvent` for handling the local participant audio and video state. 