### PR TITLE
Improve ParticipantInformation text

### DIFF
--- a/stream-video-android-previewdata/api/stream-video-android-previewdata.api
+++ b/stream-video-android-previewdata/api/stream-video-android-previewdata.api
@@ -13,6 +13,8 @@ public final class io/getstream/video/android/mock/StreamPreviewDataUtilsKt {
 	public static final fun getPreviewMemberListState ()Ljava/util/List;
 	public static final fun getPreviewParticipant ()Lio/getstream/video/android/core/ParticipantState;
 	public static final fun getPreviewParticipantsList ()Ljava/util/List;
+	public static final fun getPreviewThreeMembers ()Ljava/util/List;
+	public static final fun getPreviewTwoMembers ()Ljava/util/List;
 	public static final fun getPreviewUsers ()Ljava/util/List;
 }
 

--- a/stream-video-android-previewdata/src/main/kotlin/io/getstream/video/android/mock/StreamPreviewDataUtils.kt
+++ b/stream-video-android-previewdata/src/main/kotlin/io/getstream/video/android/mock/StreamPreviewDataUtils.kt
@@ -170,3 +170,9 @@ public val previewParticipant: ParticipantState
 /** Preview a new [MemberState]. */
 public val previewMember: MemberState
     inline get() = previewMemberListState[0]
