### PR TITLE
Bump Stream Chat SDK to 6.0.13 and landscapist to 2.2.13

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ androidxComposeNavigation = "2.7.6"
 composeStableMarker = "1.0.2"
 
 coil = "2.5.0"
-landscapist = "2.2.12"
+landscapist = "2.2.13"
 accompanist = "0.32.0"
 telephoto = "0.3.0"
 audioswitch = "1.1.8"
@@ -46,7 +46,7 @@ turbine = "0.13.0"
 
 streamWebRTC = "1.1.1"
 streamResult = "1.1.0"
-streamChat = "6.0.12"
+streamChat = "6.0.13"
 streamLog = "1.1.4"
 streamPush = "1.1.7"
 


### PR DESCRIPTION
Bump Stream Chat SDK to 6.0.13 and landscapist to 2.2.13.