### PR TITLE
Process websocket events in single thread to ensure correct order

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -80,7 +80,7 @@ public class CoordinatorSocket(
     override fun onMessage(webSocket: WebSocket, text: String) {
         logger.d { "[onMessage] text: $text " }
 
-        scope.launch {
+        scope.launch(singleThreadDispatcher) {
             // parse the message
             val jsonAdapter: JsonAdapter<VideoEvent> =
                 Serializer.moshi.adapter(VideoEvent::class.java)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -23,6 +23,7 @@ import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.getstream.video.android.core.socket.internal.HealthMonitor
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -40,6 +41,7 @@ import java.io.IOException
 import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import java.util.concurrent.Executors
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 
@@ -64,6 +66,8 @@ public open class PersistentSocket<T>(
     private val onFastReconnected: () -> Unit,
 ) : WebSocketListener() {
     internal open val logger by taggedLogger("PersistentSocket")
+
+    internal val singleThreadDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
 
     /** Mock the socket for testing */
     internal var mockSocket: WebSocket? = null

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/SfuSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/SfuSocket.kt
@@ -182,7 +182,7 @@ public class SfuSocket(
         val byteBuffer = bytes.asByteBuffer()
         val byteArray = ByteArray(byteBuffer.capacity())
         byteBuffer.get(byteArray)
-        scope.launch {
+        scope.launch(singleThreadDispatcher) {
             try {
                 val rawEvent = SfuEvent.ADAPTER.decode(byteArray)
                 val message = RTCEventMapper.mapEvent(rawEvent)


### PR DESCRIPTION
Our existing code can process the WS events in parallel leading to delivery of events in wrong order (I verified it with logging - it happens for example during fast reconnect where multiple messages arrive roughly at the same time). This breaks a lot of order-dependent logic especially with the webrtc handshakes. 