### PR TITLE
Improve call state handling when app is killed or device is locked

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4096,6 +4096,12 @@ public final class io/getstream/video/android/core/notifications/NotificationHan
 	public static final field INTENT_EXTRA_NOTIFICATION_ID Ljava/lang/String;
 }
 
+public final class io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver : android/content/BroadcastReceiver {
+	public fun <init> ()V
+	public final fun getLogger ()Lio/getstream/log/TaggedLogger;
+	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
+}
+
 public final class io/getstream/video/android/core/permission/PermissionRequest {
 	public fun <init> (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/model/User;Lorg/threeten/bp/OffsetDateTime;Ljava/util/List;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;)V
 	public synthetic fun <init> (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/model/User;Lorg/threeten/bp/OffsetDateTime;Ljava/util/List;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4098,7 +4098,6 @@ public final class io/getstream/video/android/core/notifications/NotificationHan
 
 public final class io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver : android/content/BroadcastReceiver {
 	public fun <init> ()V
-	public final fun getLogger ()Lio/getstream/log/TaggedLogger;
 	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
 }
 

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -76,8 +76,10 @@
         </receiver>
 
 
-        <service android:name=".notifications.internal.service.OngoingCallService"
-            android:foregroundServiceType="microphone"/>
+        <service
+            android:name=".notifications.internal.service.OngoingCallService"
+            android:foregroundServiceType="microphone"
+            android:stopWithTask="true" />
 
         <service android:name=".screenshare.StreamScreenShareService"
             android:foregroundServiceType="mediaProjection"/>

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -77,7 +77,7 @@
 
 
         <service android:name=".notifications.internal.service.OngoingCallService"
-            android:foregroundServiceType="microphone" />
+            android:foregroundServiceType="microphone"/>
 
         <service android:name=".screenshare.StreamScreenShareService"
             android:foregroundServiceType="mediaProjection"/>

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -78,8 +78,7 @@
 
         <service
             android:name=".notifications.internal.service.OngoingCallService"
-            android:foregroundServiceType="microphone"
-            android:stopWithTask="true" />
+            android:foregroundServiceType="microphone" />
 
         <service android:name=".screenshare.StreamScreenShareService"
             android:foregroundServiceType="mediaProjection"/>

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -76,8 +76,7 @@
         </receiver>
 
 
-        <service
-            android:name=".notifications.internal.service.OngoingCallService"
+        <service android:name=".notifications.internal.service.OngoingCallService"
             android:foregroundServiceType="microphone" />
 
         <service android:name=".screenshare.StreamScreenShareService"

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications.internal.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import io.getstream.log.taggedLogger
+import io.getstream.video.android.core.StreamVideo
+
+class ToggleCameraBroadcastReceiver : BroadcastReceiver() {
+    val logger by taggedLogger("ToggleCameraBroadcastReceiver")
+
+    override fun onReceive(context: Context, intent: Intent) {
+        when (intent.action) {
+            Intent.ACTION_SCREEN_ON -> {
+                logger.d { "Screen is on and locked." }
+            }
+            Intent.ACTION_USER_PRESENT -> {
+                logger.d { "Screen is on and unlocked." }
+                StreamVideo.instanceOrNull()?.state?.activeCall?.value?.camera?.enable()
+            }
+            Intent.ACTION_SCREEN_OFF -> {
+                // This flag actually means that the device is non-interactive.
+                // In a video call scenario, the only way to be non-interactive is when locking the phone manually.
+                logger.d { "Screen is off." }
+                StreamVideo.instanceOrNull()?.state?.activeCall?.value?.camera?.disable()
+            }
+        }
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/OngoingCallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/OngoingCallService.kt
@@ -63,7 +63,14 @@ internal class OngoingCallService : Service() {
         callId?.let {
             val notificationId = callId.hashCode()
             NotificationManagerCompat.from(this).cancel(notificationId)
+
+            val streamVideo = StreamVideo.instanceOrNull()
+            if (streamVideo != null) {
+                val call = streamVideo.call(it.type, it.id)
+                call.leave()
+            }
         }
+        logger.w { "Service was destroyed. Left call." }
         super.onDestroy()
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/OngoingCallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/OngoingCallService.kt
@@ -63,15 +63,24 @@ internal class OngoingCallService : Service() {
         callId?.let {
             val notificationId = callId.hashCode()
             NotificationManagerCompat.from(this).cancel(notificationId)
-
-            val streamVideo = StreamVideo.instanceOrNull()
-            if (streamVideo != null) {
-                val call = streamVideo.call(it.type, it.id)
-                call.leave()
-            }
         }
-        logger.w { "Service was destroyed. Left call." }
         super.onDestroy()
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        callId?.let { leaveCall(it) }
+    }
+
+    private fun leaveCall(callId: StreamCallId) {
+        val streamVideo = StreamVideo.instanceOrNull()
+        if (streamVideo != null) {
+            val call = streamVideo.call(callId.type, callId.id)
+            streamVideo.state.activeCall
+            call.leave()
+        }
+
+        logger.w { "Left ongoing call." }
     }
 
     // This service does not return a Binder


### PR DESCRIPTION
### 🎯 Goal

- End an ongoing call when the app is killed
- Stop/start the video feed when the device is locked/unlocked.

### 🛠 Implementation details

- End an ongoing call when the app is killed: use the `onTaskRemoved` callback in `OngoingCallService` to leave the call.
- Stop/start the video feed: register a broadcast receiver in `OngoingCallService` that listens for `ACTION_USER_PRESENT` and `ACTION_SCREEN_OFF` broadcasts.

TBD:
- Another option for ending the call is to use the `stopWithTask` manifest flag for `OngoingCallService` and leaving the call in `onDestroy()`.
- Should the stop/start video feed functionality be default in the SDK or just in the Demo app?
- Should `ToggleCameraBroadcastReceiver` be placed in the `notifications.internal.receivers` package?
- Should `ToggleCameraBroadcastReceiver` inherit `GenericCallActionBroadcastReceiver` and be found via a `search` method in `DefaultStreamIntentResolver`? The advantage would be the call parameter that it receives, but it would also complicate the code.

### 🎉 GIF

![](https://media.giphy.com/media/ilvOYnpQNDxmg/giphy.gif)