### PR TITLE
Enable R8/Proguard on demo application

### DIFF
--- a/dogfooding/build.gradle.kts
+++ b/dogfooding/build.gradle.kts
@@ -94,7 +94,7 @@ android {
             buildConfigField("Boolean", "BENCHMARK", "false")
         }
         getByName("release") {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/stream-video-android-core/consumer-proguard-rules.pro
+++ b/stream-video-android-core/consumer-proguard-rules.pro
@@ -1,6 +1,11 @@
 ## Stream Video Android Core Proguard Rules
 
+# Wire protocol buffer model classes
 -keep class stream.video.sfu.** { *; }
+
 -keep class com.squareup.moshi.JsonReader
 -keep class com.squareup.moshi.JsonAdapter
 -keep class kotlin.reflect.jvm.internal.* { *; }
+
+## Moshi model classes
+-keep class org.openapitools.client.** { *; }


### PR DESCRIPTION
Resolves https://github.com/GetStream/android-video-issues-tracking/issues/26

We need to enable R8/Proguard in our demo app to test that the SDK can be correctly used in client apps that use code minification.

