### PR TITLE
When the dominant speaker changes, do not scroll to the bottom.

### DIFF
--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
@@ -303,10 +303,7 @@ internal fun BoxScope.LandscapeVideoRenderer(
                     modifier = Modifier.fillMaxSize(),
                     columns = GridCells.Fixed(3),
                     content = {
-                        items(
-                            count = callParticipants.size,
-                            key = { callParticipants[it].sessionId },
-                        ) { key ->
+                        items(count = callParticipants.size) { key ->
                             // make 2 items exactly fit available height
                             val itemHeight = with(LocalDensity.current) {
                                 (constraints.maxHeight / 2).toDp()

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
@@ -324,10 +324,7 @@ internal fun BoxScope.PortraitVideoRenderer(
                     modifier = Modifier.fillMaxSize(),
                     columns = GridCells.Fixed(2),
                     content = {
-                        items(
-                            count = callParticipants.size,
-                            key = { callParticipants[it].sessionId },
-                        ) { key ->
+                        items(count = callParticipants.size) { key ->
                             // make 3 items exactly fit available height
                             val itemHeight = with(LocalDensity.current) {
                                 (constraints.maxHeight / 3).toDp()


### PR DESCRIPTION
Do not change the scroll position to the bottom when the dominant speaker changes. 