### PR TITLE
Fix camera/audio settings "force-enabled" after permission granted

### DIFF
--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/permission/CallPermissions.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/permission/CallPermissions.kt
@@ -54,10 +54,10 @@ public fun rememberCallPermissionsState(
             onPermissionsResult.invoke(it)
         } else {
             if (it[android.Manifest.permission.CAMERA] == true && isCameraEnabled) {
-                call.camera.setEnabled(true)
+                call.camera.setEnabled(true, fromUser = false)
             }
             if (it[android.Manifest.permission.RECORD_AUDIO] == true && isMicrophoneEnabled) {
-                call.microphone.setEnabled(true)
+                call.microphone.setEnabled(true, fromUser = false)
             }
         }
     }

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/permission/SinglePermission.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/permission/SinglePermission.kt
@@ -30,7 +30,7 @@ public fun rememberCameraPermissionState(
     call: Call,
     onPermissionsResult: (Boolean) -> Unit = { isGranted ->
         if (isGranted) {
-            call.camera.setEnabled(true)
+            call.camera.setEnabled(true, fromUser = false)
         }
     },
 ): VideoPermissionsState {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -568,9 +568,6 @@ public class RtcSession internal constructor(
                         audio = call.mediaManager.audioTrack,
                     ),
                 )
-                if (call.mediaManager.microphone.status.value == DeviceStatus.Enabled) {
-                    initialiseAudioTransceiver()
-                }
 
                 // step 5 create the video track
                 setLocalTrack(
@@ -584,6 +581,9 @@ public class RtcSession internal constructor(
                 logger.v { "[createUserTracks] #sfu; videoTrack: ${call.mediaManager.videoTrack.stringify()}" }
                 if (call.mediaManager.camera.status.value == DeviceStatus.Enabled) {
                     initializeVideoTransceiver()
+                }
+                if (call.mediaManager.microphone.status.value == DeviceStatus.Enabled) {
+                    initialiseAudioTransceiver()
                 }
             }
         }


### PR DESCRIPTION
This fixes an issue where giving camera or audio permissions would also mark the camera and microphone as "enabled by user" and would override previous user-selected settings. We need to enabled camera after the permission is given (to see the camera preview in lobby, and also audio for volume indicator) but these should be not treated as user selections.

I also moved the `initialiseAudioTransceiver()` after the audio track is created.