### PR TITLE
Add Audio Filters support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ Video roadmap and changelog is available [here](https://github.com/GetStream/pro
 
 - [X] Screensharing from mobile
 - [X] Picture of the video stream at the highest resolution + docs on how to add a button for this (Daniel)
+- [X] Audio & Video filters. Support  (Daniel)
 - [ ] Default livestream player UI + docs (Jaewoong/ Daniel)
 - [ ] Implement Chat overlay for Dogfooding (Jaewoong)
-- [ ] Audio & Video filters. Support  (Daniel)
 - [ ] Add Dogfooding instructions + directs Google Play (Jaewoong)
 - [ ] Reaction dialog API for Compose (Jaewoong)
 - [ ] Android SDK development.md cleanup (Daniel)

--- a/docusaurus/docs/Android/06-advanced/05-apply-video-filters.mdx
+++ b/docusaurus/docs/Android/06-advanced/05-apply-video-filters.mdx
@@ -11,7 +11,7 @@ How does this work? You can inject a filter through `Call.videoFilter`, you will
 
 ## Adding a Video Filter
 
-Create a `BitmapVideoFilter` or `RawVideoFilter` instance in your project. Here is how the abstract classes look like:
+Create a `BitmapVideoFilter` or `RawVideoFilter` instance in your project. Here is how the abstract classes are defined:
 
 ```kotlin
 abstract class BitmapVideoFilter : VideoFilter() {
@@ -131,4 +131,65 @@ The result:
 
 ## Audio Filters
 
-TODO
+The StreamVideo SDK also supports custom audio processing of the local track. This opens up possibilities for custom echo filtering, voice changing or other audio effects.
+
+If you want to have custom audio processing, you need to provide your own implementation of the `AudioFilter` interface to `Call.audioFilter`.
+
+The `AudioFilter` is defined like this:
+
+```kotlin
+interface AudioFilter {
+    /**
+     * Invoked after an audio sample is recorded. Can be used to manipulate
+     * the ByteBuffer before it's fed into WebRTC. Currently the audio in the
+     * ByteBuffer is always PCM 16bit and the buffer sample size is ~10ms.
+     *
+     * @param audioFormat format in android.media.AudioFormat
+     */
+    fun filter(audioFormat: Int, channelCount: Int, sampleRate: Int, sampleData: ByteBuffer)
+}
+```
+
+In the following example, we will build a simple audio filter that gives the user's voice a robotic touch.
+
+```kotlin
+// We assume that you already have a call instance (call is started)
+// Create a simple filter (pitch modification) and assign it to the call
+
+call.audioFilter = object: AudioFilter {
+
+    override fun filter(audioFormat: Int, channelCount: Int, sampleRate: Int, sampleData: ByteBuffer) {
+        // You can modify the pitch factor to achieve a bit different effect
+        val pitchShiftFactor = 0.8f
+        val inputBuffer = audioBuffer.duplicate()
+        inputBuffer.order(ByteOrder.LITTLE_ENDIAN) // Set byte order for correct handling of PCM data
+
+        val numSamples = inputBuffer.remaining() / 2 // Assuming 16-bit PCM audio
+
+        val outputBuffer = ByteBuffer.allocate(inputBuffer.capacity())
+        outputBuffer.order(ByteOrder.LITTLE_ENDIAN)
+
+        for (channel in 0 until numChannels) {
+            val channelBuffer = ShortArray(numSamples)
+            inputBuffer.asShortBuffer().get(channelBuffer)
+
+            for (i in 0 until numSamples) {
+                val originalIndex = (i * pitchShiftFactor).toInt()
+
+                if (originalIndex >= 0 && originalIndex < numSamples) {
+                    outputBuffer.putShort(channelBuffer[originalIndex])
+                } else {
+                    // Fill with silence if the index is out of bounds
+                    outputBuffer.putShort(0)
+                }
+            }
+        }
+
+        outputBuffer.flip()
+        audioBuffer.clear()
+        audioBuffer.put(outputBuffer)
+        audioBuffer.flip()
+    }
+}
+```
+This is a simple algorithm that just does shifting of the indexes. For a more complex one, you can also use some voice processing library. The important part is that you update the `channelBuffer` with the filtered values.

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/SettingsMenu.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/ui/call/SettingsMenu.kt
@@ -46,10 +46,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.call.audio.AudioFilter
 import io.getstream.video.android.core.call.video.BitmapVideoFilter
 import io.getstream.video.android.ui.common.R
+import io.getstream.video.android.util.SampleAudioFilter
 import io.getstream.video.android.util.SampleVideoFilter
 import kotlinx.coroutines.launch
+import java.nio.ByteBuffer
 
 @Composable
 internal fun SettingsMenu(
@@ -76,7 +79,9 @@ internal fun SettingsMenu(
     val isScreenSharing by call.screenShare.isEnabled.collectAsState()
     val screenShareButtonText = if (isScreenSharing) {
         "Stop screen-sharing"
-    } else { "Start screen-sharing" }
+    } else {
+        "Start screen-sharing"
+    }
 
     Popup(
         alignment = Alignment.BottomStart,
@@ -147,35 +152,76 @@ internal fun SettingsMenu(
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                Row(
-                    modifier = Modifier.clickable {
-                        if (call.videoFilter == null) {
-                            call.videoFilter = object : BitmapVideoFilter() {
-                                override fun filter(bitmap: Bitmap) {
-                                    SampleVideoFilter.toGrayscale(bitmap)
-                                }
-                            }
-                        } else {
-                            call.videoFilter = null
-                        }
-                    },
-                ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.stream_video_ic_fullscreen_exit),
-                        tint = VideoTheme.colors.textHighEmphasis,
-                        contentDescription = null,
-                    )
-
-                    Text(
-                        modifier = Modifier.padding(start = 20.dp),
-                        text = "Toggle video filter",
-                        color = VideoTheme.colors.textHighEmphasis,
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(12.dp))
-
                 if (showDebugOptions) {
+                    Row(
+                        modifier = Modifier.clickable {
+                            if (call.videoFilter == null) {
+                                call.videoFilter = object : BitmapVideoFilter() {
+                                    override fun filter(bitmap: Bitmap) {
+                                        SampleVideoFilter.toGrayscale(bitmap)
+                                    }
+                                }
+                            } else {
+                                call.videoFilter = null
+                            }
+                        },
+                    ) {
+                        Icon(
+                            painter = painterResource(
+                                id = R.drawable.stream_video_ic_fullscreen_exit,
+                            ),
+                            tint = VideoTheme.colors.textHighEmphasis,
+                            contentDescription = null,
+                        )
+
+                        Text(
+                            modifier = Modifier.padding(start = 20.dp),
+                            text = "Toggle video filter",
+                            color = VideoTheme.colors.textHighEmphasis,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
+                    Row(
+                        modifier = Modifier.clickable {
+                            if (call.audioFilter == null) {
+                                call.audioFilter = object : AudioFilter {
+                                    override fun filter(
+                                        audioFormat: Int,
+                                        channelCount: Int,
+                                        sampleRate: Int,
+                                        sampleData: ByteBuffer,
+                                    ) {
+                                        SampleAudioFilter.toRoboticVoice(
+                                            sampleData,
+                                            channelCount,
+                                            0.8f,
+                                        )
+                                    }
+                                }
+                            } else {
+                                call.audioFilter = null
+                            }
+                        },
+                    ) {
+                        Icon(
+                            painter = painterResource(
+                                id = R.drawable.stream_video_ic_fullscreen_exit,
+                            ),
+                            tint = VideoTheme.colors.textHighEmphasis,
+                            contentDescription = null,
+                        )
+
+                        Text(
+                            modifier = Modifier.padding(start = 20.dp),
+                            text = "Toggle audio filter",
+                            color = VideoTheme.colors.textHighEmphasis,
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(12.dp))
+
                     Row(
                         modifier = Modifier.clickable {
                             call.debug.restartSubscriberIce()

--- a/dogfooding/src/main/kotlin/io/getstream/video/android/util/SampleAudioFilter.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/util/SampleAudioFilter.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.util
+
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+object SampleAudioFilter {
+
+    fun toRoboticVoice(audioBuffer: ByteBuffer, numChannels: Int, pitchShiftFactor: Float) {
+        require(pitchShiftFactor > 0) { "Pitch shift factor must be greater than 0." }
+
+        val inputBuffer = audioBuffer.duplicate()
+        inputBuffer.order(
+            ByteOrder.LITTLE_ENDIAN,
+        ) // Set byte order for correct handling of PCM data
+
+        val numSamples = inputBuffer.remaining() / 2 // Assuming 16-bit PCM audio
+
+        val outputBuffer = ByteBuffer.allocate(inputBuffer.capacity())
+        outputBuffer.order(ByteOrder.LITTLE_ENDIAN)
+
+        for (channel in 0 until numChannels) {
+            val channelBuffer = ShortArray(numSamples)
+            inputBuffer.asShortBuffer().get(channelBuffer)
+
+            for (i in 0 until numSamples) {
+                val originalIndex = (i * pitchShiftFactor).toInt()
+
+                if (originalIndex >= 0 && originalIndex < numSamples) {
+                    outputBuffer.putShort(channelBuffer[originalIndex])
+                } else {
+                    // Fill with silence if the index is out of bounds
+                    outputBuffer.putShort(0)
+                }
+            }
+        }
+
+        outputBuffer.flip()
+        audioBuffer.clear()
+        audioBuffer.put(outputBuffer)
+        audioBuffer.flip()
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@ threetenAbp = "1.4.6"
 tink = "1.9.0"
 turbine = "0.13.0"
 
-streamWebRTC = "1.0.4"
+streamWebRTC = "1.0.6"
 streamResult = "1.1.0"
 streamChat = "6.0.0-beta1"
 streamLog = "1.1.4"

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9,6 +9,7 @@ public final class io/getstream/video/android/core/Call {
 	public final fun end (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun fireEvent (Lorg/openapitools/client/models/VideoEvent;)V
 	public final fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getAudioFilter ()Lio/getstream/video/android/core/call/audio/AudioFilter;
 	public final fun getCamera ()Lio/getstream/video/android/core/CameraManager;
 	public final fun getCid ()Ljava/lang/String;
 	public final fun getId ()Ljava/lang/String;
@@ -51,6 +52,7 @@ public final class io/getstream/video/android/core/Call {
 	public final fun sendReaction (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun sendReaction$default (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun sendStats (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setAudioFilter (Lio/getstream/video/android/core/call/audio/AudioFilter;)V
 	public final fun setVideoFilter (Lio/getstream/video/android/core/call/video/VideoFilter;)V
 	public final fun setVisibility (Ljava/lang/String;Lstream/video/sfu/models/TrackType;Z)V
 	public final fun startHLS (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -917,6 +919,10 @@ public final class io/getstream/video/android/core/call/TrackDimensions {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface class io/getstream/video/android/core/call/audio/AudioFilter {
+	public abstract fun filter (IIILjava/nio/ByteBuffer;)V
+}
+
 public final class io/getstream/video/android/core/call/connection/StreamPeerConnection : org/webrtc/PeerConnection$Observer {
 	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lio/getstream/video/android/core/model/StreamPeerType;Lorg/webrtc/MediaConstraints;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;I)V
 	public final fun addAudioTransceiver (Lorg/webrtc/MediaStreamTrack;Ljava/util/List;)V
@@ -960,6 +966,7 @@ public final class io/getstream/video/android/core/call/connection/StreamPeerCon
 	public final fun makePeerConnection (Lkotlinx/coroutines/CoroutineScope;Lorg/webrtc/PeerConnection$RTCConfiguration;Lio/getstream/video/android/core/model/StreamPeerType;Lorg/webrtc/MediaConstraints;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;I)Lio/getstream/video/android/core/call/connection/StreamPeerConnection;
 	public static synthetic fun makePeerConnection$default (Lio/getstream/video/android/core/call/connection/StreamPeerConnectionFactory;Lkotlinx/coroutines/CoroutineScope;Lorg/webrtc/PeerConnection$RTCConfiguration;Lio/getstream/video/android/core/model/StreamPeerType;Lorg/webrtc/MediaConstraints;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;IILjava/lang/Object;)Lio/getstream/video/android/core/call/connection/StreamPeerConnection;
 	public final fun makeVideoTrack (Lorg/webrtc/VideoSource;Ljava/lang/String;)Lorg/webrtc/VideoTrack;
+	public final fun setAudioRecordDataCallback (Lkotlin/jvm/functions/Function4;)V
 	public final fun setAudioSampleCallback (Lkotlin/jvm/functions/Function1;)V
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -26,6 +26,7 @@ import io.getstream.result.Result
 import io.getstream.result.Result.Failure
 import io.getstream.result.Result.Success
 import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.audio.AudioFilter
 import io.getstream.video.android.core.call.utils.SoundInputProcessor
 import io.getstream.video.android.core.call.video.VideoFilter
 import io.getstream.video.android.core.call.video.YuvFrame
@@ -137,6 +138,11 @@ public class Call(
      * Set a custom [VideoFilter] that will be applied to the video stream coming from your device.
      */
     var videoFilter: VideoFilter? = null
+
+    /**
+     * Set a custom [AudioFilter] that will be applied to the audio stream recorded on your device.
+     */
+    var audioFilter: AudioFilter? = null
 
     /**
      * Called by the [CallHealthMonitor] when the ICE restarts failed after

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -327,6 +327,15 @@ public class RtcSession internal constructor(
         clientImpl.peerConnectionFactory.setAudioSampleCallback { it ->
             call.processAudioSample(it)
         }
+
+        clientImpl.peerConnectionFactory.setAudioRecordDataCallback { audioFormat, channelCount, sampleRate, sampleData ->
+            call.audioFilter?.filter(
+                audioFormat = audioFormat,
+                channelCount = channelCount,
+                sampleRate = sampleRate,
+                sampleData = sampleData,
+            )
+        }
     }
 
     private fun listenToSocket() {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/audio/AudioFilter.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/audio/AudioFilter.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.audio
+
+import java.nio.ByteBuffer
+
+interface AudioFilter {
+    /**
+     * Invoked after an audio sample is recorded. Can be used to manipulate
+     * the ByteBuffer before it's fed into WebRTC. Currently the audio in the
+     * ByteBuffer is always PCM 16bit and the buffer sample size is ~10ms.
+     *
+     * @param audioFormat format in android.media.AudioFormat
+     */
+    fun filter(audioFormat: Int, channelCount: Int, sampleRate: Int, sampleData: ByteBuffer)
+}


### PR DESCRIPTION
Depends on: https://github.com/GetStream/webrtc-android/pull/63 

Adds support for simple audio filters. An audio filter can be added (or removed) to a Call instance with `Call.audioFilter`. 

The interface for the filter is defined like this:

```
interface AudioFilter {
    /**
     * Invoked after an audio sample is recorded. Can be used to manipulate
     * the ByteBuffer before it's fed into WebRTC. Currently the audio in the
     * ByteBuffer is always PCM 16bit and the buffer sample size is ~10ms.
     *
     * @param audioFormat format in android.media.AudioFormat
     */
    fun filter(audioFormat: Int, channelCount: Int, sampleRate: Int, sampleData: ByteBuffer)
}
```

The sample has a simple robotic voice filter that can be enabled through the "three dots" menu during a call. 