### PR TITLE
Always restart publisher peerconnection if forceReset is set

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallHealthMonitor.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallHealthMonitor.kt
@@ -155,7 +155,7 @@ public class CallHealthMonitor(
      * Will skip if we already tried to reconnect less than reconnectDebounceMs ms ago
      */
     suspend fun reconnect(forceRestart: Boolean) {
-        if (reconnectInProgress) {
+        if (reconnectInProgress && !forceRestart) {
             logger.d { "[reconnect] Reconnect already in progress - skipping" }
             return
         }


### PR DESCRIPTION
If `forceReconnect` is set (in fast-reconnect scenario) then we should try to restart the peer connections if they are already being restarted. In my tests the fast-reconnect behaves more reliably with this approach. 