### PR TITLE
Fix microphone permission - don't mark is as user selection

### DIFF
--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/permission/SinglePermission.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/permission/SinglePermission.kt
@@ -65,7 +65,7 @@ public fun rememberMicrophonePermissionState(
     call: Call,
     onPermissionsResult: (Boolean) -> Unit = { isGranted ->
         if (isGranted) {
-            call.microphone.setEnabled(true)
+            call.microphone.setEnabled(true, fromUser = false)
         }
     },
 ): VideoPermissionsState {


### PR DESCRIPTION
In the previous https://github.com/GetStream/stream-video-android/pull/772 PR I forgot about this line - we also need to make sure we don't consider the microphone permission granted event as "user selection".