### PR TITLE
Use ParticipantsSpotlight.videoRenderer parameter in ParticipantsLayout

### DIFF
--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/ParticipantsLayout.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/ParticipantsLayout.kt
@@ -99,6 +99,7 @@ public fun ParticipantsLayout(
                     isShowingReactions = style.isShowingReactions,
                     labelPosition = style.labelPosition,
                 ),
+                videoRenderer = videoRenderer
             )
         } else {
             ParticipantsRegularGrid(

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/ParticipantsLayout.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/ParticipantsLayout.kt
@@ -99,7 +99,7 @@ public fun ParticipantsLayout(
                     isShowingReactions = style.isShowingReactions,
                     labelPosition = style.labelPosition,
                 ),
-                videoRenderer = videoRenderer
+                videoRenderer = videoRenderer,
             )
         } else {
             ParticipantsRegularGrid(


### PR DESCRIPTION
### 🎯 Goal

Add `videoRenderer` parameter to `ParticipantsSpotlight` call in `ParticipantsLayout`.