### PR TITLE
Add option to make ringing notification as low priority in foreground

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4075,11 +4075,12 @@ public final class io/getstream/video/android/core/model/VisibilityOnScreenState
 
 public class io/getstream/video/android/core/notifications/DefaultNotificationHandler : io/getstream/android/push/permissions/NotificationPermissionHandler, io/getstream/video/android/core/notifications/NotificationHandler {
 	public static final field Companion Lio/getstream/video/android/core/notifications/DefaultNotificationHandler$Companion;
-	public fun <init> (Landroid/app/Application;Lio/getstream/android/push/permissions/NotificationPermissionHandler;)V
-	public synthetic fun <init> (Landroid/app/Application;Lio/getstream/android/push/permissions/NotificationPermissionHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/app/Application;Lio/getstream/android/push/permissions/NotificationPermissionHandler;Z)V
+	public synthetic fun <init> (Landroid/app/Application;Lio/getstream/android/push/permissions/NotificationPermissionHandler;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun getChannelDescription ()Ljava/lang/String;
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelName ()Ljava/lang/String;
+	public final fun getHideRingingNotificationInForeground ()Z
 	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;)Landroid/app/Notification;
 	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
 	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
@@ -4096,14 +4097,16 @@ public final class io/getstream/video/android/core/notifications/DefaultNotifica
 
 public final class io/getstream/video/android/core/notifications/NotificationConfig {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;)V
-	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;Z)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lkotlin/jvm/functions/Function0;
 	public final fun component3 ()Lio/getstream/video/android/core/notifications/NotificationHandler;
-	public final fun copy (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;)Lio/getstream/video/android/core/notifications/NotificationConfig;
-	public static synthetic fun copy$default (Lio/getstream/video/android/core/notifications/NotificationConfig;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ILjava/lang/Object;)Lio/getstream/video/android/core/notifications/NotificationConfig;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;Z)Lio/getstream/video/android/core/notifications/NotificationConfig;
+	public static synthetic fun copy$default (Lio/getstream/video/android/core/notifications/NotificationConfig;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZILjava/lang/Object;)Lio/getstream/video/android/core/notifications/NotificationConfig;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHideRingingNotificationInForeground ()Z
 	public final fun getNotificationHandler ()Lio/getstream/video/android/core/notifications/NotificationHandler;
 	public final fun getPushDeviceGenerators ()Ljava/util/List;
 	public final fun getRequestPermissionOnAppLaunch ()Lkotlin/jvm/functions/Function0;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationConfig.kt
@@ -23,4 +23,12 @@ public data class NotificationConfig(
     val pushDeviceGenerators: List<PushDeviceGenerator> = emptyList(),
     val requestPermissionOnAppLaunch: () -> Boolean = { true },
     val notificationHandler: NotificationHandler = NoOpNotificationHandler,
+    /**
+     * Set this to true if you want to make the ringing notifications as low-priority
+     * in case the application is in foreground. This will prevent the notification from
+     * interrupting the user while he is in the app. In this case you need to make sure to
+     * handle this call state and display an incoming call screen.
+     * NOTE: This setting has only an effect if you don't set a custom [NotificationHandler]!
+     */
+    val hideRingingNotificationInForeground: Boolean = false,
 )

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
@@ -151,7 +151,10 @@ internal class StreamNotificationManager private constructor(
                 } else {
                     val application = context.applicationContext as? Application
                     val updatedNotificationConfig =
-                        notificationConfig.overrideDefault(application)
+                        notificationConfig.overrideDefault(
+                            application = application,
+                            hideRingingNotificationInForeground = notificationConfig.hideRingingNotificationInForeground,
+                        )
                     val onPermissionStatus: (NotificationPermissionStatus) -> Unit = { nps ->
                         with(updatedNotificationConfig.notificationHandler) {
                             when (nps) {
@@ -182,11 +185,17 @@ internal class StreamNotificationManager private constructor(
             }
         }
 
-        private fun NotificationConfig.overrideDefault(application: Application?): NotificationConfig {
+        private fun NotificationConfig.overrideDefault(
+            application: Application?,
+            hideRingingNotificationInForeground: Boolean,
+        ): NotificationConfig {
             return application?.let {
                 val notificationHandler = notificationHandler
                     .takeUnless { it == NoOpNotificationHandler }
-                    ?: DefaultNotificationHandler(application)
+                    ?: DefaultNotificationHandler(
+                        application = application,
+                        hideRingingNotificationInForeground = hideRingingNotificationInForeground,
+                    )
                 this.copy(notificationHandler = notificationHandler)
             } ?: this
         }

--- a/stream-video-android-core/src/main/res/values/strings.xml
+++ b/stream-video-android-core/src/main/res/values/strings.xml
@@ -27,6 +27,8 @@
     <string name="stream_video_screen_sharing_notification_channel_description">Required to be enabled for screen sharing</string>
     <string name="stream_video_incoming_call_notification_channel_id" translatable="false">incoming_calls</string>
     <string name="stream_video_incoming_call_notification_channel_title">Incoming Calls</string>
+    <string name="stream_video_incoming_call_low_priority_notification_channel_id" translatable="false">incoming_calls_low_priority</string>
+    <string name="stream_video_incoming_call_low_priority_notification_channel_description">Incoming audio and video call alerts</string>
     <string name="stream_video_incoming_call_notification_channel_description">Incoming audio and video call alerts</string>
     <string name="stream_video_incoming_call_notification_title">Incoming call</string>
     <string name="stream_video_outgoing_call_notification_title" tools:ignore="TypographyEllipsis">Calling...</string>


### PR DESCRIPTION
Add an option to make ringing notifications as low priority if the application is currently in foreground. This will prevent from interrupting the user with a ringing notification popup. In this case the application needs to make sure to display a ringing call screen or some other way of notifying the user about an incoming call. This new behaviour is disabled by default. 