### PR TITLE
Propagate call ended correctly to subscribers

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -499,14 +499,6 @@ internal class StreamVideoImpl internal constructor(
             callEvent?.getCallCID()
         } ?: ""
 
-        if (selectedCid.isNotEmpty()) {
-            calls[selectedCid]?.let {
-                it.state.handleEvent(event)
-                it.session?.handleEvent(event)
-                it.handleEvent(event)
-            }
-        }
-
         // client level subscriptions
         subscriptions.forEach { sub ->
             if (!sub.isDisposed) {
@@ -526,6 +518,14 @@ internal class StreamVideoImpl internal constructor(
         // call level subscriptions
         if (selectedCid.isNotEmpty()) {
             calls[selectedCid]?.fireEvent(event)
+        }
+
+        if (selectedCid.isNotEmpty()) {
+            calls[selectedCid]?.let {
+                it.state.handleEvent(event)
+                it.session?.handleEvent(event)
+                it.handleEvent(event)
+            }
         }
     }
 


### PR DESCRIPTION
If `CallEndedEvent` is received, the `handleCall` event is called on the `call.state` this however in the case of `CallEndedEvent` would call `call.leave()` internally which would cause the `call` to be disposed and events to not be propagated anymore, thus an `EventSubscriber` used in `call.subscribe` would never receive the `CallEndedEvent`.

This fix switches the order of which the internal components are called, first propagating the `CallEndedEvent` to the subscribers then, disposing of the call internally.