### PR TITLE
Copy the no-response workflow from chat

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,24 @@
+name: No Response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Every midnight
+    - cron: '0 0 * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          daysUntilClose: 7
+          responseRequiredLabel: waiting for response
+          closeComment: >
+            This issue has been automatically closed because there has been no response
+            to our request from the original author.
+            Please don't hesitate to comment on the bug if you have
+            any more information for us - we will reopen it right away!
+            Thanks for your contribution.


### PR DESCRIPTION
Add the no-response.yaml workflow from chat that will auto-close issues if no response was added in 7 days.