### PR TITLE
Fix crash on updateLocalStats if camera is not initialised

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallStats.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallStats.kt
@@ -146,9 +146,9 @@ public class CallStats(val call: Call, val callScope: CoroutineScope) {
 
     fun updateLocalStats() {
         val displayingAt = call.session?.trackDimensions?.value ?: emptyMap()
-        val resolution = call.camera?.resolution?.value
-        val availableResolutions = call.camera?.availableResolutions?.value
-        val maxResolution = availableResolutions?.maxByOrNull { it.width * it.height }
+        val resolution = call.camera.resolution.value
+        val availableResolutions = call.camera.availableResolutions.value
+        val maxResolution = availableResolutions.maxByOrNull { it.width * it.height }
 
         val sfu = call.session?.sfuUrl
 
@@ -172,8 +172,8 @@ public class CallStats(val call: Call, val callScope: CoroutineScope) {
 
         scope.launch {
             val toMap = mutableMapOf<String, Any>()
-            toMap["availableResolutions"] = availableResolutions as Any
-            toMap["maxResolution"] = maxResolution as Any
+            toMap["availableResolutions"] = availableResolutions
+            toMap["maxResolution"] = maxResolution ?: ""
             toMap["displayingAt"] = displayingAt
             call.sendStats(toMap)
         }


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/25

In Kotlin you can't cast null to `Any` and in this case it may happen that the variables were null when available resolutions was empty (camera was not initialised yet - for example in audio room tutorial). This is a quick fix - we will revisit this code later because the updateStates() function doesn't yet send the data anyway.