### PR TITLE
Add error logging if device push registration fails

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
@@ -80,6 +80,11 @@ internal class StreamNotificationManager private constructor(
                     deviceTokenStorage.updateUserDevice(pushDevice.toDevice())
                     Result.Success(newDevice)
                 } catch (e: Exception) {
+                    logger.e(e) {
+                        "Failed to register device for push notifications " +
+                            "(PN will not work!). Does the push provider key " +
+                            "(${pushDevice.pushProvider.key}) match the key in the Stream Dashboard?"
+                    }
                     Result.Failure(Error.ThrowableError("Device couldn't be created", e))
                 }
             }


### PR DESCRIPTION
We don't log push device registration errors - this makes it harder to debug issues when push notifications don't work at all.