### PR TITLE
Use different video filter fo the screen share specifically different…

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -789,13 +789,15 @@ class MediaManagerImpl(
 ) {
     private val filterVideoProcessor =
         FilterVideoProcessor({ call.videoFilter }, { camera.surfaceTextureHelper })
+    private val screenShareFilterVideoProcessor =
+        FilterVideoProcessor({ call.videoFilter }, { screenShare.surfaceTextureHelper })
 
     // source & tracks
     val videoSource =
         call.clientImpl.peerConnectionFactory.makeVideoSource(false, filterVideoProcessor)
 
     val screenShareVideoSource by lazy {
-        call.clientImpl.peerConnectionFactory.makeVideoSource(true, filterVideoProcessor)
+        call.clientImpl.peerConnectionFactory.makeVideoSource(true, screenShareFilterVideoProcessor)
     }
 
     // for track ids we emulate the browser behaviour of random UUIDs, doing something different would be confusing


### PR DESCRIPTION
Due to shared `surfaceTextureHelper` with the camera screenshareing from Android would result in mixed source where random frames are shown from the camera or Screenshare. Participant video would remain blank and after disabling screenshare participant video is no longer available until screenshare is started again.

This PR fixes the above issue by adding a new video filter for screenshare source using the `surfaceTextureHelper` from the `screenShare` manager


The issue: screensharing from the left device (pixel 7), results in camera frames mixed with the screenshare track, while also the participant video track is blank on the receiver end.
![image](https://github.com/GetStream/stream-video-android/assets/11648905/91387725-f9bc-4218-b4dc-796b9ac71e91)
