### PR TITLE
Speakerphone fallback update

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -760,7 +760,8 @@ public final class io/getstream/video/android/core/SpeakerManager {
 	public final fun resume ()V
 	public final fun setEnabled (ZZ)V
 	public static synthetic fun setEnabled$default (Lio/getstream/video/android/core/SpeakerManager;ZZILjava/lang/Object;)V
-	public final fun setSpeakerPhone (Z)V
+	public final fun setSpeakerPhone (ZLio/getstream/video/android/core/audio/StreamAudioDevice;)V
+	public static synthetic fun setSpeakerPhone$default (Lio/getstream/video/android/core/SpeakerManager;ZLio/getstream/video/android/core/audio/StreamAudioDevice;ILjava/lang/Object;)V
 	public final fun setVolume (I)V
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -132,7 +132,7 @@ class SpeakerManager(
      * setSpeakerPhone(enable, StreamAudioDevice.Earpiece)
      * ```
      *
-     * @param enable if ture, enables the speakerphone, if false disables it and selects another device.
+     * @param enable if true, enables the speakerphone, if false disables it and selects another device.
      * @param defaultFallback when [enable] is false this is used to select the next device after the speaker.
      * */
     fun setSpeakerPhone(enable: Boolean, defaultFallback: StreamAudioDevice? = null) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -388,6 +388,7 @@ class MicrophoneManager(
         enforceSetup {
             if (enabled) {
                 enable(fromUser = fromUser)
+                mediaManager.speaker.setEnabled(enabled = false, fromUser = false)
             } else {
                 disable(fromUser = fromUser)
             }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -122,8 +122,20 @@ class SpeakerManager(
         }
     }
 
-    /** enables or disables the speakerphone */
-    fun setSpeakerPhone(enable: Boolean) {
+    /**
+     * Enables or disables the speakerphone.
+     *
+     * When the speaker is disabled the device that gets selected next is by default the first device
+     * that is NOT a speakerphone. To override this use [defaultFallback].
+     * If you want the earpice to be selected if the speakerphone is disabled do
+     * ```kotlin
+     * setSpeakerPhone(enable, StreamAudioDevice.Earpiece)
+     * ```
+     *
+     * @param enable if ture, enables the speakerphone, if false disables it and selects another device.
+     * @param defaultFallback when [enable] is false this is used to select the next device after the speaker.
+     * */
+    fun setSpeakerPhone(enable: Boolean, defaultFallback: StreamAudioDevice? = null) {
         microphoneManager.setup()
         val devices = devices.value
         if (enable) {
@@ -134,9 +146,12 @@ class SpeakerManager(
         } else {
             _speakerPhoneEnabled.value = false
             // swap back to the old one
-            val fallback =
-                selectedBeforeSpeaker
-                    ?: devices.firstOrNull { it !is StreamAudioDevice.Speakerphone }
+            val defaultFallbackFromType = defaultFallback?.let {
+                devices.filterIsInstance(defaultFallback::class.java)
+            }?.firstOrNull()
+            val fallback = defaultFallbackFromType ?: selectedBeforeSpeaker ?: devices.firstOrNull {
+                it !is StreamAudioDevice.Speakerphone
+            }
             microphoneManager.select(fallback)
         }
     }


### PR DESCRIPTION
When disabling the speakerphone in `setSpeakerPhone(boolean)` the `fallback` device is set to `the first which is NOT a speakerphone`. Extend the api into `setSpeakerPhone(boolean, StreamAudioDevice) to allow for a preference when selecting a fallback.