### PR TITLE
Allow Subscriber ICE restart in fast reconnect

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -393,12 +393,8 @@ public class RtcSession internal constructor(
         // ice restart
         subscriber?.let {
             if (!it.isHealthy()) {
-                // Do not request subscriber ICE restart in fast-reconnect mode - this will
-                // be done for you by the SFU
-                if (!forceRestart) {
-                    logger.i { "ice restarting subscriber peer connection" }
-                    requestSubscriberIceRestart()
-                }
+                logger.i { "ice restarting subscriber peer connection" }
+                requestSubscriberIceRestart()
             }
         }
         publisher?.let {


### PR DESCRIPTION
We don't need to disable subscriber ICE restarts in fast-reconnect mode - SFU can handle this. 