### PR TITLE
Add button to kill SFU WS connection - reconnect test

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/SettingsMenu.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/SettingsMenu.kt
@@ -151,6 +151,34 @@ internal fun SettingsMenu(
 
                     Row(
                         modifier = Modifier.clickable {
+                            call.debug.doFullReconnection()
+                            onDismissed.invoke()
+                            Toast.makeText(
+                                context,
+                                "Killing SFU WS. Should trigger reconnect...",
+                                Toast.LENGTH_SHORT,
+                            ).show()
+                        },
+                    ) {
+                        Icon(
+                            painter = painterResource(
+                                id = R.drawable.stream_video_ic_fullscreen_exit,
+                            ),
+                            tint = VideoTheme.colors.textHighEmphasis,
+                            contentDescription = null,
+                        )
+
+                        Text(
+                            modifier = Modifier.padding(start = 20.dp),
+                            text = "Kill SFU WS",
+                            color = VideoTheme.colors.textHighEmphasis,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Row(
+                        modifier = Modifier.clickable {
                             call.debug.switchSfu()
                             onDismissed.invoke()
                             Toast.makeText(context, "Switch sfu", Toast.LENGTH_SHORT).show()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -831,6 +831,10 @@ public class Call(
     @InternalStreamVideoApi
     public class Debug(val call: Call) {
 
+        public fun doFullReconnection() {
+            call.session?.sfuConnectionModule?.sfuSocket?.cancel()
+        }
+
         public fun restartSubscriberIce() {
             call.session?.subscriber?.connection?.restartIce()
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -145,6 +145,13 @@ public open class PersistentSocket<T>(
         }
     }
 
+    /**
+     * Used for testing only - to bring down the socket connection immediately.
+     */
+    internal fun cancel() {
+        socket?.cancel()
+    }
+
     fun cleanup() {
         destroyed = true
         disconnect()


### PR DESCRIPTION
We are adding a "Kill SFU WS" button for reconnection testing. This will immediately close the SfuSocket connection (it will do `WebSocket.cancel()` and this should then trigger a full call reconnection flow.