### PR TITLE
Show avatar when video not available, add padding to grid layout for 6 participants

### DIFF
--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
@@ -135,7 +135,8 @@ public fun CallContent(
             call = call,
             modifier = Modifier
                 .fillMaxSize()
-                .weight(1f),
+                .weight(1f)
+                .padding(bottom = 2.dp),
             style = style,
             videoRenderer = videoRenderer,
         )

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
@@ -24,13 +24,11 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
@@ -24,11 +24,13 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
@@ -136,7 +138,7 @@ public fun CallContent(
             modifier = Modifier
                 .fillMaxSize()
                 .weight(1f)
-                .padding(bottom = 2.dp),
+                .padding(bottom = VideoTheme.dimens.participantsGridPadding),
             style = style,
             videoRenderer = videoRenderer,
         )

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
@@ -93,7 +93,7 @@ public fun VideoRenderer(
         return
     }
 
-    // Sow avatar always behind the video.
+    // Show avatar always behind the video.
     videoFallbackContent.invoke(call)
 
     if (video?.enabled == true) {

--- a/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
+++ b/stream-video-android-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
@@ -93,6 +93,9 @@ public fun VideoRenderer(
         return
     }
 
+    // Sow avatar always behind the video.
+    videoFallbackContent.invoke(call)
+
     if (video?.enabled == true) {
         val mediaTrack = video.track
         val sessionId = video.sessionId
@@ -132,13 +135,7 @@ public fun VideoRenderer(
                     modifier = modifier.testTag("video_renderer"),
                 )
             }
-        } else {
-            // fallback when the video is available but the track didn't load yet
-            videoFallbackContent.invoke(call)
         }
-    } else {
-        // fallback when no video is available. video.enabled is false
-        videoFallbackContent.invoke(call)
     }
 }
 


### PR DESCRIPTION
Add bottom grid padding to improve visibility in 3x3 layout. 
Always render the video fallback behind the video for better experience to avoid black screen instead of e.g. the user avatar.