+
+public val previewTwoMembers: List<MemberState>
+    inline get() = previewMemberListState.take(2)
+
+public val previewThreeMembers: List<MemberState>
+    inline get() = previewMemberListState.take(3)

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -1809,8 +1809,12 @@ public final class io/getstream/video/android/compose/ui/components/participants
 public final class io/getstream/video/android/compose/ui/components/participants/internal/ComposableSingletons$ParticipantInformationKt {
 	public static final field INSTANCE Lio/getstream/video/android/compose/ui/components/participants/internal/ComposableSingletons$ParticipantInformationKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/video/android/compose/ui/components/participants/internal/ParticipantAvatarsKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/ParticipantInformation.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/ParticipantInformation.kt
@@ -40,6 +40,8 @@ import io.getstream.video.android.core.model.CallStatus
 import io.getstream.video.android.core.utils.toCallUser
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewMemberListState
+import io.getstream.video.android.mock.previewThreeMembers
+import io.getstream.video.android.mock.previewTwoMembers
 import io.getstream.video.android.ui.common.util.buildLargeCallText
 import io.getstream.video.android.ui.common.util.buildSmallCallText
 
@@ -55,7 +57,7 @@ public fun ParticipantInformation(
     ) {
         val context = LocalContext.current
         val callUsers by remember { derivedStateOf { participants.map { it.toCallUser() } } }
-        val text = if (participants.size < 3) {
+        val text = if (participants.size <= 3) {
             buildSmallCallText(context, callUsers)
         } else {
             buildLargeCallText(context, callUsers)
@@ -102,7 +104,33 @@ public fun ParticipantInformation(
     }
 }
 
-@Preview
+@Preview("2 users")
+@Composable
+private fun ParticipantInformationTwoUsersPreview() {
+    StreamPreviewDataUtils.initializeStreamVideo(LocalContext.current)
+    VideoTheme {
+        ParticipantInformation(
+            isVideoType = true,
+            callStatus = CallStatus.Incoming,
+            participants = previewTwoMembers,
+        )
+    }
+}
+
+@Preview("3 users")
+@Composable
+private fun ParticipantInformationThreeUsersPreview() {
+    StreamPreviewDataUtils.initializeStreamVideo(LocalContext.current)
+    VideoTheme {
+        ParticipantInformation(
+            isVideoType = true,
+            callStatus = CallStatus.Incoming,
+            participants = previewThreeMembers,
+        )
+    }
+}
+
+@Preview("More than 3 users")
 @Composable
 private fun ParticipantInformationPreview() {
     StreamPreviewDataUtils.initializeStreamVideo(LocalContext.current)

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -120,8 +120,8 @@ public final class io/getstream/video/android/ui/common/util/ColorUtilsKt {
 
 public final class io/getstream/video/android/ui/common/util/ParticipantsTextKt {
 	public static final fun buildLargeCallText (Landroid/content/Context;Ljava/util/List;)Ljava/lang/String;
-	public static final fun buildSmallCallText (Landroid/content/Context;Ljava/util/List;I)Ljava/lang/String;
-	public static synthetic fun buildSmallCallText$default (Landroid/content/Context;Ljava/util/List;IILjava/lang/Object;)Ljava/lang/String;
+	public static final fun buildSmallCallText (Landroid/content/Context;Ljava/util/List;IZ)Ljava/lang/String;
+	public static synthetic fun buildSmallCallText$default (Landroid/content/Context;Ljava/util/List;IZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class io/getstream/video/android/ui/common/util/ResourcesKt {

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/ParticipantsText.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/ParticipantsText.kt
@@ -27,6 +27,7 @@ public fun buildSmallCallText(
     context: Context,
     participants: List<CallUser>,
     maxDisplayedNameCount: Int = 3,
+    onlyUseComma: Boolean = false,
 ): String {
     if (participants.isEmpty()) {
         return context.getString(
@@ -35,13 +36,17 @@ public fun buildSmallCallText(
     }
 
     val names = participants.map { it.getNameOrId() }
-    val conjunction = context.getString(R.string.stream_video_call_participants_conjunction)
-
     val stringBuilder = StringBuilder(names.first())
 
     if (participants.size > 1) {
-        for (i in 1 until participants.size.coerceAtMost(maxDisplayedNameCount)) {
-            stringBuilder.append(" $conjunction ${names[i]}")
+        val max = participants.size.coerceAtMost(maxDisplayedNameCount)
+        for (i in 1 until max) {
+            val conjunction = if (i < max - 1 || onlyUseComma) {
+                ","
+            } else {
+                " ${context.getString(R.string.stream_video_call_participants_conjunction)}"
+            }
+            stringBuilder.append("$conjunction ${names[i]}")
         }
     }
 
@@ -61,7 +66,7 @@ public fun buildLargeCallText(
     val conjunction = context.getString(R.string.stream_video_call_participants_conjunction)
     val trailing = context.getString(R.string.stream_video_call_participants_trailing)
 
-    val initial = buildSmallCallText(context, participants)
+    val initial = buildSmallCallText(context, participants, onlyUseComma = true)
     if (participants.size == 1) return initial
 
     return "$initial $conjunction +${participants.size - 3} $trailing"


### PR DESCRIPTION
### 🎯 Goal

Improve the participant information string in Outgoing & Incoming call screens.

### 🛠 Implementation details

Small changes in the `ParticipantInformation` and `ParticipantsText` files.

### 🎨 UI Changes

| Before | Step 1 | Step 2 |
| --- | --- | --- |
| "+0 more" and unneeded "and". | Remove "+0 more" | Replace unneeded "and" with comma |
| ![participant info - before](https://github.com/GetStream/stream-video-android/assets/65943217/1634f0f5-78cc-4d9c-9c71-e2857a879fa7) | ![participant info - after - 1](https://github.com/GetStream/stream-video-android/assets/65943217/de530d07-674c-46f2-bd63-42a136deb1a3) | ![participant info - after - 2](https://github.com/GetStream/stream-video-android/assets/65943217/431fee1f-136f-4a8b-858c-aa82cd5e1729) |

| After | After |
| --- | --- |
| 2 participants  | 4+ participants |
| ![participant info - after - 4](https://github.com/GetStream/stream-video-android/assets/65943217/5c588dff-9ddb-4cb5-b027-4920dd0e366c) | ![participant info - after - 3](https://github.com/GetStream/stream-video-android/assets/65943217/6941ceb7-f083-47b8-91af-f9d7ddff1635) |

### 🧪 Testing

Call several users in either the demo app or the audio call sample app.