### PR TITLE
Fix video filter green artefacts issue & segmentation fault crash

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/YuvFrame.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/YuvFrame.kt
@@ -56,8 +56,6 @@ object YuvFrame {
         val planes = arrayOf<ByteBuffer>(toI420.dataY, toI420.dataU, toI420.dataV)
         val strides = intArrayOf(toI420.strideY, toI420.strideU, toI420.strideV)
 
-        toI420.release()
-
         val halfWidth = (width + 1).shr(1)
         val halfHeight = (height + 1).shr(1)
 
@@ -91,6 +89,8 @@ object YuvFrame {
                 byteBuffer.position(limit)
             }
         }
+
+        toI420.release()
 
         return I420Buffer.wrap(byteBuffer, width, height)
     }


### PR DESCRIPTION
### 🎯 Goal

When converting a WebRTC VideoFrame to a Bitmap and applying YUV-ARGB conversion, green artefacts appear on the resulting frame. Also, a segmentation fault crash appears after running for a while. Fix these issues.

### 🛠 Implementation details

In `YuvFrame.copyPlanes()`: move the i420 buffer release to the end of the method. Probably YUV plane information was released before being used, and that caused problems when converting from one color space to another. Data was missing. Also, the segmentation fault crash is gone by doing this change.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![w_artefacts](https://github.com/GetStream/stream-video-android/assets/65943217/03fd237f-c05d-4ff1-ad80-0457707b58da)|![wo_artefacts](https://github.com/GetStream/stream-video-android/assets/65943217/e5838609-fe6f-40a0-a4d9-9057dbd0aa4a) |

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Comparison screenshots added for visual changes

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs