### PR TITLE
Implement onAllPermissionsGranted for rememberCallPermissionsState

### DIFF
--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -3,8 +3,8 @@ public final class io/getstream/video/android/compose/lifecycle/MediaPiPLifecycl
 }
 
 public final class io/getstream/video/android/compose/permission/CallPermissionsKt {
-	public static final fun LaunchCallPermissions (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
-	public static final fun rememberCallPermissionsState (Lio/getstream/video/android/core/Call;Ljava/util/List;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/getstream/video/android/compose/permission/VideoPermissionsState;
+	public static final fun LaunchCallPermissions (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun rememberCallPermissionsState (Lio/getstream/video/android/core/Call;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/getstream/video/android/compose/permission/VideoPermissionsState;
 }
 
 public final class io/getstream/video/android/compose/permission/ComposableSingletons$LaunchPermissionRequestKt {
@@ -929,7 +929,7 @@ public final class io/getstream/video/android/compose/ui/components/call/activec
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/activecall/CallContentKt {
-	public static final fun CallContent (Lio/getstream/video/android/core/Call;Landroidx/compose/ui/Modifier;Lio/getstream/video/android/compose/ui/components/call/renderer/LayoutType;ZLio/getstream/video/android/compose/permission/VideoPermissionsState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lio/getstream/video/android/compose/ui/components/call/renderer/VideoRendererStyle;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ZLkotlin/jvm/functions/Function3;ZLandroidx/compose/runtime/Composer;III)V
+	public static final fun CallContent (Lio/getstream/video/android/core/Call;Landroidx/compose/ui/Modifier;Lio/getstream/video/android/compose/ui/components/call/renderer/LayoutType;Lio/getstream/video/android/compose/permission/VideoPermissionsState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lio/getstream/video/android/compose/ui/components/call/renderer/VideoRendererStyle;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ZLkotlin/jvm/functions/Function3;ZLandroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/activecall/ComposableSingletons$AudioCallContentKt {

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -3,8 +3,8 @@ public final class io/getstream/video/android/compose/lifecycle/MediaPiPLifecycl
 }
 
 public final class io/getstream/video/android/compose/permission/CallPermissionsKt {
-	public static final fun LaunchCallPermissions (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
-	public static final fun rememberCallPermissionsState (Lio/getstream/video/android/core/Call;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lio/getstream/video/android/compose/permission/VideoPermissionsState;
+	public static final fun LaunchCallPermissions (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun rememberCallPermissionsState (Lio/getstream/video/android/core/Call;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lio/getstream/video/android/compose/permission/VideoPermissionsState;
 }
 
 public final class io/getstream/video/android/compose/permission/ComposableSingletons$LaunchPermissionRequestKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/permission/CallPermissions.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/permission/CallPermissions.kt
@@ -52,7 +52,7 @@ public fun rememberCallPermissionsState(
         )
     },
     onPermissionsResult: ((Map<String, Boolean>) -> Unit)? = null,
-    onAllPermissionsGranted: (() -> Unit)? = null,
+    onAllPermissionsGranted: (suspend () -> Unit)? = null,
 ): VideoPermissionsState {
     if (LocalInspectionMode.current) return fakeVideoPermissionsState
 
@@ -103,7 +103,7 @@ public fun rememberCallPermissionsState(
 public fun LaunchCallPermissions(
     call: Call,
     onPermissionsResult: ((Map<String, Boolean>) -> Unit)? = null,
-    onAllPermissionsGranted: (() -> Unit)? = null,
+    onAllPermissionsGranted: (suspend () -> Unit)? = null,
 ) {
     val callPermissionsState =
         rememberCallPermissionsState(

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/permission/CallPermissions.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/permission/CallPermissions.kt
@@ -52,6 +52,7 @@ public fun rememberCallPermissionsState(
         )
     },
     onPermissionsResult: ((Map<String, Boolean>) -> Unit)? = null,
+    onAllPermissionsGranted: (() -> Unit)? = null,
 ): VideoPermissionsState {
     if (LocalInspectionMode.current) return fakeVideoPermissionsState
 
@@ -70,6 +71,14 @@ public fun rememberCallPermissionsState(
             }
         }
     }
+
+    val allPermissionsGranted = permissionState.allPermissionsGranted
+    LaunchedEffect(key1 = allPermissionsGranted) {
+        if (allPermissionsGranted) {
+            onAllPermissionsGranted?.invoke()
+        }
+    }
+
     return remember(call, permissions) {
         object : VideoPermissionsState {
             override val allPermissionsGranted: Boolean
@@ -94,8 +103,13 @@ public fun rememberCallPermissionsState(
 public fun LaunchCallPermissions(
     call: Call,
     onPermissionsResult: ((Map<String, Boolean>) -> Unit)? = null,
+    onAllPermissionsGranted: (() -> Unit)? = null,
 ) {
     val callPermissionsState =
-        rememberCallPermissionsState(call = call, onPermissionsResult = onPermissionsResult)
+        rememberCallPermissionsState(
+            call = call,
+            onPermissionsResult = onPermissionsResult,
+            onAllPermissionsGranted = onAllPermissionsGranted,
+        )
     LaunchedEffect(key1 = call) { callPermissionsState.launchPermissionRequest() }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/CallContent.kt
@@ -100,7 +100,6 @@ public fun CallContent(
     call: Call,
     modifier: Modifier = Modifier,
     layout: LayoutType = LayoutType.DYNAMIC,
-    isShowingOverlayAppBar: Boolean = false,
     permissions: VideoPermissionsState = rememberCallPermissionsState(call = call),
     onBackPressed: () -> Unit = {},
     onCallAction: (CallAction) -> Unit = { DefaultOnCallActionHandler.onCallAction(call, it) },


### PR DESCRIPTION
Implement `onAllPermissionsGranted` for `rememberCallPermissionsState`.

This solution resolves #1026 by utilizing the `onAllPermissionsGranted` lambda to detect when all necessary permissions are granted, enabling us to proceed with joining the call.

```kotlin
CallContent(
    permissions = rememberCallPermissionsState(
        call = call,
        onAllPermissionsGranted = {
            call.join()
        }
    ),
  ..
)
```