### PR TITLE
Prevent crash if MediaStreamTrack is already disposed

### DIFF
--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
@@ -148,7 +148,14 @@ private fun cleanTrack(
     mediaTrack: MediaTrack?,
 ) {
     if (view != null && mediaTrack is VideoTrack) {
-        mediaTrack.video.removeSink(view)
+        try {
+            mediaTrack.video.removeSink(view)
+        } catch (e: Exception) {
+            // The MediaStreamTrack can be already disposed at this point (from other parts of the code)
+            // Removing the Sink at this point will throw a IllegalStateException("MediaStreamTrack has been disposed.")
+            // See MediaStreamTrack.checkMediaStreamTrackExists()
+            StreamLog.w("VideoRenderer") { "Failed to removeSink in onDispose:  ${e.message}" }
+        }
     }
 }
 
@@ -163,7 +170,7 @@ private fun setupVideo(
             mediaTrack.video.addSink(renderer)
         }
     } catch (e: Exception) {
-        StreamLog.d("VideoRenderer") { e.message.toString() }
+        StreamLog.w("VideoRenderer") { e.message.toString() }
     }
 }
 


### PR DESCRIPTION
The MediaStreamTrack can get disposed from other parts of the code and the UI can then try to remove the Sink from a disposed MediaStreamTrack which will throw an exception. Unfortunately I haven't found a clean way to check if the `MediaStreamTrack` is disposed. We should eventually double check that we are updating the `ParticipantState.Media` in `VideoRenderer` and setting the `video` field as soon as it's disposed.