### PR TITLE
Improve SDK BitmapVideoFilter memory usage

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/FilterVideoProcessor.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/FilterVideoProcessor.kt
@@ -37,6 +37,7 @@ internal class FilterVideoProcessor(
     private var inputWidth = 0
     private var inputHeight = 0
     private var inputBuffer: VideoFrame.TextureBuffer? = null
+    private var yuvBuffer: VideoFrame.I420Buffer? = null
     private val textures = IntArray(1)
     private var inputFrameBitmap: Bitmap? = null
 
@@ -90,9 +91,9 @@ internal class FilterVideoProcessor(
                 GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, inputFrameBitmap!!, 0)
 
                 // Convert the buffer back to YUV (VideoFrame needs YUV)
-                val convert = yuvConverter.convert(inputBuffer)
+                yuvBuffer = yuvConverter.convert(inputBuffer)
 
-                sink?.onFrame(VideoFrame(convert, 0, frame.timestampNs))
+                sink?.onFrame(VideoFrame(yuvBuffer, 0, frame.timestampNs))
             }
         } else {
             throw Error("Unsupported video filter type ${filter.invoke()}")
@@ -104,6 +105,8 @@ internal class FilterVideoProcessor(
     }
 
     private fun initialize(width: Int, height: Int, textureHelper: SurfaceTextureHelper) {
+        yuvBuffer?.release()
+
         if (this.inputWidth != width || this.inputHeight != height) {
             this.inputWidth = width
             this.inputHeight = height

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/YuvFrame.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/YuvFrame.kt
@@ -71,25 +71,26 @@ object YuvFrame {
         val width = webRtcI420Buffer.width
         val height = webRtcI420Buffer.height
 
-        when (videoFrame!!.rotation) {
-            90, -270 -> {
-                libYuvRotatedI420Buffer?.close()
-                libYuvRotatedI420Buffer = I420Buffer.allocate(height, width) // swapped width and height
-                libYuvI420Buffer.rotate(libYuvRotatedI420Buffer!!, RotateMode.ROTATE_90)
-            }
-            180, -180 -> {
-                if (width != libYuvRotatedI420Buffer?.width || height != libYuvRotatedI420Buffer?.height) {
-                    libYuvRotatedI420Buffer?.close()
-                    libYuvRotatedI420Buffer = I420Buffer.allocate(width, height)
-                }
-                libYuvI420Buffer.rotate(libYuvRotatedI420Buffer!!, RotateMode.ROTATE_180)
-            }
-            270, -90 -> {
-                libYuvRotatedI420Buffer?.close()
-                libYuvRotatedI420Buffer = I420Buffer.allocate(height, width) // swapped width and height
-                libYuvI420Buffer.rotate(libYuvRotatedI420Buffer!!, RotateMode.ROTATE_270)
-            }
+        when (rotationDegrees) {
+            90, -270 -> changeOrientation(width, height, RotateMode.ROTATE_90) // upside down, 90
+            180, -180 -> keepOrientation(width, height, RotateMode.ROTATE_180) // right, 180
+            270, -90 -> changeOrientation(width, height, RotateMode.ROTATE_270) // upright, 270
+            else -> keepOrientation(width, height, RotateMode.ROTATE_0) // left, 0 - default video frame rotation
         }
+    }
+
+    private fun changeOrientation(width: Int, height: Int, rotateMode: RotateMode) {
+        libYuvRotatedI420Buffer?.close()
+        libYuvRotatedI420Buffer = I420Buffer.allocate(height, width) // swapped width and height
+        libYuvI420Buffer.rotate(libYuvRotatedI420Buffer!!, rotateMode)
+    }
+
+    private fun keepOrientation(width: Int, height: Int, rotateMode: RotateMode) {
+        if (width != libYuvRotatedI420Buffer?.width || height != libYuvRotatedI420Buffer?.height) {
+            libYuvRotatedI420Buffer?.close()
+            libYuvRotatedI420Buffer = I420Buffer.allocate(width, height)
+        }
+        libYuvI420Buffer.rotate(libYuvRotatedI420Buffer!!, rotateMode)
     }
 
     private fun createLibYuvAbgrBuffer() {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/YuvFrame.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/video/YuvFrame.kt
@@ -75,7 +75,7 @@ object YuvFrame {
             90, -270 -> changeOrientation(width, height, RotateMode.ROTATE_90) // upside down, 90
             180, -180 -> keepOrientation(width, height, RotateMode.ROTATE_180) // right, 180
             270, -90 -> changeOrientation(width, height, RotateMode.ROTATE_270) // upright, 270
-            else -> keepOrientation(width, height, RotateMode.ROTATE_0) // left, 0 - default video frame rotation
+            else -> keepOrientation(width, height, RotateMode.ROTATE_0) // left, 0, default
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

When using `BitmapVideoFilter`, memory usage increases rapidly and the client app crashes. Memory usage should be stable, GC should be able to keep up.

### 🛠 Implementation details

Refactored `YuvFrame`:
- Used libyuv to copy YUV planes
- Used buffer rotation insted of bitmap rotation (rotated I420 buffer, which is shorter)
- Cleaned-up memory
- Code structure and naming improvements

Released `yuvBuffer` in `FilterVideoProcessor`.

### 🧠 Memory Usage

| Demo app profiling with filter enabled in a call on a Pixel 4 |
| --- |
| Before: Reached ~4 GB in under 5 mins and crashed |
| ![memory-usage-high](https://github.com/GetStream/stream-video-android/assets/65943217/6f143a35-5786-492c-b758-1ab587b41f8c) |
| After: Stays in the 360-590 MB range even after 2h. Stable. |
| ![memory-usage-good](https://github.com/GetStream/stream-video-android/assets/65943217/3c834f69-2189-4fb7-83f3-717900629232) |

### 🧪 Testing

- Start a call, enable video filter (background blur) and leave call running.
- Needs testing on a lower-end device.
- Needs battery profiling.
- See test results in comments below.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes

### ☑️Reviewer Checklist
- [x] New feature tested and works

### 🎉 GIF

![](https://media.giphy.com/media/KX5nwoDX97AtPvKBF6/giphy.gif)