### PR TITLE
Handle null started_at in call state

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -193,6 +193,11 @@ public class CallState(
         _participants.mapState { it.values.toList() }
 
     private val _startedAt: MutableStateFlow<OffsetDateTime?> = MutableStateFlow(null)
+
+    /**
+     * Will return always null with current SFU implementation - it may be fixed later. For now
+     * do not use it.
+     */
     public val startedAt: StateFlow<OffsetDateTime?> = _startedAt
 
     private val _participantCounts: MutableStateFlow<ParticipantCount?> = MutableStateFlow(null)
@@ -896,8 +901,14 @@ public class CallState(
         // update the participant count
         _participantCounts.value = event.participantCount
 
-        val instant = Instant.ofEpochSecond(event.callState.started_at?.epochSecond!!, 0)
-        _startedAt.value = OffsetDateTime.ofInstant(instant, ZoneOffset.UTC)
+        val startedAt = event.callState.started_at
+        if (startedAt != null) {
+            val instant = Instant.ofEpochSecond(startedAt.epochSecond, 0)
+            _startedAt.value = OffsetDateTime.ofInstant(instant, ZoneOffset.UTC)
+        } else {
+            _startedAt.value = null
+        }
+
         // creates the participants
         val participantStates = event.callState.participants.map {
             getOrCreateParticipant(it)


### PR DESCRIPTION
Per Slack discussion the `started_at` event isn't always properly set from SFU and can be actually null. It may be fixed later but for now we don't recommend to use it.