### PR TITLE
Fix input not visible in demo (keyboard issue)

### DIFF
--- a/dogfooding/src/main/AndroidManifest.xml
+++ b/dogfooding/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
             android:name="io.getstream.video.android.MainActivity"
             android:exported="true"
             android:theme="@style/Dogfooding"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustPan">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/5

The input for Call ID is covered by the keyboard - we need to use `adjustPan` (or we could also leave `adjustResize` but then we would need to make the layout scrollable).