### PR TITLE
Fix concurrent modification exception

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -310,11 +310,11 @@ public class Call(
         if (!permissionPass) {
             logger.w {
                 "\n[Call.join()] called without having the required permissions.\n" +
-                        "This will work only if you have [runForegroundServiceForCalls = false] in the StreamVideoBuilder.\n" +
-                        "The reason is that [Call.join()] will by default start an ongoing call foreground service,\n" +
-                        "To start this service and send the appropriate audio/video tracks the permissions are required,\n" +
-                        "otherwise the service will fail to start, resulting in a crash.\n" +
-                        "You can re-define your permissions and their expected state by overriding the [permissionCheck] in [StreamVideoBuilder]\n"
+                    "This will work only if you have [runForegroundServiceForCalls = false] in the StreamVideoBuilder.\n" +
+                    "The reason is that [Call.join()] will by default start an ongoing call foreground service,\n" +
+                    "To start this service and send the appropriate audio/video tracks the permissions are required,\n" +
+                    "otherwise the service will fail to start, resulting in a crash.\n" +
+                    "You can re-define your permissions and their expected state by overriding the [permissionCheck] in [StreamVideoBuilder]\n"
             }
         }
         // if we are a guest user, make sure we wait for the token before running the join flow
@@ -339,7 +339,7 @@ public class Call(
                 } else {
                     logger.w {
                         "[join] Call settings were null - this should never happen after a call" +
-                                "is joined. MediaManager will not be initialised with server settings."
+                            "is joined. MediaManager will not be initialised with server settings."
                     }
                 }
                 return result
@@ -511,9 +511,9 @@ public class Call(
 
             // We were not able to restore the SFU peer connection in time
             if (System.currentTimeMillis() - (
-                        sfuSocketReconnectionTime
-                            ?: System.currentTimeMillis()
-                        ) > sfuReconnectTimeoutMillis
+                    sfuSocketReconnectionTime
+                        ?: System.currentTimeMillis()
+                    ) > sfuReconnectTimeoutMillis
             ) {
                 leave(Error("Failed to do a full reconnect - connection issue?"))
                 return
@@ -564,7 +564,7 @@ public class Call(
             } else {
                 logger.e {
                     "[switchSfu] Failed to get a join response during " +
-                            "migration - falling back to reconnect. Error ${joinResponse.errorOrNull()}"
+                        "migration - falling back to reconnect. Error ${joinResponse.errorOrNull()}"
                 }
                 state._connection.value = RealtimeConnection.Reconnecting
             }


### PR DESCRIPTION
This PR fixes a bug that would cause a crash when modifying the `subscribers` for call events at the same time when `fireEvent` is invoked.