### PR TITLE
Fix reported FPS (divide by 1000)

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -1299,6 +1299,11 @@ public class RtcSession internal constructor(
                             VideoQuality.VIDEO_QUALITY_LOW_UNSPECIFIED
                         }
                     }
+
+                    // We need to divide by 1000 because the the FramerateRange is multiplied
+                    // by 1000 (see javadoc).
+                    val fps = (captureResolution?.framerate?.max ?: 0).div(1000)
+
                     VideoLayer(
                         rid = it.rid ?: "",
                         video_dimension = VideoDimension(
@@ -1306,7 +1311,7 @@ public class RtcSession internal constructor(
                             height = height.toInt(),
                         ),
                         bitrate = it.maxBitrateBps ?: 0,
-                        fps = captureResolution?.framerate?.max ?: 0,
+                        fps = fps,
                         quality = quality,
                     )
                 }


### PR DESCRIPTION
We report 30 000 fps instead of 30 :-). iOS reports correct value.