### PR TITLE
Fix direct call privacy issues 

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4102,7 +4102,7 @@ public final class io/getstream/video/android/core/notifications/NotificationHan
 }
 
 public final class io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver : android/content/BroadcastReceiver {
-	public fun <init> ()V
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;)V
 	public fun onReceive (Landroid/content/Context;Landroid/content/Intent;)V
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
@@ -37,8 +37,6 @@ class ToggleCameraBroadcastReceiver(coroutineScope: CoroutineScope) : BroadcastR
         logger.d { "Init active call value: " + streamVideo?.state?.activeCall?.value?.cid }
         logger.d { "Init ringing call value: " + streamVideo?.state?.ringingCall?.value?.cid }
 
-        // TODO: active call should be set to ringing call automatically?
-
         streamVideo?.let { streamVideo ->
             call = streamVideo.state.activeCall.value ?: streamVideo.state.ringingCall.value
 
@@ -57,19 +55,10 @@ class ToggleCameraBroadcastReceiver(coroutineScope: CoroutineScope) : BroadcastR
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
-            // For when the call screen is visible even if the screen is locked.
-            // Because of lockscreenVisibility = Notification.VISIBILITY_PUBLIC for channel?
-            // To reproduce scenario: answer from locked screen then lock-unlock
             Intent.ACTION_SCREEN_ON -> {
+                // Could be useful when the call screen is visible even if the screen is locked.
+                // Because of lockscreenVisibility = Notification.VISIBILITY_PUBLIC for channel?
                 logger.d { "Screen is on and locked. Call: ${call?.id}" }
-                // TODO:
-                // Solution works for normal active call & ringing call scenarios, but:
-                // Problem:
-                //  - answer call while unlocked
-                //  - lock then turn screen on by moving phone -> camera is on
-                //  - turn screen on by tap or button -> camera is off
-                //  - do the same in normal call -> camera is on even if unlocking by moving phone or button
-                if (shouldEnableCameraAgain) call?.camera?.enable()
             }
             Intent.ACTION_USER_PRESENT -> {
                 logger.d { "Screen is on and unlocked. Call: ${call?.id}" }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
@@ -20,33 +20,67 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import io.getstream.log.taggedLogger
+import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.StreamVideo
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 class ToggleCameraBroadcastReceiver(coroutineScope: CoroutineScope) : BroadcastReceiver() {
     private val logger by taggedLogger("ToggleCameraBroadcastReceiver")
     private val streamVideo = StreamVideo.instanceOrNull()
     private var call: Call? = null
     private var shouldEnableCameraAgain = false
-    private val logger by taggedLogger("ToggleCameraBroadcastReceiver")
+
+    init {
+        logger.d { "Init" }
+        logger.d { "Active call value: " + streamVideo?.state?.activeCall?.value?.id }
+        logger.d { "Ringing call value: " + streamVideo?.state?.ringingCall?.value?.id }
+
+        // TODO: active call should be set to ringing call automatically?
+        call = streamVideo?.state?.activeCall?.value ?: streamVideo?.state?.ringingCall?.value
+
+        coroutineScope.launch {
+            if (call == null) {
+                streamVideo?.state?.ringingCall?.collect {
+                    if (it != null) {
+                        call = it
+                        logger.d { "Ringing call changed to ${call?.id}" }
+                    }
+                }
+                streamVideo?.state?.activeCall?.collect {
+                    if (it != null) {
+                        call = it
+                        logger.d { "Active call changed to ${call?.id}" }
+                    }
+                }
+            }
+        }
+    }
 
     override fun onReceive(context: Context, intent: Intent) {
         when (intent.action) {
             Intent.ACTION_SCREEN_ON -> {
-                logger.d { "Screen is on and locked." }
+                logger.d { "Screen is on and locked. Call: ${call?.id}" }
+                // TODO:
+                // For when the call screen is visible even if the screen is locked.
+                // Because of lockscreenVisibility = Notification.VISIBILITY_PUBLIC for channel?
+                // To reproduce: answer from locked screen the lock-unlock
+                // Problem: answer call while unlocked. Lock then turn screen on by moving phone -> camera is on. Turn screen on by tap or button -> camera is off.
+                if (shouldEnableCameraAgain) call?.camera?.enable()
             }
             Intent.ACTION_USER_PRESENT -> {
-                logger.d { "Screen is on and unlocked." }
-                if (shouldEnableCameraAgain) activeCall?.camera?.enable()
+                logger.d { "Screen is on and unlocked. Call: ${call?.id}" }
+                if (shouldEnableCameraAgain) call?.camera?.enable()
             }
             Intent.ACTION_SCREEN_OFF -> {
                 // This broadcast action actually means that the device is non-interactive.
                 // In a video call scenario, the only way to be non-interactive is when locking the phone manually.
-                activeCall?.camera.let { camera ->
+                call?.camera.let { camera ->
                     shouldEnableCameraAgain = camera?.isEnabled?.value ?: false
                     camera?.disable()
                 }
 
-                logger.d { "Screen is off. Should re-enable camera: $shouldEnableCameraAgain." }
+                logger.d { "Screen is off. Call: ${call?.id}. Should re-enable camera: $shouldEnableCameraAgain." }
             }
         }
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
@@ -22,8 +22,10 @@ import android.content.Intent
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.StreamVideo
 
-class ToggleCameraBroadcastReceiver : BroadcastReceiver() {
-    private val activeCall = StreamVideo.instanceOrNull()?.state?.activeCall?.value
+class ToggleCameraBroadcastReceiver(coroutineScope: CoroutineScope) : BroadcastReceiver() {
+    private val logger by taggedLogger("ToggleCameraBroadcastReceiver")
+    private val streamVideo = StreamVideo.instanceOrNull()
+    private var call: Call? = null
     private var shouldEnableCameraAgain = false
     private val logger by taggedLogger("ToggleCameraBroadcastReceiver")
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver.kt
@@ -23,6 +23,7 @@ import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.StreamVideo
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 
@@ -43,10 +44,12 @@ class ToggleCameraBroadcastReceiver(coroutineScope: CoroutineScope) : BroadcastR
 
             if (call == null) {
                 coroutineScope.launch {
-                    merge(streamVideo.state.activeCall, streamVideo.state.ringingCall).collect {
-                        if (it != null) call = it
-                        logger.d { "Collected call: ${it?.cid}" }
-                    }
+                    merge(streamVideo.state.activeCall, streamVideo.state.ringingCall)
+                        .distinctUntilChangedBy { it?.cid }
+                        .collect {
+                            if (it != null) call = it
+                            logger.d { "Collected call: ${it?.cid}" }
+                        }
                 }
             }
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -59,7 +59,7 @@ internal class CallService : Service() {
     private val serviceScope: CoroutineScope = CoroutineScope(Dispatchers.IO)
 
     // Camera handling receiver
-    private val toggleCameraBroadcastReceiver = ToggleCameraBroadcastReceiver()
+    private val toggleCameraBroadcastReceiver = ToggleCameraBroadcastReceiver(serviceScope)
 
     internal companion object {
         const val TRIGGER_KEY =

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -60,6 +60,7 @@ internal class CallService : Service() {
 
     // Camera handling receiver
     private val toggleCameraBroadcastReceiver = ToggleCameraBroadcastReceiver(serviceScope)
+    private var isToggleCameraBroadcastReceiverRegistered = false
 
     internal companion object {
         const val TRIGGER_KEY =
@@ -304,25 +305,31 @@ internal class CallService : Service() {
         stopSelf()
     }
     private fun registerToggleCameraBroadcastReceiver() {
-        try {
-            registerReceiver(
-                toggleCameraBroadcastReceiver,
-                IntentFilter().apply {
-                    addAction(Intent.ACTION_SCREEN_ON)
-                    addAction(Intent.ACTION_SCREEN_OFF)
-                    addAction(Intent.ACTION_USER_PRESENT)
-                },
-            )
-        } catch (e: Exception) {
-            logger.e(e) { "Unable to register ToggleCameraBroadcastReceiver." }
+        if (!isToggleCameraBroadcastReceiverRegistered) {
+            try {
+                registerReceiver(
+                    toggleCameraBroadcastReceiver,
+                    IntentFilter().apply {
+                        addAction(Intent.ACTION_SCREEN_ON)
+                        addAction(Intent.ACTION_SCREEN_OFF)
+                        addAction(Intent.ACTION_USER_PRESENT)
+                    },
+                )
+                isToggleCameraBroadcastReceiverRegistered = true
+            } catch (e: Exception) {
+                logger.e(e) { "Unable to register ToggleCameraBroadcastReceiver." }
+            }
         }
     }
 
     private fun unregisterToggleCameraBroadcastReceiver() {
-        try {
-            unregisterReceiver(toggleCameraBroadcastReceiver)
-        } catch (e: Exception) {
-            logger.e(e) { "Unable to unregister ToggleCameraBroadcastReceiver." }
+        if (isToggleCameraBroadcastReceiverRegistered) {
+            try {
+                unregisterReceiver(toggleCameraBroadcastReceiver)
+                isToggleCameraBroadcastReceiverRegistered = false
+            } catch (e: Exception) {
+                logger.e(e) { "Unable to unregister ToggleCameraBroadcastReceiver." }
+            }
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

- Improve camera off/on when locked/unlocked: check for null `activeCall` and `ringingCall`.
- SDK should set `activeCall` in ringing call scenario? - it also doesn't on iOS
- Solve `Receiver not registered (ToggleCameraBroadcastReceiver)` exception when ending the call.
- See [issue](https://github.com/GetStream/android-video-issues-tracking/issues/54) for details.

### 🛠 Implementation details

- Collect `activeCall` and `ringingCall` value updates.
- Used `CallService` coroutine scope in `ToggleCameraBroadcastReceiver` as the receiver is registered/unregistered only by this service.
- Control `ToggleCameraBroadcastReceiver` registrations with flag to avoid unregister exception.
- A second iteration of this feature will be needed. See issue [here](https://github.com/GetStream/android-video-issues-tracking/issues/56).

### 🧪 Testing

- Create a direct call, lock/unlock and watch camera off/on behavior. 
- Check the logs for `activeCall`/`ringingCall` value and for lock events.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch

### ☑️Reviewer Checklist

- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works