### PR TITLE
Improve incoming call reject logic

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -336,8 +336,9 @@ internal class CallService : Service() {
                 logger.i { "Received event in service: $event" }
                 when (event) {
                     is CallAcceptedEvent -> {
-                        handleCallAcceptedOnAnotherDevice(
+                        stopServiceIfCallAcceptedByMeOnAnotherDevice(
                             acceptedByUserId = event.user.id,
+                            myUserId = streamVideo.userId,
                             callRingingState = call.state.ringingState.value,
                         )
                     }
@@ -393,9 +394,7 @@ internal class CallService : Service() {
         }
     }
 
-    private fun handleCallAcceptedOnAnotherDevice(acceptedByUserId: String, callRingingState: RingingState) {
-        val myUserId = StreamVideo.instanceOrNull()?.userId
-
+    private fun stopServiceIfCallAcceptedByMeOnAnotherDevice(acceptedByUserId: String, myUserId: String, callRingingState: RingingState) {
         // If call was accepted by me, but current device is still ringing, it means the call was accepted on another device
         if (acceptedByUserId == myUserId && callRingingState is RingingState.Incoming) {
             // So stop ringing on this device

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -343,8 +343,11 @@ internal class CallService : Service() {
                     }
 
                     is CallRejectedEvent -> {
-                        // When call is rejected by the caller
-                        stopService()
+                        stopServiceIfCallRejectedByMeOrCaller(
+                            rejectedByUserId = event.user.id,
+                            myUserId = streamVideo.userId,
+                            createdByUserId = call.state.createdBy.value?.id,
+                        )
                     }
 
                     is CallEndedEvent -> {
@@ -396,6 +399,13 @@ internal class CallService : Service() {
         // If call was accepted by me, but current device is still ringing, it means the call was accepted on another device
         if (acceptedByUserId == myUserId && callRingingState is RingingState.Incoming) {
             // So stop ringing on this device
+            stopService()
+        }
+    }
+
+    private fun stopServiceIfCallRejectedByMeOrCaller(rejectedByUserId: String, myUserId: String, createdByUserId: String?) {
+        if (rejectedByUserId == myUserId || rejectedByUserId == createdByUserId) {
+            // If call is rejected by me (even on another device) OR the caller, stop the service
             stopService()
         }
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -395,7 +395,7 @@ internal class CallService : Service() {
     }
 
     private fun stopServiceIfCallAcceptedByMeOnAnotherDevice(acceptedByUserId: String, myUserId: String, callRingingState: RingingState) {
-        // If call was accepted by me, but current device is still ringing, it means the call was accepted on another device
+        // If incoming call was accepted by me, but current device is still ringing, it means the call was accepted on another device
         if (acceptedByUserId == myUserId && callRingingState is RingingState.Incoming) {
             // So stop ringing on this device
             stopService()
@@ -403,8 +403,8 @@ internal class CallService : Service() {
     }
 
     private fun stopServiceIfCallRejectedByMeOrCaller(rejectedByUserId: String, myUserId: String, createdByUserId: String?) {
+        // If incoming call is rejected by me (even on another device) OR cancelled by the caller, stop the service
         if (rejectedByUserId == myUserId || rejectedByUserId == createdByUserId) {
-            // If call is rejected by me (even on another device) OR the caller, stop the service
             stopService()
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Improve incoming call reject logic in the following scenarios:
- We have `UserOutgoing`, `User1` and `User2`. `User1` _rejects_, call _should still ring_ for `User2`.
- We have `UserOutgoing` and `User1` on multiple devices. `User1` rejects, _ringing should stop_ on all its devices.
- We have `UserOutgoing` and other users. `UserOutgoing` rejects, _ringing should stop_ for everyone.

### 🛠 Implementation details

- Added new logic in `CallService.observeCallState()` for `CallRejectedEvent`.