### PR TITLE
Configure ComposeStabilityPath for Kotlin compiler and mark unstable parameters to stable

### DIFF
--- a/build-logic/convention/src/main/kotlin/io/getstream/video/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/io/getstream/video/AndroidCompose.kt
@@ -1,11 +1,11 @@
 package io.getstream.video
 
 import com.android.build.api.dsl.CommonExtension
-import java.io.File
 import org.gradle.api.Project
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.getByType
+import java.io.File
 
 /**
  * Configure Compose-specific options
@@ -26,7 +26,7 @@ internal fun Project.configureAndroidCompose(
         }
 
         kotlinOptions {
-            freeCompilerArgs = freeCompilerArgs + buildComposeMetricsParameters()
+            freeCompilerArgs += buildComposeMetricsParameters() + configureComposeStabilityPath()
         }
     }
 
@@ -58,5 +58,15 @@ private fun Project.buildComposeMetricsParameters(): List<String> {
             "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder.absolutePath
         )
     }
+    return metricParameters.toList()
+}
+
+private fun Project.configureComposeStabilityPath(): List<String> {
+    val metricParameters = mutableListOf<String>()
+    metricParameters.add("-P")
+    metricParameters.add(
+        "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
+            project.path + "/compose_compiler_config.conf"
+    )
     return metricParameters.toList()
 }

--- a/build-logic/convention/src/main/kotlin/io/getstream/video/AndroidCompose.kt
+++ b/build-logic/convention/src/main/kotlin/io/getstream/video/AndroidCompose.kt
@@ -40,9 +40,11 @@ internal fun Project.configureAndroidCompose(
 private fun Project.buildComposeMetricsParameters(): List<String> {
     val metricParameters = mutableListOf<String>()
     val enableMetricsProvider = project.providers.gradleProperty("enableComposeCompilerMetrics")
+    val relativePath = projectDir.relativeTo(rootDir)
+    val buildDir = layout.buildDirectory.get().asFile
     val enableMetrics = (enableMetricsProvider.orNull == "true")
     if (enableMetrics) {
-        val metricsFolder = File(project.buildDir, "compose-metrics")
+        val metricsFolder = buildDir.resolve("compose-metrics").resolve(relativePath)
         metricParameters.add("-P")
         metricParameters.add(
             "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" + metricsFolder.absolutePath
@@ -52,7 +54,7 @@ private fun Project.buildComposeMetricsParameters(): List<String> {
     val enableReportsProvider = project.providers.gradleProperty("enableComposeCompilerReports")
     val enableReports = (enableReportsProvider.orNull == "true")
     if (enableReports) {
-        val reportsFolder = File(project.buildDir, "compose-reports")
+        val reportsFolder = buildDir.resolve("compose-reports").resolve(relativePath)
         metricParameters.add("-P")
         metricParameters.add(
             "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" + reportsFolder.absolutePath
@@ -63,10 +65,10 @@ private fun Project.buildComposeMetricsParameters(): List<String> {
 
 private fun Project.configureComposeStabilityPath(): List<String> {
     val metricParameters = mutableListOf<String>()
+    val stabilityConfigurationFile = rootDir.resolve("compose_compiler_config.conf")
     metricParameters.add("-P")
     metricParameters.add(
-        "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" +
-            project.path + "/compose_compiler_config.conf"
+        "plugin:androidx.compose.compiler.plugins.kotlin:stabilityConfigurationPath=" + stabilityConfigurationFile.absolutePath
     )
     return metricParameters.toList()
 }

--- a/compose_compiler_config.conf
+++ b/compose_compiler_config.conf
@@ -1,0 +1,3 @@
+kotlin.collections.List
+org.threeten.bp.OffsetDateTime
+org.threeten.bp.LocalDateTime

--- a/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
@@ -20,7 +20,9 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.google.firebase.analytics.FirebaseAnalytics
 import dagger.hilt.android.AndroidEntryPoint
 import io.getstream.video.android.analytics.FirebaseEvents
@@ -37,7 +39,8 @@ import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-    @Inject lateinit var dataStore: StreamUserDataStore
+    @Inject
+    lateinit var dataStore: StreamUserDataStore
     private val firebaseAnalytics by lazy { FirebaseAnalytics.getInstance(this) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -55,8 +58,10 @@ class MainActivity : ComponentActivity() {
             }
         }
 
-        lifecycleScope.launchWhenCreated {
-            InAppUpdateHelper(this@MainActivity).checkForAppUpdates()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                InAppUpdateHelper(this@MainActivity).checkForAppUpdates()
+            }
         }
 
         lifecycleScope.launch {

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,3 +38,7 @@ android.nonTransitiveRClass=true
 
 # Disabled R8 full mode
 android.suppressUnsupportedCompileSdk=34
+
+# Build Compose Compiler metrics
+enableComposeCompilerMetrics=true
+enableComposeCompilerReports=true

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MemberState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MemberState.kt
@@ -16,8 +16,10 @@
 
 package io.getstream.video.android.core
 
+import androidx.compose.runtime.Immutable
 import io.getstream.video.android.model.User
 
+@Immutable
 public data class MemberState(
     val user: User,
     val custom: Map<String, Any?>,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/stats/model/RtcIceCandidateStats.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/stats/model/RtcIceCandidateStats.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.video.android.core.call.stats.model
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class RtcIceCandidateStats(
     override val id: String?,
     override val type: String?,


### PR DESCRIPTION
Configure ComposeStabilityPath for Kotlin compiler and mark unstable parameters to stable.