### PR TITLE
Fix random name generation in demo app

### DIFF
--- a/dogfooding/src/main/kotlin/io/getstream/video/android/util/UserIdGenerator.kt
+++ b/dogfooding/src/main/kotlin/io/getstream/video/android/util/UserIdGenerator.kt
@@ -19,7 +19,11 @@ package io.getstream.video.android.util
 object UserIdGenerator {
 
     fun generateRandomString(length: Int = 8, upperCaseOnly: Boolean = false): String {
-        val allowedChars = ('A'..'Z') + ('0'..'9') + if (!upperCaseOnly) { ('a'..'z') } else { }
+        val allowedChars: List<Char> = ('A'..'Z') + ('0'..'9') + if (!upperCaseOnly) {
+            ('a'..'z')
+        } else {
+            emptyList()
+        }
 
         return (1..length)
             .map { allowedChars.random() }


### PR DESCRIPTION
Small fix for random userId generator - the `{ }` caused a  wrong name to be generated with a `Kotlin.Unit` inside the random generated name. 