### PR TITLE
Full call functionality after direct call is accepted

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
@@ -24,13 +24,11 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.getstream.result.Result
 import io.getstream.video.android.compose.theme.VideoTheme
-import io.getstream.video.android.compose.ui.components.call.activecall.CallContent
 import io.getstream.video.android.compose.ui.components.call.ringing.RingingCallContent
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.StreamVideo
@@ -43,10 +41,8 @@ import io.getstream.video.android.core.call.state.ToggleCamera
 import io.getstream.video.android.core.call.state.ToggleMicrophone
 import io.getstream.video.android.core.call.state.ToggleSpeakerphone
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
-import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.mapper.isValidCallId
 import io.getstream.video.android.model.mapper.toTypeAndId
-import io.getstream.video.android.ui.call.CallActivity
 import io.getstream.video.android.ui.call.CallScreen
 import io.getstream.video.android.util.StreamVideoInitHelper
 import kotlinx.coroutines.Dispatchers

--- a/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DirectCallActivity.kt
@@ -43,8 +43,11 @@ import io.getstream.video.android.core.call.state.ToggleCamera
 import io.getstream.video.android.core.call.state.ToggleMicrophone
 import io.getstream.video.android.core.call.state.ToggleSpeakerphone
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
+import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.mapper.isValidCallId
 import io.getstream.video.android.model.mapper.toTypeAndId
+import io.getstream.video.android.ui.call.CallActivity
+import io.getstream.video.android.ui.call.CallScreen
 import io.getstream.video.android.util.StreamVideoInitHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -150,10 +153,16 @@ class DirectCallActivity : ComponentActivity() {
                             reject(call)
                         },
                         onAcceptedContent = {
-                            CallContent(
-                                modifier = Modifier.fillMaxSize(),
+                            CallScreen(
                                 call = call,
-                                onCallAction = onCallAction,
+                                showDebugOptions = BuildConfig.DEBUG,
+                                onCallDisconnected = {
+                                    finish()
+                                },
+                                onUserLeaveCall = {
+                                    call.leave()
+                                    finish()
+                                },
                             )
                         },
                         onRejectedContent = {

--- a/demo-app/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
@@ -45,6 +45,7 @@ import io.getstream.video.android.core.call.state.ToggleSpeakerphone
 import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.model.streamCallId
+import io.getstream.video.android.ui.call.CallScreen
 import io.getstream.video.android.util.StreamVideoInitHelper
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -129,10 +130,16 @@ class IncomingCallActivity : ComponentActivity() {
                             finish()
                         },
                         onAcceptedContent = {
-                            CallContent(
-                                modifier = Modifier.fillMaxSize(),
+                            CallScreen(
                                 call = call,
-                                onCallAction = onCallAction,
+                                showDebugOptions = BuildConfig.DEBUG,
+                                onCallDisconnected = {
+                                    finish()
+                                },
+                                onUserLeaveCall = {
+                                    call.leave()
+                                    finish()
+                                },
                             )
                         },
                         onRejectedContent = {

--- a/demo-app/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/IncomingCallActivity.kt
@@ -24,14 +24,12 @@ import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
 import dagger.hilt.android.AndroidEntryPoint
 import io.getstream.result.Result
 import io.getstream.video.android.compose.theme.VideoTheme
-import io.getstream.video.android.compose.ui.components.call.activecall.CallContent
 import io.getstream.video.android.compose.ui.components.call.ringing.RingingCallContent
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.call.state.AcceptCall


### PR DESCRIPTION
Instead of using the `CallContent` composable, use the `CallScreen` composable in `DirectCallActivity` and `IncomingCallActivity` (same as in the `CallActivity`) in order to have full functionality after a direct call is accepted.