### PR TITLE
Fix bug that makes IncomingCallScreen to not show the correct content

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
@@ -71,7 +71,8 @@ class IncomingCallActivity : ComponentActivity() {
             // Update the call state. This activity could have been started from a push notification.
             // Doing a call.get() will also internally update the Call state object with the latest
             // state from the backend.
-            val result = call.get()
+            // We know it's a direct call because we're in the IncomingCallActivity
+            val result = call.get(ring = true)
 
             if (result is Result.Failure) {
                 // Failed to recover the current state of the call
@@ -92,6 +93,8 @@ class IncomingCallActivity : ComponentActivity() {
                 call.join()
             }
 
+            // Activity has no content for a while, because setContent isn't called, as it
+            // waits for several suspend functions. Move setContent outside of this coroutine?
             setContent {
                 VideoTheme {
                     val onCallAction: (CallAction) -> Unit = { callAction ->

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -218,12 +218,13 @@ public class Call(
     }
 
     /** Basic crud operations */
-    suspend fun get(): Result<GetCallResponse> {
-        val response = clientImpl.getCall(type, id)
-        response.onSuccess {
-            state.updateFromResponse(it)
+    suspend fun get(ring: Boolean = false): Result<GetCallResponse> {
+        if (ring) client.state.addRingingCall(this)
+
+        return clientImpl.getCall(type, id).apply {
+            onSuccess { state.updateFromResponse(it) }
+            onError { client.state.removeRingingCall() }
         }
-        return response
     }
 
     /** Create a call. You can create a call client side, many apps prefer to do this server side though */


### PR DESCRIPTION
### 🎯 Goal

When receiving a call, we have no reliable way of knowing it's a direct call, as the app is not in the foreground so it doesn't receive a `CallRingEvent` WS event. Issue with log outputs [here](https://github.com/GetStream/android-video-issues-tracking/issues/51).

### 🛠 Implementation details

Proposition:
- We can rely on the `call.ring` push notification that comes in and starts an `IncomingCallActivity`.
- `Call.create()` has a `ring` parameter, that's used to call `ClientState.addRingingCall()`. We can add a similar parameter to `Call.get()`, so we can call `ClientState.addRingingCall()` inside of it, if `ring == true`, similar to how `Call.create()` does it.
- `ClientState.addRingingCall()` then sets the `ClientState.ringingCall` property that's eventually used to correctly update the call state to `Incoming` in `CallState.updateRingingState()`. This way, the correct UI is shown when the `RingingCallContent` component is used.

- ❓  The question is if users will know they have to use `Call.get()`. Also, it isn't clear when `StreamVideo.call()`, `Call.create()` and `Call.get()` should be used in client apps. Maybe some method renaming and new doc pages are needed.