### PR TITLE
Update core unit tests

### DIFF
--- a/stream-video-android-core/build.gradle.kts
+++ b/stream-video-android-core/build.gradle.kts
@@ -202,6 +202,7 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.kotlin.test.junit)
     testImplementation(libs.kotlinx.coroutines.debug)
+    testImplementation(libs.kotlinx.serialization.converter)
 
     // instrument tests
     androidTestImplementation(libs.stream.log.android)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
@@ -41,7 +41,7 @@ class ClientAndAuthTest : TestBase() {
     fun regularUser() = runTest {
         val builder = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
             user = testData.users["thierry"]!!,
             token = testData.tokens["thierry"]!!,
@@ -55,7 +55,7 @@ class ClientAndAuthTest : TestBase() {
     fun anonymousUser() = runTest {
         val builder = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
             user = User(
                 type = UserType.Anonymous,
@@ -74,7 +74,7 @@ class ClientAndAuthTest : TestBase() {
         // API call is getGuestUser or something like that
         val client = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
             user = User(
                 id = "guest",
@@ -90,7 +90,7 @@ class ClientAndAuthTest : TestBase() {
     fun subscribeToAllEvents() = runTest {
         val client = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
             user = User(
                 id = "guest",
@@ -108,7 +108,7 @@ class ClientAndAuthTest : TestBase() {
     fun subscribeToSpecificEvents() = runTest {
         val client = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
             user = User(
                 id = "guest",
@@ -127,10 +127,10 @@ class ClientAndAuthTest : TestBase() {
     fun waitForWSConnection() = runTest {
         val client = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
-            testData.users["thierry"]!!,
-            testData.tokens["thierry"]!!,
+            user = testData.users["thierry"]!!,
+            token = authData!!.token,
         ).build()
         assertThat(client.state.connection.value).isEqualTo(ConnectionState.PreConnect)
         val clientImpl = client as StreamVideoImpl
@@ -149,8 +149,8 @@ class ClientAndAuthTest : TestBase() {
             context = context,
             apiKey = "notvalid",
             geo = GEO.GlobalEdgeNetwork,
-            testData.users["thierry"]!!,
-            testData.tokens["thierry"]!!,
+            user = testData.users["thierry"]!!,
+            token = authData!!.token,
         ).build()
     }
 
@@ -159,10 +159,10 @@ class ClientAndAuthTest : TestBase() {
     fun `test an expired token, no provider set`() = runTest {
         val client = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
-            testData.users["thierry"]!!,
-            testData.expiredToken,
+            user = testData.users["thierry"]!!,
+            token = authData!!.token,
         ).build()
 
         val result = client.call("default", "123").create()
@@ -179,10 +179,10 @@ class ClientAndAuthTest : TestBase() {
         StreamVideo.removeClient()
         val client = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
-            testData.users["thierry"]!!,
-            testData.expiredToken,
+            user = testData.users["thierry"]!!,
+            token = testData.expiredToken,
             tokenProvider = { error ->
                 testData.tokens["thierry"]!!
             },
@@ -211,10 +211,10 @@ class ClientAndAuthTest : TestBase() {
     fun `two clients is not allowed`() = runTest {
         val builder = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
-            testData.users["thierry"]!!,
-            testData.tokens["thierry"]!!,
+            user = testData.users["thierry"]!!,
+            token = authData!!.token,
         )
         val client = builder.build()
         val client2 = builder.build()
@@ -226,10 +226,10 @@ class ClientAndAuthTest : TestBase() {
         // often you'll want to run the connection task in the background and not wait for it
         val client = StreamVideoBuilder(
             context = context,
-            apiKey = apiKey,
+            apiKey = authData!!.apiKey,
             geo = GEO.GlobalEdgeNetwork,
-            testData.users["thierry"]!!,
-            testData.tokens["thierry"]!!,
+            user = testData.users["thierry"]!!,
+            token = authData!!.token,
         ).build()
         val clientImpl = client as StreamVideoImpl
         client.subscribe {

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestBase.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestBase.kt
@@ -87,10 +87,10 @@ open class IntegrationTestBase(val connectCoordinatorWS: Boolean = true) : TestB
     fun setupVideo() {
         builder = StreamVideoBuilder(
             context = ApplicationProvider.getApplicationContext(),
-            apiKey = "hd8szvscpxvd",
+            apiKey = authData?.apiKey!!,
             geo = GEO.GlobalEdgeNetwork,
-            testData.users["thierry"]!!,
-            testData.tokens["thierry"]!!,
+            user = testData.users["thierry"]!!,
+            token = authData?.token!!,
             loggingLevel = LoggingLevel(Priority.DEBUG, HttpLoggingLevel.BASIC),
         )
 //        if (BuildConfig.CORE_TEST_LOCAL == "1") {

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestHelper.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestHelper.kt
@@ -27,7 +27,7 @@ public class IntegrationTestHelper {
     val context: Context
 
     val expiredToken =
-        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeUBnZXRzdHJlYW0uaW8iLCJpc3MiOiJwcm9udG8iLCJzdWIiOiJ1c2VyL3RoaWVycnlAZ2V0c3RyZWFtLmlvIiwiaWF0IjoxNjgxMjUxMDg4LCJleHAiOjE2ODEyNjE4OTN9.VinzXBwvT_AGXNBG8QTz9HJFSR6LhqIEtVpIlmY1aEc"
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiNW9STEJjMXQiLCJpc3MiOiJodHRwczovL3Byb250by5nZXRzdHJlYW0uaW8iLCJzdWIiOiJ1c2VyLzVvUkxCYzF0IiwiaWF0IjoxNzExNTIzNzkxLCJleHAiOjE3MTIxMjg1OTZ9.VzKQ1aMsL5LnJb6xHdV3stBfqTo-GU57FXLmrF4xpkI"
 
     val fakeSDP = """
         v=0

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/SocketTestBase.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/SocketTestBase.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.base
+
+import android.content.Context
+import android.net.ConnectivityManager
+import io.getstream.video.android.core.dispatchers.DispatcherProvider
+import io.getstream.video.android.core.internal.network.NetworkStateProvider
+import io.getstream.video.android.core.socket.CoordinatorSocket
+import io.getstream.video.android.core.socket.PersistentSocket
+import io.mockk.impl.annotations.RelaxedMockK
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import okhttp3.OkHttpClient
+import okhttp3.WebSocket
+import okhttp3.logging.HttpLoggingInterceptor
+import org.openapitools.client.models.VideoEvent
+import java.util.concurrent.TimeUnit
+
+open class SocketTestBase : TestBase() {
+    val coordinatorUrl =
+        "https://video.stream-io-api.com/video/connect?api_key=${authData?.apiKey!!}&stream-auth-type=jwt&X-Stream-Client=stream-video-android"
+    val sfuUrl = "wss://sfu-f079b1a.dpk-den1.stream-io-video.com/ws"
+    val sfuToken =
+        "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiI4ZDBlYjU0NDg4ZDFiYTUxOTk3Y2Y1NWRmYTY0Y2NiMCIsInN1YiI6InVzZXIvdGhpZXJyeSIsImF1ZCI6WyJzZnUtZjA3OWIxYS5kcGstZGVuMS5zdHJlYW0taW8tdmlkZW8uY29tIl0sImV4cCI6MTY4NDI5NTQyMiwibmJmIjoxNjg0MjczODIyLCJpYXQiOjE2ODQyNzM4MjIsImFwcF9pZCI6MTEyOTUyOCwiY2FsbF9pZCI6ImRlZmF1bHQ6ZTJjMDRkZjYtYTNiMy00YTcyLWIxMjctOTJiNjkyZmMxMDA2IiwidXNlciI6eyJpZCI6InRoaWVycnkiLCJuYW1lIjoiVGhpZXJyeSIsImltYWdlIjoiaGVsbG8iLCJ0cCI6IkdvNGhUc3R4MEhoUDFXRnBDa0NlT0w0ZmpxVDRCQWx1In0sInJvbGVzIjpbInVzZXIiXSwib3duZXIiOnRydWV9.Fp5z70vshi6UoGMMNV1aZd1AIAS4fvm46jJ_O3YGfdyReUXl7gDHeonxwrbT0OJ-rd2tyGVHCCrbvkqGEznwKg"
+
+    @RelaxedMockK
+    lateinit var mockedWebSocket: WebSocket
+
+    /**
+     * Mocks
+     * - network state, so we can fake going offline/online
+     * - socket, so we can pretend the network is unavailable or we get an error
+     */
+
+    val networkStateProvider = NetworkStateProvider(
+        connectivityManager = context
+            .getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager,
+    )
+    val scope = CoroutineScope(DispatcherProvider.IO)
+
+    fun buildOkHttp(): OkHttpClient {
+        val connectionTimeoutInMs = 10000L
+        return OkHttpClient.Builder()
+            .addInterceptor(
+                HttpLoggingInterceptor().apply {
+                    level = HttpLoggingInterceptor.Level.BASIC
+                },
+            )
+            .connectTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+            .writeTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+            .readTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+            .callTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+            .build()
+    }
+
+    fun collectEvents(socket: CoordinatorSocket): Pair<List<VideoEvent>, List<Throwable>> {
+        val events = mutableListOf<VideoEvent>()
+        val errors = mutableListOf<Throwable>()
+
+        runBlocking {
+            val job = launch {
+                socket.events.collect {
+                    events.add(it)
+                }
+            }
+
+            val job2 = launch {
+                socket.errors.collect() {
+                    errors.add(it)
+                }
+            }
+
+            delay(1000)
+            socket.disconnect(PersistentSocket.DisconnectReason.ByRequest)
+            job.cancel()
+            job2.cancel()
+        }
+
+        return Pair(events, errors)
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/TestBase.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/TestBase.kt
@@ -20,10 +20,13 @@ import io.getstream.log.Priority
 import io.getstream.log.StreamLog
 import io.getstream.log.streamLog
 import io.getstream.result.Result
+import io.getstream.video.android.core.base.auth.GetAuthDataResponse
+import io.getstream.video.android.core.base.auth.StreamService
 import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
 import io.mockk.MockKAnnotations
 import io.mockk.impl.annotations.MockK
 import io.mockk.junit4.MockKRule
+import kotlinx.coroutines.runBlocking
 import org.junit.Before
 import org.junit.Rule
 import org.threeten.bp.Clock
@@ -42,14 +45,22 @@ public open class TestBase {
 
     val nowUtc = OffsetDateTime.now(Clock.systemUTC())
 
-    /** API Key */
-    val apiKey = "hd8szvscpxvd"
-
     @get:Rule
     val mockkRule = MockKRule(this)
 
     @MockK(relaxUnitFun = true, relaxed = true)
     lateinit var mockedPCFactory: StreamPeerConnectionFactory
+
+    var authData: GetAuthDataResponse? = null
+
+    init {
+        runBlocking {
+            authData = StreamService.instance.getAuthData(
+                environment = "pronto",
+                userId = testData.users["thierry"]!!.id,
+            )
+        }
+    }
 
     @Before
     fun setUp() {

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/auth/GetAuthDataResponse.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/auth/GetAuthDataResponse.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.base.auth
+
+import kotlinx.serialization.Serializable
+
+@Serializable data class GetAuthDataResponse(val userId: String, val apiKey: String, val token: String)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/auth/StreamService.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/auth/StreamService.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.base.auth
+
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+import retrofit2.create
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface StreamService {
+    @GET("api/auth/create-token")
+    suspend fun getAuthData(
+        @Query("environment") environment: String,
+        @Query("user_id") userId: String?,
+    ): GetAuthDataResponse
+
+    companion object {
+        private const val BASE_URL = "https://pronto.getstream.io/"
+
+        private val json = Json { ignoreUnknownKeys = true }
+
+        private val retrofit = Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+            .build()
+
+        val instance = retrofit.create<StreamService>()
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Refactor `core` unit tests in order to fix failures.

### 🛠 Implementation details

Used the auth endpoint (`api/auth/create-token`) instead of hardcoded `apiKey` and `token` and reworked tests to used it.