### PR TITLE
Dismiss direct call notification when call is cancelled

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
@@ -76,7 +76,7 @@ class DirectCallActivity : ComponentActivity() {
             val call = StreamVideo.instance().call(type, id)
 
             // Get list of members
-            val members: List<String> = listOf("XPU1WRE9")
+            val members: List<String> = intent.getStringArrayExtra(EXTRA_MEMBERS_ARRAY)?.asList() ?: emptyList()
 
             // You must add yourself as member too
             val membersWithMe = members.toMutableList().apply { add(call.user.id) }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
@@ -76,7 +76,7 @@ class DirectCallActivity : ComponentActivity() {
             val call = StreamVideo.instance().call(type, id)
 
             // Get list of members
-            val members: List<String> = intent.getStringArrayExtra(EXTRA_MEMBERS_ARRAY)?.asList() ?: emptyList()
+            val members: List<String> = listOf("XPU1WRE9")
 
             // You must add yourself as member too
             val membersWithMe = members.toMutableList().apply { add(call.user.id) }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -152,6 +152,10 @@ public open class DefaultNotificationHandler(
             .build()
     }
 
+    override fun onCallCancelled(callId: StreamCallId) {
+        notificationManager.cancel(INCOMING_CALL_NOTIFICATION_ID)
+    }
+
     private fun maybeCreateChannel(channelId: String, context: Context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             val channel = NotificationChannel(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationHandler.kt
@@ -25,6 +25,7 @@ public interface NotificationHandler : NotificationPermissionHandler {
     fun onNotification(callId: StreamCallId, callDisplayName: String)
     fun onLiveCall(callId: StreamCallId, callDisplayName: String)
     fun getOngoingCallNotification(callId: StreamCallId): Notification?
+    fun onCallCancelled(callId: StreamCallId)
 
     companion object {
         const val ACTION_NOTIFICATION = "io.getstream.video.android.action.NOTIFICATION"

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
@@ -25,6 +25,7 @@ internal object NoOpNotificationHandler : NotificationHandler {
     override fun onNotification(callId: StreamCallId, callDisplayName: String) { /* NoOp */ }
     override fun onLiveCall(callId: StreamCallId, callDisplayName: String) { /* NoOp */ }
     override fun getOngoingCallNotification(callId: StreamCallId): Notification? = null
+    override fun onCallCancelled(callId: StreamCallId) { /* NoOp */ }
     override fun onPermissionDenied() { /* NoOp */ }
     override fun onPermissionGranted() { /* NoOp */ }
     override fun onPermissionRationale() { /* NoOp */ }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -56,16 +56,16 @@ internal class VideoPushDelegate(
                 .let { StreamCallId(it.first, it.second) }
             CoroutineScope(DispatcherProvider.IO).launch {
                 when (payload[KEY_TYPE]) {
-                    KEY_TYPE_RING -> handleRingType(callId, payload)
+                    KEY_TYPE_DIRECT_CALL -> handleDirectCallType(callId, payload)
                     KEY_TYPE_NOTIFICATION -> handleNotificationType(callId, payload)
                     KEY_TYPE_LIVE_STARTED -> handleLiveStartedType(callId, payload)
-                    KEY_TYPE_CANCELLED -> handleCallCancelledType(callId, payload)
+                    KEY_TYPE_DIRECT_CALL_CANCELLED -> handleDirectCallCancelledType(callId, payload)
                 }
             }
         }
     }
 
-    private suspend fun handleRingType(callId: StreamCallId, payload: Map<String, Any?>) {
+    private suspend fun handleDirectCallType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         getStreamVideo("ring-type-notification")?.onRingingCall(callId, callDisplayName)
     }
@@ -80,7 +80,7 @@ internal class VideoPushDelegate(
         getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName)
     }
 
-    private fun handleCallCancelledType(callId: StreamCallId, payload: Map<String, Any?>) {
+    private fun handleDirectCallCancelledType(callId: StreamCallId, payload: Map<String, Any?>) {
         getStreamVideo("call-cancelled-notification")?.onCallCancelled(callId)
     }
 
@@ -137,17 +137,17 @@ internal class VideoPushDelegate(
      * Verify if the map contains a known type.
      */
     private fun Map<String, Any?>.containsKnownType(): Boolean = when (this[KEY_TYPE]) {
-        KEY_TYPE_RING -> isValidRingType()
+        KEY_TYPE_DIRECT_CALL -> isValidDirectCallType()
         KEY_TYPE_NOTIFICATION -> isValidNotificationType()
         KEY_TYPE_LIVE_STARTED -> isValidLiveStarted()
-        KEY_TYPE_CANCELLED -> true
+        KEY_TYPE_DIRECT_CALL_CANCELLED -> true
         else -> false
     }
 
     /**
      * Verify if the map contains all keys/values for a Ring Type.
      */
-    private fun Map<String, Any?>.isValidRingType(): Boolean =
+    private fun Map<String, Any?>.isValidDirectCallType(): Boolean =
         // TODO: KEY_CALL_DISPLAY_NAME can be empty. Are there any other important key/values?
         // !(this[KEY_CALL_DISPLAY_NAME] as? String).isNullOrBlank()
         true
@@ -183,10 +183,10 @@ internal class VideoPushDelegate(
     private companion object {
         private const val KEY_SENDER = "sender"
         private const val KEY_TYPE = "type"
-        private const val KEY_TYPE_RING = "call.ring"
+        private const val KEY_TYPE_DIRECT_CALL = "call.ring"
         private const val KEY_TYPE_NOTIFICATION = "call.notification"
         private const val KEY_TYPE_LIVE_STARTED = "call.live_started"
-        private const val KEY_TYPE_CANCELLED = "call.cancelled"
+        private const val KEY_TYPE_DIRECT_CALL_CANCELLED = "call.direct_call_cancelled"
         private const val KEY_CALL_CID = "call_cid"
         private const val KEY_CALL_DISPLAY_NAME = "call_display_name"
         private const val KEY_CREATED_BY_DISPLAY_NAME = "created_by_display_name"

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -59,6 +59,7 @@ internal class VideoPushDelegate(
                     KEY_TYPE_RING -> handleRingType(callId, payload)
                     KEY_TYPE_NOTIFICATION -> handleNotificationType(callId, payload)
                     KEY_TYPE_LIVE_STARTED -> handleLiveStartedType(callId, payload)
+                    KEY_TYPE_CANCELLED -> handleCallCancelledType(callId, payload)
                 }
             }
         }
@@ -77,6 +78,10 @@ internal class VideoPushDelegate(
     private suspend fun handleLiveStartedType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName)
+    }
+
+    private fun handleCallCancelledType(callId: StreamCallId, payload: Map<String, Any?>) {
+        getStreamVideo("call-cancelled-notification")?.onCallCancelled(callId)
     }
 
     /**
@@ -135,6 +140,7 @@ internal class VideoPushDelegate(
         KEY_TYPE_RING -> isValidRingType()
         KEY_TYPE_NOTIFICATION -> isValidNotificationType()
         KEY_TYPE_LIVE_STARTED -> isValidLiveStarted()
+        KEY_TYPE_CANCELLED -> true
         else -> false
     }
 
@@ -180,6 +186,7 @@ internal class VideoPushDelegate(
         private const val KEY_TYPE_RING = "call.ring"
         private const val KEY_TYPE_NOTIFICATION = "call.notification"
         private const val KEY_TYPE_LIVE_STARTED = "call.live_started"
+        private const val KEY_TYPE_CANCELLED = "call.cancelled"
         private const val KEY_CALL_CID = "call_cid"
         private const val KEY_CALL_DISPLAY_NAME = "call_display_name"
         private const val KEY_CREATED_BY_DISPLAY_NAME = "created_by_display_name"

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -65,17 +65,17 @@ internal class VideoPushDelegate(
         }
     }
 
-    private suspend fun handleDirectCallType(callId: StreamCallId, payload: Map<String, Any?>) {
+    private fun handleDirectCallType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         getStreamVideo("ring-type-notification")?.onRingingCall(callId, callDisplayName)
     }
 
-    private suspend fun handleNotificationType(callId: StreamCallId, payload: Map<String, Any?>) {
+    private fun handleNotificationType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         getStreamVideo("generic-notification")?.onNotification(callId, callDisplayName)
     }
 
-    private suspend fun handleLiveStartedType(callId: StreamCallId, payload: Map<String, Any?>) {
+    private fun handleLiveStartedType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
         getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName)
     }


### PR DESCRIPTION
### 🎯 Goal

The direct call notification should be dismissed when the call initiator cancels the call.

### 🛠 Implementation details

Added and handled a new notification type for direct call cancellation.

### ☑️Reviewer Checklist
- [ ] New feature tested and works

### 🎉 GIF

![](https://media.giphy.com/media/WTQosN9BAwNAUBHTRM/giphy.gif)