### PR TITLE
Recordings library and dynamic loading sub-menus

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -18,6 +18,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <!-- For Android < 10 -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission
         android:name="com.google.android.gms.permission.AD_ID"
         tools:node="remove" />

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/menu/MenuDefinitions.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/menu/MenuDefinitions.kt
@@ -35,12 +35,17 @@ import androidx.compose.material.icons.filled.SettingsVoice
 import androidx.compose.material.icons.filled.SpeakerPhone
 import androidx.compose.material.icons.filled.SwitchLeft
 import androidx.compose.material.icons.filled.VideoFile
+import androidx.compose.material.icons.filled.VideoLibrary
 import androidx.compose.material.icons.filled.VideoSettings
 import io.getstream.video.android.core.audio.StreamAudioDevice
 import io.getstream.video.android.ui.menu.base.ActionMenuItem
+import io.getstream.video.android.ui.menu.base.DynamicSubMenuItem
 import io.getstream.video.android.ui.menu.base.MenuItem
 import io.getstream.video.android.ui.menu.base.SubMenuItem
 
+/**
+ * Defines the default Stream menu for the demo app.
+ */
 fun defaultStreamMenu(
     showDebugOptions: Boolean = false,
     codecList: List<MediaCodecInfo>,
@@ -57,6 +62,7 @@ fun defaultStreamMenu(
     onSwitchSfuClick: () -> Unit,
     onDeviceSelected: (StreamAudioDevice) -> Unit,
     availableDevices: List<StreamAudioDevice>,
+    loadRecordings: suspend () -> List<MenuItem>,
 ) = buildList<MenuItem> {
     add(
         ActionMenuItem(
@@ -98,6 +104,13 @@ fun defaultStreamMenu(
             },
         ),
     )
+    add(
+        DynamicSubMenuItem(
+            title = "Recordings",
+            icon = Icons.Default.VideoLibrary,
+            itemsLoader = loadRecordings,
+        ),
+    )
     if (showDebugOptions) {
         add(
             SubMenuItem(
@@ -117,6 +130,9 @@ fun defaultStreamMenu(
     }
 }
 
+/**
+ * Lists the available codecs for this device as list of [MenuItem]
+ */
 fun codecMenu(codecList: List<MediaCodecInfo>, onCodecSelected: (MediaCodecInfo) -> Unit) =
     codecList.map {
         val isHw = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
@@ -132,6 +148,9 @@ fun codecMenu(codecList: List<MediaCodecInfo>, onCodecSelected: (MediaCodecInfo)
         )
     }
 
+/**
+ * Optionally defines the debug sub-menu of the demo app.
+ */
 fun debugSubmenu(
     codecList: List<MediaCodecInfo>,
     onCodecSelected: (MediaCodecInfo) -> Unit,

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/menu/base/MenuTypes.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/menu/base/MenuTypes.kt
@@ -18,12 +18,24 @@ package io.getstream.video.android.ui.menu.base
 
 import androidx.compose.ui.graphics.vector.ImageVector
 
-open class MenuItem(
+/**
+ * Parent class on all menu items.
+ *
+ * @param title - title of the item, used to display in the menu, or a subtitle to the sub menu.
+ * @param icon - the icon to be shown with the item.
+ * @param highlight -  if the icon should be highlighted or not (usually tinted with primary color)
+ */
+abstract class MenuItem(
     val title: String,
     val icon: ImageVector,
     val highlight: Boolean = false,
 )
 
+/**
+ * Same as [MenuItem] but additionally has an action associated with it.
+ *
+ * @param action - the action that will execute when the item is clicked.
+ */
 class ActionMenuItem(
     title: String,
     icon: ImageVector,
@@ -31,5 +43,23 @@ class ActionMenuItem(
     val action: () -> Unit,
 ) : MenuItem(title, icon, highlight)
 
-class SubMenuItem(title: String, icon: ImageVector, val items: List<MenuItem>) :
+/**
+ * Unlike the [ActionMenuItem] the [SubMenuItem] contains a list of [MenuItem] that create a new submenu.
+ * Clicking a [SubMenuItem] will show the [items].
+ *
+ * @param items - the items will be shown in the menu.
+ */
+open class SubMenuItem(title: String, icon: ImageVector, val items: List<MenuItem>) :
     MenuItem(title, icon)
+
+/**
+ * Similar to the [SubMenuItem] the [DynamicSubMenuItem] contains an [itemsLoader] function to load the items.
+ * The [DynamicMenu] knows how to invoke this function to dynamically load the items while showing a progress indicator.
+ *
+ * @param itemsLoader the items provider function.
+ */
+class DynamicSubMenuItem(
+    title: String,
+    icon: ImageVector,
+    val itemsLoader: suspend () -> List<MenuItem>,
+) : MenuItem(title, icon)

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/menu/base/MenuTypes.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/menu/base/MenuTypes.kt
@@ -62,4 +62,4 @@ class DynamicSubMenuItem(
     title: String,
     icon: ImageVector,
     val itemsLoader: suspend () -> List<MenuItem>,
-) : MenuItem(title, icon)
+) : SubMenuItem(title, icon, emptyList())

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -37,7 +37,8 @@ public final class io/getstream/video/android/core/Call {
 	public final fun join (ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun join$default (Lio/getstream/video/android/core/Call;ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun leave ()V
-	public final fun listRecordings (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun listRecordings (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listRecordings$default (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun muteAllUsers (ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun muteAllUsers$default (Lio/getstream/video/android/core/Call;ZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun muteUser (Ljava/lang/String;ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -916,8 +916,13 @@ public class Call(
         }
     }
 
-    suspend fun listRecordings(): Result<ListRecordingsResponse> {
-        return clientImpl.listRecordings(type, id, "what")
+    /**
+     * List the recordings for this call.
+     *
+     * @param sessionId - if session ID is supplied, only recordings for that session will be loaded.
+     */
+    suspend fun listRecordings(sessionId: String? = null): Result<ListRecordingsResponse> {
+        return clientImpl.listRecordings(type, id, sessionId)
     }
 
     suspend fun muteUser(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -931,11 +931,15 @@ internal class StreamVideoImpl internal constructor(
     suspend fun listRecordings(
         type: String,
         id: String,
-        sessionId: String,
+        sessionId: String?,
     ): Result<ListRecordingsResponse> {
         return wrapAPICall {
             val result =
-                connectionModule.api.listRecordingsTypeIdSession1(type, id, sessionId)
+                if (sessionId == null) {
+                    connectionModule.api.listRecordingsTypeId0(type, id)
+                } else {
+                    connectionModule.api.listRecordingsTypeIdSession1(type, id, sessionId)
+                }
             result
         }
     }


### PR DESCRIPTION
This PR adds the capability to show dynamic menu items with loading indicators while asynchronously fetching the data for the items. Utilising this feature is the new Recordings sub-menu. 

Adds:
- Dynamic loading menu items
- Recordings library list
-  Allow to download the recordings (automatically handle permission for API bellow Android 10)


https://github.com/GetStream/stream-video-android/assets/11648905/bb855c48-f218-4063-a401-652398ea5029


