### PR TITLE
Prevent camera freezing on call cleanup

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallActivity.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallActivity.kt
@@ -79,15 +79,15 @@ class CallActivity : ComponentActivity() {
             CallScreen(
                 call = call,
                 showDebugOptions = io.getstream.video.android.BuildConfig.DEBUG,
-                onLeaveCall = {
+                onCallDisconnected = {
+                    // call state changed to disconnected - we can leave the screen
+                    goBackToMainScreen()
+                },
+                onUserLeaveCall = {
                     call.leave()
-
-                    val intent = Intent(this, MainActivity::class.java).apply {
-                        flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                    }
-                    startActivity(intent)
-
-                    finish()
+                    // we don't need to wait for the call state to change to disconnected, we can
+                    // leave immediately
+                    goBackToMainScreen()
                 },
             )
 
@@ -110,6 +110,16 @@ class CallActivity : ComponentActivity() {
                     }
                 }
             }
+        }
+    }
+
+    private fun goBackToMainScreen() {
+        if (!isFinishing) {
+            val intent = Intent(this@CallActivity, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            startActivity(intent)
+            finish()
         }
     }
 

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
@@ -60,7 +60,8 @@ import kotlinx.coroutines.launch
 fun CallScreen(
     call: Call,
     showDebugOptions: Boolean = false,
-    onLeaveCall: () -> Unit = {},
+    onCallDisconnected: () -> Unit = {},
+    onUserLeaveCall: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val isCameraEnabled by call.camera.isEnabled.collectAsState()
@@ -79,14 +80,14 @@ fun CallScreen(
 
     LaunchedEffect(key1 = callState) {
         if (callState == RealtimeConnection.Disconnected) {
-            onLeaveCall.invoke()
+            onCallDisconnected.invoke()
         } else if (callState is RealtimeConnection.Failed) {
             Toast.makeText(
                 context,
                 "Call connection failed (${(callState as RealtimeConnection.Failed).error}",
                 Toast.LENGTH_LONG,
             ).show()
-            onLeaveCall.invoke()
+            onCallDisconnected.invoke()
         }
     }
 
@@ -103,7 +104,7 @@ fun CallScreen(
                         if (chatState.currentValue == ModalBottomSheetValue.Expanded) {
                             scope.launch { chatState.hide() }
                         } else {
-                            onLeaveCall.invoke()
+                            onUserLeaveCall.invoke()
                         }
                     },
                     controlsContent = {
@@ -177,7 +178,7 @@ fun CallScreen(
                                         modifier = Modifier.size(
                                             VideoTheme.dimens.controlActionsButtonSize,
                                         ),
-                                        onCallAction = { onLeaveCall.invoke() },
+                                        onCallAction = { onUserLeaveCall.invoke() },
                                     )
                                 },
                             ),
@@ -190,7 +191,7 @@ fun CallScreen(
                 if (chatState.currentValue == ModalBottomSheetValue.Expanded) {
                     scope.launch { chatState.hide() }
                 } else {
-                    onLeaveCall.invoke()
+                    onCallDisconnected.invoke()
                 }
             },
         )


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/21

This fixes problems where the camera would freeze when the call is left quickly after joining it. There were several issues:
- we were not calling `mediaManager.cleanup()` in `Call.leave()` and the camera along with the tracks was not released properly
- there is no guard against double leaving - this can crash because the resources are already disposed and disposing or manipulating them after this point leads to unexpected exceptions
- to be safe I also altered the `CallLobbyViewModel` to make sure we only collect the first call settings, update the UI and then stop collecting
- in the demo in `CallLobbyViewModel` we need to differentiate between the user leaving the call (by clicking a button) and the call state changing to disconnected (can be some other issue, not directly UI action related). 
- also a slight improvement in demo UX - camera and mic are by default on and then we update the state after we get the settings response (which is a bit delayed, so we assume it's enabled to make it look nicer when the lobby screen starts).