### PR TITLE
Fix, when videoType is false, do not show the camera button

### DIFF
--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/outgoingcall/OutgoingCallContent.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/outgoingcall/OutgoingCallContent.kt
@@ -156,6 +156,7 @@ public fun OutgoingCallContent(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
                 .padding(bottom = VideoTheme.dimens.componentHeightM),
+            isVideoCall = isVideoType,
             isCameraEnabled = isCameraEnabled,
             isMicrophoneEnabled = isMicrophoneEnabled,
             onCallAction = onCallAction,


### PR DESCRIPTION
Fix a bug where the camera button would still be shown even thou the `isVideoType=false`