### PR TITLE
Remove logout and ring test buttons from demo app

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
@@ -134,17 +134,19 @@ private fun CallJoinHeader(
             )
         }
 
-        TextButton(
-            colors = ButtonDefaults.textButtonColors(contentColor = Color.White),
-            content = { Text(text = "Ring test") },
-            onClick = { onRingTestClicked.invoke() },
-        )
+        if (BuildConfig.FLAVOR != "production") {
+            TextButton(
+                colors = ButtonDefaults.textButtonColors(contentColor = Color.White),
+                content = { Text(text = "Ring test") },
+                onClick = { onRingTestClicked.invoke() },
+            )
 
-        StreamButton(
-            modifier = Modifier.widthIn(125.dp),
-            text = stringResource(id = R.string.sign_out),
-            onClick = { callJoinViewModel.signOut() },
-        )
+            StreamButton(
+                modifier = Modifier.widthIn(125.dp),
+                text = stringResource(id = R.string.sign_out),
+                onClick = { callJoinViewModel.signOut() },
+            )
+        }
     }
 }
 


### PR DESCRIPTION
In the demo app (`production` flavor) there is no reason to display the logout button because we do an auto-login. And the "Ring Test" is also not necessary - we can just keep it for internal testing.