### PR TITLE
Fix barcode scanner multiple callbacks

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/barcode/BardcodeScanner.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/barcode/BardcodeScanner.kt
@@ -239,9 +239,15 @@ private fun BoxScope.CornerRectWithArcs(color: Color, cornerRadius: Float, strok
 private fun rememberQrCodeCallback(): OnSuccessListener<Barcode> {
     val context = LocalContext.current
     val firebaseAnalytics by lazy { FirebaseAnalytics.getInstance(context) }
+    var codeScanned = false
 
     return remember {
         OnSuccessListener<Barcode> {
+            if (codeScanned) {
+                Log.d("BarcodeScanner", "Barcode already processed - skipping")
+                return@OnSuccessListener
+            }
+
             val url = it.url?.url
             val callId = if (url != null) {
                 val id = Uri.parse(url).getQueryParameter("id")
@@ -255,6 +261,7 @@ private fun rememberQrCodeCallback(): OnSuccessListener<Barcode> {
             }
 
             if (!callId.isNullOrEmpty()) {
+                codeScanned = true
                 firebaseAnalytics.logEvent(FirebaseEvents.SCAN_QR_CODE, null)
                 context.startActivity(DeeplinkingActivity.createIntent(context, callId))
             } else {


### PR DESCRIPTION
The barcode scanner is quite fast and can deliver multiple callbacks in short succession leading to crashes. We need to stop after first successful scan. 