### PR TITLE
Use native blur() in Compose

### DIFF
--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -599,16 +599,18 @@ public final class io/getstream/video/android/compose/ui/components/avatar/UserA
 
 public final class io/getstream/video/android/compose/ui/components/background/CallBackgroundKt {
 	public static final fun CallBackground (Landroidx/compose/ui/Modifier;Ljava/util/List;ZZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
-	public static final fun ParticipantImageBackground (Ljava/lang/String;Landroidx/compose/ui/Modifier;ILandroidx/compose/runtime/Composer;II)V
+	public static final fun ParticipantImageBackground-6a0pyJM (Ljava/lang/String;Landroidx/compose/ui/Modifier;FLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/background/ComposableSingletons$CallBackgroundKt {
 	public static final field INSTANCE Lio/getstream/video/android/compose/ui/components/background/ComposableSingletons$CallBackgroundKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/CallAppBarKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/background/CallBackground.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/background/CallBackground.kt
@@ -32,12 +32,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.animation.crossfade.CrossfadePlugin
 import com.skydoves.landscapist.coil.CoilImage
 import com.skydoves.landscapist.components.rememberImageComponent
-import com.skydoves.landscapist.transformation.blur.BlurTransformationPlugin
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.AvatarImagePreview
 import io.getstream.video.android.core.MemberState
@@ -120,7 +120,7 @@ private fun OutgoingCallBackground(callUsers: List<CallUser>, isVideoType: Boole
 public fun ParticipantImageBackground(
     userImage: String?,
     modifier: Modifier = Modifier,
-    blurRadius: Int = 20,
+    blurRadius: Dp = 20.dp,
 ) {
     if (!userImage.isNullOrEmpty()) {
         CoilImage(
@@ -130,7 +130,9 @@ public fun ParticipantImageBackground(
                     .fillMaxSize()
                     .blur(15.dp)
             } else {
-                modifier.fillMaxSize()
+                modifier
+                    .fillMaxSize()
+                    .blur(blurRadius)
             },
             imageModel = { userImage },
             previewPlaceholder = R.drawable.stream_video_call_sample,
@@ -140,7 +142,6 @@ public fun ParticipantImageBackground(
             ),
             component = rememberImageComponent {
                 +CrossfadePlugin()
-                +BlurTransformationPlugin(blurRadius)
             },
         )
     } else {


### PR DESCRIPTION
Using the native `blur()` instead of the blur plugin from Landscapist will get rid of RenderScript conflicts in the sample app (we use RS for the blur video sample). The native blur is only supported for Android 12+ - we will have to eventually code our own blur later. 