### PR TITLE
Permission handling improvement

### DIFF
--- a/docusaurus/docs/Android/03-guides/08-permissions-and-moderation.mdx
+++ b/docusaurus/docs/Android/03-guides/08-permissions-and-moderation.mdx
@@ -67,6 +67,20 @@ val microphonePermissionState = rememberMicrophonePermissionState(call = call)
 microphonePermissionState.launchPermissionRequest()
 ```
 
+:::note
+The permissions are required and any usage of the `Call` object without them may result in a crash.
+:::
+
+In order to notify an inconsistency the SDK will log a warning when `Call.join()` is being called without the required permissions.
+This is completely ok, if you have a [call type](./05-call-types.mdx) which does not require streaming audio or video from the users device (e.g. `audio_room` or live broadcast where the user is only a guest and listens in to the stream).
+
+The SDK by default will check for runtime permissions based on call capabilities, so if your call requires audio to be sent, the SDK will expect that the `android.Manifest.permission.RECORD_AUDIO` is granted.
+
+:::warning
+If you are not overriding the `runForegroundServiceForCalls` flag to `false` in the `StreamVideoBuilder` the resulting foreground service that starts for [keeping the call alive](./06-keeping-the-call-alive.mdx) can not run without the permissions and will crash with a detailed message.
+:::
+
+If you wish to override the behavior on which permissions are required for your calls you can provide a new implementation of `StreamPermissionCheck` to the `StreamVideoBuilder`.
 ### Moderation Capabilities
 
 You can block a user or remove them from a call

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -808,7 +808,8 @@ public final class io/getstream/video/android/core/StreamVideoBuilder {
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;Z)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;ZLjava/lang/String;)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;ZLjava/lang/String;Lio/getstream/video/android/core/sounds/Sounds;)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;ZLjava/lang/String;Lio/getstream/video/android/core/sounds/Sounds;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;ZLjava/lang/String;Lio/getstream/video/android/core/sounds/Sounds;Lio/getstream/video/android/core/permission/android/StreamPermissionCheck;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;ZLjava/lang/String;Lio/getstream/video/android/core/sounds/Sounds;Lio/getstream/video/android/core/permission/android/StreamPermissionCheck;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Lio/getstream/video/android/core/StreamVideo;
 	public final fun getScope ()Lkotlinx/coroutines/CoroutineScope;
 }
@@ -4171,6 +4172,10 @@ public final class io/getstream/video/android/core/permission/PermissionRequest 
 	public final fun setGrantedAt (Lorg/threeten/bp/OffsetDateTime;)V
 	public final fun setRejectedAt (Lorg/threeten/bp/OffsetDateTime;)V
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/video/android/core/permission/android/StreamPermissionCheck {
+	public abstract fun checkAndroidPermissions (Landroid/content/Context;Lio/getstream/video/android/core/Call;)Z
 }
 
 public final class io/getstream/video/android/core/socket/CoordinatorSocket : io/getstream/video/android/core/socket/PersistentSocket {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -303,6 +303,19 @@ public class Call(
         ring: Boolean = false,
         notify: Boolean = false,
     ): Result<RtcSession> {
+        val permissionPass =
+            clientImpl.permissionCheck.checkAndroidPermissions(clientImpl.context, this)
+        // Check android permissions and log a warning to make sure developers requested adequate permissions prior to using the call.
+        if (!permissionPass) {
+            logger.w {
+                "\n[Call.join()] called without having the required permissions.\n" +
+                    "This will work only if you have [runForegroundServiceForCalls = false] in the StreamVideoBuilder.\n" +
+                    "The reason is that [Call.join()] will by default start an ongoing call foreground service,\n" +
+                    "To start this service and send the appropriate audio/video tracks the permissions are required,\n" +
+                    "otherwise the service will fail to start, resulting in a crash.\n" +
+                    "You can re-define your permissions and their expected state by overriding the [permissionCheck] in [StreamVideoBuilder]\n"
+            }
+        }
         // if we are a guest user, make sure we wait for the token before running the join flow
         clientImpl.guestUserJob?.await()
         // the join flow should retry up to 3 times

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -29,6 +29,8 @@ import io.getstream.video.android.core.logging.LoggingLevel
 import io.getstream.video.android.core.notifications.NotificationConfig
 import io.getstream.video.android.core.notifications.internal.StreamNotificationManager
 import io.getstream.video.android.core.notifications.internal.storage.DeviceTokenStorage
+import io.getstream.video.android.core.permission.android.DefaultStreamPermissionCheck
+import io.getstream.video.android.core.permission.android.StreamPermissionCheck
 import io.getstream.video.android.core.sounds.Sounds
 import io.getstream.video.android.model.ApiKey
 import io.getstream.video.android.model.User
@@ -68,6 +70,7 @@ import java.util.UUID
  * @property runForegroundServiceForCalls If set to true, when there is an active call the SDK will run a foreground service to keep the process alive. (default: true)
  * @property localSfuAddress Local SFU address (IP:port) to be used for testing. Leave null if not needed.
  * @property sounds Overwrite the default SDK sounds. See [Sounds].
+ * @property permissionCheck used to check for system permission based on call capabilities. See [StreamPermissionCheck].
  */
 public class StreamVideoBuilder @JvmOverloads constructor(
     context: Context,
@@ -87,6 +90,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
     private val runForegroundServiceForCalls: Boolean = true,
     private val localSfuAddress: String? = null,
     private val sounds: Sounds = Sounds(),
+    private val permissionCheck: StreamPermissionCheck = DefaultStreamPermissionCheck(),
 ) {
     private val context: Context = context.applicationContext
 
@@ -166,6 +170,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             runForegroundService = runForegroundServiceForCalls,
             testSfuAddress = localSfuAddress,
             sounds = sounds,
+            permissionCheck = permissionCheck,
         )
 
         if (user.type == UserType.Guest) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -43,6 +43,8 @@ import io.getstream.video.android.core.model.UpdateUserPermissionsData
 import io.getstream.video.android.core.model.toRequest
 import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.core.notifications.internal.StreamNotificationManager
+import io.getstream.video.android.core.permission.android.DefaultStreamPermissionCheck
+import io.getstream.video.android.core.permission.android.StreamPermissionCheck
 import io.getstream.video.android.core.socket.ErrorResponse
 import io.getstream.video.android.core.socket.PersistentSocket
 import io.getstream.video.android.core.socket.SocketState
@@ -137,6 +139,7 @@ internal class StreamVideoImpl internal constructor(
     internal val runForegroundService: Boolean = true,
     internal val testSfuAddress: String? = null,
     internal val sounds: Sounds,
+    internal val permissionCheck: StreamPermissionCheck = DefaultStreamPermissionCheck(),
 ) : StreamVideo,
     NotificationHandler by streamNotificationManager {
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/permission/android/DefaultStreamPermissionCheck.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/permission/android/DefaultStreamPermissionCheck.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.permission.android
+
+import android.content.Context
+import io.getstream.video.android.core.Call
+
+/**
+ * Default stream permission check.
+ */
+internal class DefaultStreamPermissionCheck : StreamPermissionCheck {
+    override fun checkAndroidPermissions(
+        context: Context,
+        call: Call,
+    ): Boolean = checkPermissionsExpectations(context, call)
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/permission/android/PermissionUtilities.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/permission/android/PermissionUtilities.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.permission.android
+
+import android.content.Context
+import android.content.pm.PackageManager
+import androidx.core.content.ContextCompat
+import io.getstream.video.android.core.Call
+import org.openapitools.client.models.OwnCapability
+
+/**
+ * Default mapper for stream calls.
+ */
+internal val defaultPermissionMapper: (OwnCapability) -> String? = { capability ->
+    when (capability) {
+        is OwnCapability.SendAudio -> {
+            android.Manifest.permission.RECORD_AUDIO
+        }
+
+        is OwnCapability.SendVideo -> {
+            android.Manifest.permission.CAMERA
+        }
+
+        else -> {
+            // Do not add any permission
+            null
+        }
+    }
+}
+
+/**
+ * Default expectation for all permissions that we may inquire is granted.
+ */
+internal val defaultPermissionExpectation: (permission: String) -> Int =
+    { _ -> PackageManager.PERMISSION_GRANTED }
+
+/**
+ * Default check against the system if the permission is granted.
+ */
+internal fun defaultPermissionSystemCheck(context: Context): (permission: String) -> Int =
+    { permission -> ContextCompat.checkSelfPermission(context, permission) }
+
+/**
+ * Maps a list of [OwnCapability] to list of [String] where the strings, are android manifest permissions.
+ * used the [defaultPermissionMapper].
+ *
+ * Additional mapper can be supplied for different mapping.
+ *
+ * @return the list of permissions, based on the [OwnCapability] list.
+ */
+internal fun List<OwnCapability>.mapPermissions(mapper: (OwnCapability) -> String?): List<String> =
+    this.mapNotNull {
+        mapper.invoke(it)
+    }.toSet().toList() // Remove duplicates.
+
+/**
+ * Check permission against the system.
+ *
+ * @param systemPermissionCheck usually equal to { ContextCompat.checkSelfPermission(context,string) }.
+ * @param permissionExpectation =
+ */
+internal fun List<String>.checkAllPermissions(
+    systemPermissionCheck: (String) -> Int,
+    permissionExpectation: (String) -> Int = defaultPermissionExpectation,
+): Boolean {
+    for (permission in this) {
+        if (systemPermissionCheck.invoke(permission) != permissionExpectation.invoke(permission)) {
+            // If any permission is not according to expectation
+            return false
+        }
+    }
+    // If all permission are according to expectation function, assume true.
+    return true
+}
+
+/**
+ * Check android permissions. for a call
+ *
+ * @param context the android contex.t
+ * @param call the [Call].
+ * @param permissionMapper mapper used to map list of [OwnCapability] into android.Manifest.* permissions.
+ * @param permissionExpectation an expectation for each mapped permission one of [PackageManager.PERMISSION_GRANTED] or [PackageManager.PERMISSION_DENIED]
+ */
+internal fun checkPermissionsExpectations(
+    context: Context,
+    call: Call,
+    permissionMapper: (OwnCapability) -> String? = defaultPermissionMapper,
+    permissionExpectation: (String) -> Int = defaultPermissionExpectation,
+) = call.state.ownCapabilities.value.mapPermissions(permissionMapper)
+    .checkAllPermissions(defaultPermissionSystemCheck(context), permissionExpectation)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/permission/android/StreamPermissionCheck.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/permission/android/StreamPermissionCheck.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.permission.android
+
+import android.content.Context
+import io.getstream.video.android.core.Call
+
+/**
+ * Android permission check for [Call]
+ * Depending on the call capabilities, [checkAndroidPermissions] will return true if all the android permissions are granted required by the call.
+ * By default having a capability to stream audio for an audio call will require the [android.Manifest.permission.RECORD_AUDIO] permission.
+ * This check ensures that the required permission based on the call configuration are granted.
+ *
+ * The default implementation checks for two permissions:
+ *
+ * [android.Manifest.permission.RECORD_AUDIO] if the call has [org.openapitools.client.models.OwnCapability.SendAudio] capability
+ *
+ * and
+ *
+ * [android.Manifest.permission.CAMERA] if the call has [org.openapitools.client.models.OwnCapability.SendVideo] capability.
+ *
+ * This means that editing the configuration of the call has effect on which permissions are checked.
+ * It is possible to provide a separate implementation to this interface to override this behavior.
+ *
+ * NOTE:
+ * If the [io.getstream.video.android.core.StreamVideoBuilder.runForegroundServiceForCalls] is true
+ * the foreground service that starts will crash if [checkAndroidPermissions] returns false.
+ *
+ * @see [io.getstream.video.android.core.StreamVideoBuilder]
+ */
+interface StreamPermissionCheck {
+
+    /**
+     * Return true if the user granted all the permissions so the [Call] can run.
+     *
+     * e.g. if the user granted the android.Manifest.permission.RECORD_AUDIO and the Call.state.ownCapability has "SendAudio"
+     * then we are safe to join and use the [call] since the permission for recording audio is granted and the user can stream the audio track.
+     */
+    fun checkAndroidPermissions(
+        context: Context,
+        call: Call,
+    ): Boolean
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/permission/android/PermissionUtilitiesKtTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/permission/android/PermissionUtilitiesKtTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.permission.android
+
+import android.content.pm.PackageManager
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+import org.openapitools.client.models.OwnCapability
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PermissionUtilitiesKtTest {
+
+    @Test
+    fun `Correctly map the permissions based on the default mapper`() {
+        // Given
+        val capabilities = listOf(OwnCapability.SendAudio, OwnCapability.SendVideo)
+        // When
+        val defaultMapped = capabilities.mapPermissions(defaultPermissionMapper)
+        // Then
+        assertArrayEquals(
+            arrayOf(android.Manifest.permission.RECORD_AUDIO, android.Manifest.permission.CAMERA),
+            defaultMapped.toTypedArray(),
+        )
+    }
+
+    @Test
+    fun `Correctly map the permissions based on the custom mapper`() {
+        // Given
+        val capabilities = listOf(OwnCapability.SendAudio, OwnCapability.SendVideo)
+        val expectedPermission = android.Manifest.permission.ACCEPT_HANDOVER
+        // When
+        val mapped = capabilities.mapPermissions {
+            // All capabilities map to this permission, for testing
+            expectedPermission
+        }
+        // Then
+        assertArrayEquals(arrayOf(expectedPermission), mapped.toTypedArray())
+    }
+
+    @Test
+    fun `Check permission expectation base on default mapper and expectations`() {
+        // Given
+        val capabilities = listOf(OwnCapability.SendAudio, OwnCapability.SendVideo)
+        val permissions = capabilities.mapPermissions(defaultPermissionMapper)
+
+        // When
+        val actual = permissions.checkAllPermissions(systemPermissionCheck = {
+            // return as if the permission is granted
+            PackageManager.PERMISSION_GRANTED
+        })
+
+        // Then
+        assertTrue(actual)
+    }
+
+    @Test
+    fun `Check permission expectation base on default mapper and expectations when permissions are denied`() {
+        // Given
+        val capabilities = listOf(OwnCapability.SendAudio, OwnCapability.SendVideo)
+        val permissions = capabilities.mapPermissions(defaultPermissionMapper)
+
+        // When
+        val actual = permissions.checkAllPermissions(systemPermissionCheck = {
+            // return as if the permission is granted
+            PackageManager.PERMISSION_DENIED
+        })
+
+        // Then
+        assertFalse(actual)
+    }
+
+    @Test
+    fun `Check permission expectation base on default mapper and custom expectations`() {
+        // Given
+        val capabilities = listOf(OwnCapability.SendAudio, OwnCapability.SendVideo)
+        val permissions = capabilities.mapPermissions(defaultPermissionMapper)
+
+        // When
+        val actual = permissions.checkAllPermissions(systemPermissionCheck = {
+            // return as if the permission is granted
+            PackageManager.PERMISSION_GRANTED
+        }, {
+            when (it) {
+                // Expect granted permission for record audio
+                android.Manifest.permission.RECORD_AUDIO -> PackageManager.PERMISSION_GRANTED
+                // Denied for everything else.
+                else -> PackageManager.PERMISSION_DENIED
+            }
+        })
+
+        // Then
+        // We expect false because the mock system check returns GRANTED for all permissions,
+        // where we expect granted only for the RECORD_AUDIO
+        assertFalse(actual)
+    }
+}

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -7,6 +7,27 @@ public final class io/getstream/video/android/compose/permission/CallPermissions
 	public static final fun rememberCallPermissionsState (Lio/getstream/video/android/core/Call;Ljava/util/List;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/getstream/video/android/compose/permission/VideoPermissionsState;
 }
 
+public final class io/getstream/video/android/compose/permission/ComposableSingletons$LaunchPermissionRequestKt {
+	public static final field INSTANCE Lio/getstream/video/android/compose/permission/ComposableSingletons$LaunchPermissionRequestKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function5;
+	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function5;
+	public final fun getLambda-3$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function3;
+}
+
+public final class io/getstream/video/android/compose/permission/LaunchPermissionRequestKt {
+	public static final fun LaunchPermissionRequest (Ljava/util/List;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+}
+
+public abstract interface class io/getstream/video/android/compose/permission/LaunchPermissionRequestScope {
+	public abstract fun AllPermissionsGranted (Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun NoneGranted (Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun SomeGranted (Lkotlin/jvm/functions/Function5;Landroidx/compose/runtime/Composer;I)V
+}
+
 public final class io/getstream/video/android/compose/permission/SinglePermissionKt {
 	public static final fun LaunchCameraPermissions (Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
 	public static final fun LaunchMicrophonePermissions (Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/permission/LaunchPermissionRequest.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/permission/LaunchPermissionRequest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.compose.permission
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionStatus
+import com.google.accompanist.permissions.rememberMultiplePermissionsState
+
+/**
+ * An API to ensure that the list of [permissions] is granted.
+ *
+ * Usage
+ * ```kotlin
+ * LaunchPermissionRequest(listOf(android.Manifest.RECORD_AUDIO, android.Manifest.CAMERA) {
+ *      Granted {
+ *          // All permissions granted
+ *      }
+ *      SomeGranted { granted, notGranted, showRationale ->
+ *          // Some of the permissions were granted, you can check which ones.
+ *      }
+ *      NotGranted {
+ *          // None of the permissions were granted.
+ *      }
+ * }
+ *
+ *
+ * ```
+ *
+ * @param permissions the required permissions.
+ * @param content the composable content used to register the
+ */
+@OptIn(ExperimentalPermissionsApi::class, ExperimentalPermissionsApi::class)
+@Composable
+public fun LaunchPermissionRequest(
+    permissions: List<String>,
+    content: @Composable LaunchPermissionRequestScope.() -> Unit,
+) {
+    val permissionsState = rememberMultiplePermissionsState(
+        permissions = permissions,
+    )
+    // Init scope
+    val ensurePermissionScope = LaunchPermissionRequestScopeImpl()
+    // Register callbacks
+    content(ensurePermissionScope)
+
+    if (permissionsState.allPermissionsGranted) {
+        // All permissions are granted, call the "granted" content
+        ensurePermissionScope.grantedContent()
+    } else {
+        val anyPermissionWasGranted = permissionsState.permissions.any {
+            it.status == PermissionStatus.Granted
+        }
+        if (anyPermissionWasGranted) {
+            val granted = permissionsState.permissions.mapNotNull {
+                if (it.status == PermissionStatus.Granted) {
+                    it.permission
+                } else {
+                    null
+                }
+            }
+            val notGranted = permissionsState.permissions.mapNotNull {
+                if (it.status is PermissionStatus.Denied) {
+                    it.permission
+                } else {
+                    null
+                }
+            }
+
+            ensurePermissionScope.someGrantedContent(
+                granted,
+                notGranted,
+                permissionsState.shouldShowRationale,
+            )
+        } else {
+            ensurePermissionScope.notGrantedContent(permissionsState.shouldShowRationale)
+        }
+    }
+    LaunchedEffect(key1 = true) {
+        permissionsState.launchMultiplePermissionRequest()
+    }
+}
+
+/**
+ * Scope for the [LaunchPermissionRequest] composable.
+ * Used to register the content callbacks for when the permissions are available or not.
+ */
+public interface LaunchPermissionRequestScope {
+    /**
+     * Called after the request, when the user has granted all the requested permissions for this scope.
+     */
+    @Composable
+    public fun AllPermissionsGranted(content: @Composable () -> Unit)
+
+    /**
+     * Some permissions were granted, while others were not.
+     * Use the [content] parameters to decide what to do in certain cases if some permissions are optional to you.
+     */
+    @Composable
+    public fun SomeGranted(
+        content: @Composable (
+            granted: List<String>,
+            notGranted: List<String>,
+            showRationale: Boolean,
+        ) -> Unit,
+    )
+
+    /**
+     * None of the permissions were granted.
+     */
+    @Composable
+    public fun NoneGranted(content: @Composable (showRationale: Boolean) -> Unit)
+}
+
+private class LaunchPermissionRequestScopeImpl : LaunchPermissionRequestScope {
+
+    var grantedContent: @Composable () -> Unit = { }
+    var someGrantedContent: @Composable (
+        granted: List<String>,
+        notGranted: List<String>,
+        showRationale: Boolean,
+    ) -> Unit =
+        { _, _, _ -> }
+    var notGrantedContent: @Composable (showRationale: Boolean) -> Unit = { }
+
+    @Composable
+    override fun AllPermissionsGranted(content: @Composable () -> Unit) {
+        grantedContent = content
+    }
+
+    @Composable
+    override fun SomeGranted(
+        content: @Composable (
+            granted: List<String>,
+            notGranted: List<String>,
+            showRationale: Boolean,
+        ) -> Unit,
+    ) {
+        someGrantedContent = content
+    }
+
+    @Composable
+    override fun NoneGranted(content: @Composable (showRationale: Boolean) -> Unit) {
+        notGrantedContent = content
+    }
+}


### PR DESCRIPTION
This PR aims to improve the permission handling and provide optional way to manage Android permissions. Further it aims to  improve the logging and behaviour in two sensitive places when calls can happen without the required permissions:
* On `Call.join()` will now log a warning explaining the service may crash if started and advising the user on what to do.
* `CallService.onStartCommand()` will now crash by itself, instead of waiting for the system to crash it if the permissions are not granted. The message is similar as with `Call.join()` explaining in details what is the cause and what can be done. (see screenshots)

Users are advised to use the `onPermissionResult` callback in `LaunchCallPermission` or optionally use the new composable `LaunchPermissionRequest`. This is a composable that can render different contents based on the permission state.

Additionally a new way to ensure permissions are granted is added. `StreamPermissionCheck` is an interface that can 
 be used to check at any time if a list of permissions is granted for given `Call`.
The default behaviour is that calls with audio capability will require `manifest.permission.RECORD_AUDIO` and calls with video capability will require `manifest.permission.CAMERA` on top of it. The `DefaultStreamPermissionCheck` is the default implementation of the interface, but the actual implementation is found in two pure functions in `PermissionUtiltities.kt` which are also the ones that are tested.

The users of the SDK can override default permission mapping and state expectations by implementing a custom `StreamPermissionCheck` and providing it in the `StreamVideoBuilder` for instance. You can force the app to behave as if all the permissions are always granted, by providing an implementation that will return `true` for the check regardless of the parameters.

Warning after `Call.join()` without permissions:
![image](https://github.com/GetStream/stream-video-android/assets/11648905/c34654ce-559f-473b-a659-37b93f92b616)


Custom error message after `CallService.onStartCommand()` without the required permissions:
![Screenshot 2024-03-11 at 15 55 31](https://github.com/GetStream/stream-video-android/assets/11648905/0a231da7-b4c3-48e4-b33a-8bf32c0c072d)

