### PR TITLE
Improve VideoFrame YUV -> Bitmap conversion

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -2752,6 +2752,11 @@ public abstract class io/getstream/video/android/core/call/video/RawVideoFilter 
 public class io/getstream/video/android/core/call/video/VideoFilter {
 }
 
+public final class io/getstream/video/android/core/call/video/YuvFrame {
+	public static final field INSTANCE Lio/getstream/video/android/core/call/video/YuvFrame;
+	public final fun bitmapFromVideoFrame (Lorg/webrtc/VideoFrame;)Landroid/graphics/Bitmap;
+}
+
 public final class io/getstream/video/android/core/dispatchers/DispatcherProvider {
 	public static final field INSTANCE Lio/getstream/video/android/core/dispatchers/DispatcherProvider;
 	public final fun getDefault ()Lkotlinx/coroutines/CoroutineDispatcher;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/FilterVideoProcessor.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/FilterVideoProcessor.kt
@@ -63,9 +63,7 @@ internal class FilterVideoProcessor(
             sink?.onFrame(filteredFrame)
         } else if (currentFilter is BitmapVideoFilter) {
             // first prepare a Bitmap for the client
-            val yuvFrame = YuvFrame(frame)
-            inputFrameBitmap = yuvFrame.getBitmap()
-            yuvFrame.dispose()
+            inputFrameBitmap = YuvFrame.bitmapFromVideoFrame(frame)
 
             if (inputFrameBitmap != null && sink != null) {
                 // Prepare helpers (runs only once or if the dimensions change)


### PR DESCRIPTION
This change uses a more native approach to the YUV (I420) -> ARGB Bitmap conversion with help of the LibYUV library. It is about 25% faster and the code is much easier to read - we leave most of the conversion logic to the LibYUV library instead of our code.