### PR TITLE
Improve avatar components

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/CallStats.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/CallStats.kt
@@ -74,7 +74,6 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.UserAvatar
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewCall
@@ -342,10 +341,9 @@ fun UserAndCallId(call: Call, clipboardManager: ClipboardManager?) {
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 UserAvatar(
-                    textSize = StyleSize.S,
                     modifier = Modifier.size(44.dp),
-                    userName = call.user.userNameOrId,
                     userImage = call.user.image,
+                    userName = call.user.userNameOrId,
                 )
                 Column(modifier = Modifier.padding(start = 8.dp)) {
                     Text(

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/ParticipantsDialog.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/ParticipantsDialog.kt
@@ -55,7 +55,6 @@ import androidx.compose.ui.window.DialogProperties
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.UserAvatar
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.mock.StreamPreviewDataUtils
@@ -146,10 +145,9 @@ fun ParticipantsListContent(
                     val userName by participant.userNameOrId.collectAsStateWithLifecycle()
                     val userImage by participant.image.collectAsStateWithLifecycle()
                     UserAvatar(
-                        textSize = StyleSize.S,
                         modifier = Modifier.size(VideoTheme.dimens.genericXxl),
-                        userName = userName,
                         userImage = userImage,
+                        userName = userName,
                         isShowingOnlineIndicator = false,
                     )
                     Spacer(modifier = Modifier.size(VideoTheme.dimens.spacingM))

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
@@ -96,7 +96,6 @@ import io.getstream.video.android.compose.ui.components.base.StreamButton
 import io.getstream.video.android.compose.ui.components.base.StreamDialogPositiveNegative
 import io.getstream.video.android.compose.ui.components.base.StreamIconToggleButton
 import io.getstream.video.android.compose.ui.components.base.StreamTextField
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewUsers
 import io.getstream.video.android.model.User
@@ -224,9 +223,8 @@ private fun CallJoinHeader(
             ) {
                 UserAvatar(
                     modifier = Modifier.size(VideoTheme.dimens.componentHeightL),
-                    textSize = StyleSize.S,
-                    userName = it.userNameOrId,
                     userImage = it.image,
+                    userName = it.userNameOrId,
                 )
             }
 

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
@@ -68,7 +68,6 @@ import io.getstream.video.android.R
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.UserAvatar
 import io.getstream.video.android.compose.ui.components.base.StreamButton
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.compose.ui.components.call.lobby.CallLobby
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.call.state.ToggleCamera
@@ -173,10 +172,9 @@ private fun CallLobbyHeaderContent(
         val userValue = user.value
         if (userValue != null) {
             UserAvatar(
-                textSize = StyleSize.S,
                 modifier = Modifier.size(32.dp),
-                userName = userValue.userNameOrId,
                 userImage = userValue.image,
+                userName = userValue.userNameOrId,
             )
 
             Spacer(modifier = Modifier.width(4.dp))

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/outgoing/DirectCallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/outgoing/DirectCallJoinScreen.kt
@@ -52,7 +52,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.UserAvatar
 import io.getstream.video.android.compose.ui.components.base.StreamButton
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.mock.previewUsers
 import io.getstream.video.android.model.User
 import io.getstream.video.android.models.GoogleAccount
@@ -96,10 +95,9 @@ private fun Header(user: User?) {
         Row {
             user?.let {
                 UserAvatar(
-                    textSize = StyleSize.XS,
                     modifier = Modifier.size(24.dp),
-                    userName = it.userNameOrId,
                     userImage = it.image,
+                    userName = it.userNameOrId,
                 )
                 Spacer(modifier = Modifier.width(8.dp))
             }
@@ -213,10 +211,9 @@ private fun UserRow(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             UserAvatar(
-                textSize = StyleSize.M,
                 modifier = Modifier.size(50.dp),
-                userName = name,
                 userImage = avatarUrl,
+                userName = name,
             )
             Spacer(modifier = Modifier.width(10.dp))
             Text(

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -496,10 +496,6 @@ public final class io/getstream/video/android/compose/ui/components/audio/Regula
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/video/android/compose/ui/components/avatar/AvatarKt {
-	public static final fun Avatar-RIwbUY4 (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JILjava/lang/Integer;Landroidx/compose/ui/text/TextStyle;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
-}
-
 public final class io/getstream/video/android/compose/ui/components/avatar/ComposableSingletons$AvatarKt {
 	public static final field INSTANCE Lio/getstream/video/android/compose/ui/components/avatar/ComposableSingletons$AvatarKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
@@ -551,11 +547,11 @@ public final class io/getstream/video/android/compose/ui/components/avatar/Onlin
 }
 
 public final class io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackgroundKt {
-	public static final fun UserAvatarBackground-xr0SGnQ (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;FLandroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JJILjava/lang/Integer;Landroidx/compose/runtime/Composer;III)V
+	public static final fun UserAvatarBackground-1UyhGxE (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;FLandroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JLjava/lang/Integer;ILandroidx/compose/ui/text/TextStyle;JLandroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/avatar/UserAvatarKt {
-	public static final fun UserAvatar-S9GcbaY (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JILjava/lang/Integer;Landroidx/compose/ui/text/TextStyle;JZLio/getstream/video/android/compose/ui/components/avatar/OnlineIndicatorAlignment;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
+	public static final fun UserAvatar-S9GcbaY (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JLjava/lang/Integer;ILandroidx/compose/ui/text/TextStyle;JZLio/getstream/video/android/compose/ui/components/avatar/OnlineIndicatorAlignment;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/background/CallBackgroundKt {
@@ -1780,6 +1776,17 @@ public final class io/getstream/video/android/compose/ui/components/participants
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class io/getstream/video/android/compose/ui/components/participants/ComposableSingletons$ParticipantAvatarsKt {
+	public static final field INSTANCE Lio/getstream/video/android/compose/ui/components/participants/ComposableSingletons$ParticipantAvatarsKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class io/getstream/video/android/compose/ui/components/participants/ParticipantAvatarsKt {
+	public static final fun ParticipantAvatars (Ljava/util/List;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/participants/internal/ComposableSingletons$CallParticipantListAppBarKt {

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -497,7 +497,7 @@ public final class io/getstream/video/android/compose/ui/components/audio/Regula
 }
 
 public final class io/getstream/video/android/compose/ui/components/avatar/AvatarKt {
-	public static final fun Avatar-zf1_rLo (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;Lio/getstream/video/android/compose/ui/components/base/styling/StyleSize;Landroidx/compose/ui/text/TextStyle;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JILjava/lang/Integer;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
+	public static final fun Avatar-RIwbUY4 (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JILjava/lang/Integer;Landroidx/compose/ui/text/TextStyle;JLkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/avatar/ComposableSingletons$AvatarKt {
@@ -551,11 +551,11 @@ public final class io/getstream/video/android/compose/ui/components/avatar/Onlin
 }
 
 public final class io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackgroundKt {
-	public static final fun UserAvatarBackground-xr0SGnQ (Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;FLandroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JJILjava/lang/Integer;Landroidx/compose/runtime/Composer;III)V
+	public static final fun UserAvatarBackground-xr0SGnQ (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;FLandroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JJILjava/lang/Integer;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/avatar/UserAvatarKt {
-	public static final fun UserAvatar-8W8krDU (Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;Lio/getstream/video/android/compose/ui/components/base/styling/StyleSize;JILjava/lang/Integer;JZLio/getstream/video/android/compose/ui/components/avatar/OnlineIndicatorAlignment;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
+	public static final fun UserAvatar-S9GcbaY (Landroidx/compose/ui/Modifier;Ljava/lang/String;Ljava/lang/String;Landroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/layout/ContentScale;Ljava/lang/String;JILjava/lang/Integer;Landroidx/compose/ui/text/TextStyle;JZLio/getstream/video/android/compose/ui/components/avatar/OnlineIndicatorAlignment;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/background/CallBackgroundKt {

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -1810,13 +1810,6 @@ public final class io/getstream/video/android/compose/ui/components/participants
 	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class io/getstream/video/android/compose/ui/components/participants/internal/ComposableSingletons$ParticipantAvatarsKt {
-	public static final field INSTANCE Lio/getstream/video/android/compose/ui/components/participants/internal/ComposableSingletons$ParticipantAvatarsKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public fun <init> ()V
-	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class io/getstream/video/android/compose/ui/components/participants/internal/ComposableSingletons$ParticipantInformationKt {
 	public static final field INSTANCE Lio/getstream/video/android/compose/ui/components/participants/internal/ComposableSingletons$ParticipantInformationKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
@@ -1826,10 +1819,6 @@ public final class io/getstream/video/android/compose/ui/components/participants
 	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
-}
-
-public final class io/getstream/video/android/compose/ui/components/participants/internal/ParticipantAvatarsKt {
-	public static final fun ParticipantAvatars (Ljava/util/List;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/participants/internal/ParticipantInformationKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/audio/ParticipantAudio.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/audio/ParticipantAudio.kt
@@ -86,11 +86,11 @@ public fun ParticipantAudio(
     ) {
         Box(modifier = Modifier.fillMaxSize()) {
             UserAvatar(
-                userName = nameOrId,
-                userImage = userImage,
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(VideoTheme.dimens.spacingM),
+                userImage = userImage,
+                userName = nameOrId,
             )
 
             if (isSpeaking && style.isShowingSpeakingBorder) {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
@@ -44,7 +44,6 @@ import com.skydoves.landscapist.coil.CoilImage
 import com.skydoves.landscapist.components.rememberImageComponent
 import com.skydoves.landscapist.placeholder.placeholder.PlaceholderPlugin
 import io.getstream.video.android.compose.theme.VideoTheme
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.ui.common.R
 
 /**
@@ -53,36 +52,30 @@ import io.getstream.video.android.ui.common.R
  *
  * @param modifier Modifier for styling.
  * @param imageUrl The URL of the image to load.
- * @param initials The fallback text.
+ * @param fallbackText The fallback text.
  * @param shape The shape of the avatar.
- * @param textStyle The text style of the [initials] text.
- * @param contentScale The scale option used for the content.
- * @param contentDescription Description of the image.
- * @param requestSize The actual request size.
+ * @param textStyle The text style of the [fallbackText] text.
+ * @param imageScale The scale option used for the image.
+ * @param imageDescription Description of the image.
+ * @param imageRequestSize The actual request size.
  * @param previewPlaceholder A placeholder that will be displayed on the Compose preview (IDE).
  * @param loadingPlaceholder A placeholder that will be displayed while loading an image.
- * @param initialsAvatarOffset The initials offset to apply to the avatar.
+ * @param textOffset The initials offset to apply to the avatar.
  * @param onClick OnClick action, that can be nullable.
  */
 @Composable
 public fun Avatar(
     modifier: Modifier = Modifier,
     imageUrl: String? = null,
-    initials: String? = null,
+    fallbackText: String? = null,
     shape: Shape = VideoTheme.shapes.circle,
-    textSize: StyleSize = StyleSize.XL,
+    imageScale: ContentScale = ContentScale.Crop,
+    imageDescription: String? = null,
+    imageRequestSize: IntSize = IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE),
+    @DrawableRes previewPlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
+    @DrawableRes loadingPlaceholder: Int? = LocalAvatarPreviewProvider.getLocalAvatarLoadingPlaceholder(),
     textStyle: TextStyle = VideoTheme.typography.titleM,
-    contentScale: ContentScale = ContentScale.Crop,
-    contentDescription: String? = null,
-    requestSize: IntSize = IntSize(
-        DEFAULT_IMAGE_SIZE,
-        DEFAULT_IMAGE_SIZE,
-    ),
-    @DrawableRes previewPlaceholder: Int =
-        LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
-    @DrawableRes loadingPlaceholder: Int? =
-        LocalAvatarPreviewProvider.getLocalAvatarLoadingPlaceholder(),
-    initialsAvatarOffset: DpOffset = DpOffset(0.dp, 0.dp),
+    textOffset: DpOffset = DpOffset(0.dp, 0.dp),
     onClick: (() -> Unit)? = null,
 ) {
     if (LocalInspectionMode.current && !imageUrl.isNullOrEmpty()) {
@@ -98,13 +91,13 @@ public fun Avatar(
         return
     }
 
-    if (imageUrl.isNullOrEmpty() && !initials.isNullOrBlank()) {
+    if (imageUrl.isNullOrEmpty() && !fallbackText.isNullOrBlank()) {
         InitialsAvatar(
             modifier = modifier,
-            initials = initials,
-            textSize = textSize,
-            shape = shape,
+            text = fallbackText,
             textStyle = textStyle,
+            textOffset = textOffset,
+            shape = shape,
         )
         return
     }
@@ -123,9 +116,9 @@ public fun Avatar(
         modifier = clickableModifier.clip(shape),
         imageModel = { imageUrl },
         imageOptions = ImageOptions(
-            contentDescription = contentDescription,
-            contentScale = contentScale,
-            requestSize = requestSize,
+            contentDescription = imageDescription,
+            contentScale = imageScale,
+            requestSize = imageRequestSize,
         ),
         previewPlaceholder = painterResource(id = previewPlaceholder),
         component = rememberImageComponent {
@@ -137,10 +130,10 @@ public fun Avatar(
         failure = {
             InitialsAvatar(
                 modifier = modifier,
-                initials = initials.orEmpty(),
-                shape = shape,
+                text = fallbackText.orEmpty(),
                 textStyle = textStyle,
-                avatarOffset = initialsAvatarOffset,
+                textOffset = textOffset,
+                shape = shape,
             )
         },
     )
@@ -152,7 +145,7 @@ private fun AvatarInitialPreview() {
     VideoTheme {
         Avatar(
             modifier = Modifier.size(72.dp),
-            initials = "Thierry",
+            fallbackText = "Thierry",
         )
     }
 }
@@ -163,7 +156,7 @@ internal fun AvatarImagePreview() {
     VideoTheme {
         Avatar(
             modifier = Modifier.size(72.dp),
-            initials = null,
+            fallbackText = null,
             previewPlaceholder = R.drawable.stream_video_call_sample,
         )
     }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
@@ -72,8 +72,8 @@ public fun Avatar(
     imageScale: ContentScale = ContentScale.Crop,
     imageDescription: String? = null,
     imageRequestSize: IntSize = IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE),
-    @DrawableRes previewPlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
     @DrawableRes loadingPlaceholder: Int? = LocalAvatarPreviewProvider.getLocalAvatarLoadingPlaceholder(),
+    @DrawableRes previewModePlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
     textStyle: TextStyle = VideoTheme.typography.titleM,
     textOffset: DpOffset = DpOffset(0.dp, 0.dp),
     onClick: (() -> Unit)? = null,
@@ -84,7 +84,7 @@ public fun Avatar(
                 .fillMaxSize()
                 .clip(CircleShape)
                 .testTag("avatar"),
-            painter = painterResource(id = previewPlaceholder),
+            painter = painterResource(id = previewModePlaceholder),
             contentScale = ContentScale.Crop,
             contentDescription = null,
         )
@@ -120,7 +120,7 @@ public fun Avatar(
             contentScale = imageScale,
             requestSize = imageRequestSize,
         ),
-        previewPlaceholder = painterResource(id = previewPlaceholder),
+        previewPlaceholder = painterResource(id = previewModePlaceholder),
         component = rememberImageComponent {
             +CrossfadePlugin()
             loadingPlaceholder?.let {
@@ -157,7 +157,7 @@ internal fun AvatarImagePreview() {
         Avatar(
             modifier = Modifier.size(72.dp),
             fallbackText = null,
-            previewPlaceholder = R.drawable.stream_video_call_sample,
+            previewModePlaceholder = R.drawable.stream_video_call_sample,
         )
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
@@ -47,8 +47,8 @@ import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.ui.common.R
 
 /**
- * An avatar that renders an image from the provided image URL. In case the image URL
- * is empty or there was an error loading the image, it falls back to showing name initials.
+ * An avatar that renders an image or a fallback text. In case the image URL
+ * is empty or there was an error loading the image, it falls back to showing initials.
  * If needed, the initials font size is gradually decreased automatically until the text fits within the avatar boundaries.
  *
  * @param modifier Modifier used for styling.
@@ -66,7 +66,7 @@ import io.getstream.video.android.ui.common.R
  * @param onClick Handler to be called when the user clicks on the avatar.
  */
 @Composable
-public fun Avatar(
+internal fun Avatar(
     modifier: Modifier = Modifier,
     imageUrl: String? = null,
     fallbackText: String? = null,

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/Avatar.kt
@@ -48,20 +48,22 @@ import io.getstream.video.android.ui.common.R
 
 /**
  * An avatar that renders an image from the provided image URL. In case the image URL
- * was empty or there was an error loading the image, it falls back to the initials avatar.
+ * is empty or there was an error loading the image, it falls back to showing name initials.
+ * If needed, the initials font size is gradually decreased automatically until the text fits within the avatar boundaries.
  *
- * @param modifier Modifier for styling.
- * @param imageUrl The URL of the image to load.
- * @param fallbackText The fallback text.
+ * @param modifier Modifier used for styling.
+ * @param imageUrl The URL of the image to be displayed.
+ * @param fallbackText The fallback text to be used for the initials avatar.
  * @param shape The shape of the avatar.
- * @param textStyle The text style of the [fallbackText] text.
- * @param imageScale The scale option used for the image.
- * @param imageDescription Description of the image.
- * @param imageRequestSize The actual request size.
- * @param previewPlaceholder A placeholder that will be displayed on the Compose preview (IDE).
- * @param loadingPlaceholder A placeholder that will be displayed while loading an image.
- * @param textOffset The initials offset to apply to the avatar.
- * @param onClick OnClick action, that can be nullable.
+ * @param imageScale The scale rule used for the image.
+ * @param imageDescription Accessibility description for the image.
+ * @param imageRequestSize The image size to be requested.
+ * @param loadingPlaceholder Placeholder image to be displayed while loading the remote image.
+ * @param previewModePlaceholder Placeholder image to be displayed in Compose previews (IDE).
+ * @param textStyle The text style of the [fallbackText] text. The `fontSize`, `fontFamily` and `fontWeight` properties are used.
+ * If the font size is too large, it will be gradually decreased automatically.
+ * @param textOffset Offset to be applied to the initials text.
+ * @param onClick Handler to be called when the user clicks on the avatar.
  */
 @Composable
 public fun Avatar(

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/InitialsAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/InitialsAvatar.kt
@@ -50,22 +50,21 @@ import io.getstream.video.android.core.utils.initials
  * Represents a special avatar case when we need to show the initials instead of an image. Usually happens when there
  * are no images to show in the avatar.
  *
- * @param initials The initials to show.
+ * @param text The initials to show.
  * @param modifier Modifier for styling.
  * @param shape The shape of the avatar.
  * @param textStyle The [TextStyle] that will be used for the initials.
- * @param avatarOffset The initials offset to apply to the avatar.
- * @param initialTransformer A custom transformer to tweak initials.
+ * @param textOffset The initials offset to apply to the avatar.
+ * @param initialsTransformer A custom transformer to tweak initials.
  */
 @Composable
 internal fun InitialsAvatar(
-    initials: String,
     modifier: Modifier = Modifier,
-    shape: Shape = VideoTheme.shapes.circle,
-    textSize: StyleSize = StyleSize.XL,
+    text: String,
     textStyle: TextStyle = VideoTheme.typography.titleM,
-    avatarOffset: DpOffset = DpOffset(0.dp, 0.dp),
-    initialTransformer: (String) -> String = { it.initials() },
+    textOffset: DpOffset = DpOffset(0.dp, 0.dp),
+    shape: Shape = VideoTheme.shapes.circle,
+    initialsTransformer: (String) -> String = { it.initials() },
 ) {
     val colors = initialsColors(initials = initials)
     var fontSize by remember { mutableStateOf(50.sp) }
@@ -123,19 +122,19 @@ private fun InitialsAvatarPreview() {
     VideoTheme {
         Column {
             Avatar(
-                initials = "Jaewoong Eum",
+                fallbackText = "Jaewoong Eum",
             )
             Spacer(modifier = Modifier.size(24.dp))
             Avatar(
-                initials = "Aleksandar Apostolov",
+                fallbackText = "Aleksandar Apostolov",
             )
             Spacer(modifier = Modifier.size(24.dp))
             Avatar(
-                initials = "Danie",
+                fallbackText = "Danie",
             )
             Spacer(modifier = Modifier.size(24.dp))
             Avatar(
-                initials = "Jaewoong Eum",
+                fallbackText = "Jaewoong Eum",
             )
             Spacer(modifier = Modifier.size(24.dp))
         }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/InitialsAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/InitialsAvatar.kt
@@ -40,9 +40,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import io.getstream.video.android.compose.theme.VideoTheme
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.compose.utils.initialsColors
 import io.getstream.video.android.core.utils.initials
 
@@ -66,8 +64,8 @@ internal fun InitialsAvatar(
     shape: Shape = VideoTheme.shapes.circle,
     initialsTransformer: (String) -> String = { it.initials() },
 ) {
-    val colors = initialsColors(initials = initials)
-    var fontSize by remember { mutableStateOf(50.sp) }
+    val colors = initialsColors(text = text)
+    var fontSize by remember { mutableStateOf(textStyle.fontSize) }
     var readyToDrawText by remember { mutableStateOf(false) }
 
     Box(
@@ -77,41 +75,34 @@ internal fun InitialsAvatar(
             .clip(shape)
             .background(color = colors.second),
     ) {
-        val resolvedTextSize = when (textSize) {
-            StyleSize.L -> VideoTheme.dimens.textSizeL
-            StyleSize.XS -> VideoTheme.dimens.textSizeXs
-            StyleSize.S -> VideoTheme.dimens.textSizeS
-            StyleSize.M -> VideoTheme.dimens.textSizeM
-            StyleSize.XL -> VideoTheme.dimens.textSizeXl
-            StyleSize.XXL -> VideoTheme.dimens.textSizeXxl
-        }
         Text(
             modifier = Modifier
                 .align(Alignment.Center)
-                .offset(avatarOffset.x, avatarOffset.y)
+                .offset(textOffset.x, textOffset.y)
                 .drawWithContent { if (readyToDrawText) drawContent() },
-            text = initialTransformer.invoke(initials),
+            text = initialsTransformer.invoke(text),
             fontSize = fontSize,
             style = textStyle.copy(color = colors.first),
             onTextLayout = { layoutResult ->
                 Log.d("InitialsAvatar", "fontSize: $fontSize")
                 if (layoutResult.didOverflowWidth || layoutResult.didOverflowHeight) {
-                    fontSize *= 0.5
+                    fontSize *= 0.37
                 } else {
-                    if (!readyToDrawText) fontSize = (fontSize.value * 0.8).sp // One last scale to 80%
                     readyToDrawText = true
                 }
             },
-            // TODO: understand usage scenarios for avatars (textSize, style, offset, other params)
-            // TODO: tweak starting font size and decrease step
-            // TODO: handle possible exceptions
-            // TODO: compare avatars on emulator with device
+            // TODO: understand how it will be used and what params to offer (starting from ParticipantAvatars, UserAvatar, Avatar, InitialsAvatar)
+            // remove textSize, add textStyle in all, use fontSize from textStyle as default, scale if overflowing. Scale step param needed? Test
+            // TODO: --understand usage scenarios for avatars (textSize, style, offset, other params)
+            // TODO: --tweak starting font size and decrease step. Offer params.
+            // TODO: --handle possible exceptions
+            // TODO: --compare avatars on emulator with device
             // TODO: --why does preview show a correct size for letters if I use 0.7 or 0.5?
-            // TODO: how to add a proportional space around the text?
-            // TODO: what is the initial font size
-            // TODO: deprecate unneeded params
+            // TODO: --how to add a proportional space around the text?
+            // TODO: --what is the initial font size
+            // TODO: deprecate unneeded params?
             // TODO: --add readyToDraw
-            // TODO: test in UserAvatar & in apps
+            // TODO: test in demo app & AUDIO call sample
         )
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/InitialsAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/InitialsAvatar.kt
@@ -91,18 +91,6 @@ internal fun InitialsAvatar(
                     readyToDrawText = true
                 }
             },
-            // TODO: understand how it will be used and what params to offer (starting from ParticipantAvatars, UserAvatar, Avatar, InitialsAvatar)
-            // remove textSize, add textStyle in all, use fontSize from textStyle as default, scale if overflowing. Scale step param needed? Test
-            // TODO: --understand usage scenarios for avatars (textSize, style, offset, other params)
-            // TODO: --tweak starting font size and decrease step. Offer params.
-            // TODO: --handle possible exceptions
-            // TODO: --compare avatars on emulator with device
-            // TODO: --why does preview show a correct size for letters if I use 0.7 or 0.5?
-            // TODO: --how to add a proportional space around the text?
-            // TODO: --what is the initial font size
-            // TODO: deprecate unneeded params?
-            // TODO: --add readyToDraw
-            // TODO: test in demo app & AUDIO call sample
         )
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
@@ -41,20 +41,20 @@ import io.getstream.video.android.model.User
 import io.getstream.video.android.ui.common.R
 
 /**
- * Component that renders an image as an avatar. If the image is unavailable, it uses name initials as a fallback.
+ * Component that renders an image or a name as an avatar. If the image is `null` or unavailable, it uses the name initials.
  * Can also show an "is online" indicator.
  * If needed, the initials font size is gradually decreased automatically until the text fits within the avatar boundaries.
  *
  * @param modifier Modifier used for styling.
  * @param userImage The URL of the image to be displayed. Usually [User.image].
- * @param userName The name to be used for the initials fallback. Usually [User.name].
+ * @param userName The name to be used for the initials. Usually [User.name].
  * @param shape The shape of the avatar. `CircleShape` by default.
  * @param imageScale The scale rule used for the image. `Crop` by default.
  * @param imageDescription The image content description for accessibility. `Null` by default.
  * @param imageRequestSize The image size to be requested. Original size by default.
  * @param loadingPlaceholder Placeholder image to be displayed while loading the remote image.
  * @param previewModePlaceholder Placeholder image to be displayed in Compose previews (IDE).
- * @param textStyle The [TextStyle] to be used for the initials text fallback. The `fontSize`, `fontFamily` and `fontWeight` properties are used.
+ * @param textStyle The [TextStyle] to be used for the initials text. The `fontSize`, `fontFamily` and `fontWeight` properties are used.
  * If the font size is too large, it will be gradually decreased automatically.
  * @param textOffset Offset to be applied to the initials text.
  * @param isShowingOnlineIndicator Flag used to display/hide the "is online" indicator. `False` by default.
@@ -68,8 +68,8 @@ import io.getstream.video.android.ui.common.R
 @Composable
 public fun UserAvatar(
     modifier: Modifier = Modifier,
-    userImage: String?,
-    userName: String?,
+    userImage: String? = null,
+    userName: String? = null,
     shape: Shape = VideoTheme.shapes.circle,
     imageScale: ContentScale = ContentScale.Crop,
     imageDescription: String? = null,

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
@@ -38,27 +38,32 @@ import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewParticipantsList
 import io.getstream.video.android.model.User
 import io.getstream.video.android.ui.common.R
+import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantAvatars
 
 /**
- * Represents the [User] avatar that's shown on the Messages screen or in headers of DMs.
+ * Component that renders an image as an avatar. If the image is unavailable, it uses name initials as a fallback.
+ * Can also show an "is online" indicator.
+ * If needed, the initials font size is gradually decreased automatically until the text fits within the avatar boundaries.
  *
- * Based on the state within the [User], we either show an image or their initials.
+ * @param modifier Modifier used for styling.
+ * @param userImage The URL of the image to be displayed. Usually [User.image].
+ * @param userName The name to be used for the initials fallback. Usually [User.name].
+ * @param shape The shape of the avatar. `CircleShape` by default.
+ * @param imageScale The scale rule used for the image. `Crop` by default.
+ * @param imageDescription The image content description for accessibility. `Null` by default.
+ * @param imageRequestSize The image size to be requested. Original size by default.
+ * @param loadingPlaceholder Placeholder image to be displayed while loading the remote image.
+ * @param previewModePlaceholder Placeholder image to be displayed in Compose previews (IDE).
+ * @param textStyle The [TextStyle] to be used for the initials text fallback. The `fontSize`, `fontFamily` and `fontWeight` properties are used.
+ * If the font size is too large, it will be gradually decreased automatically.
+ * @param textOffset Offset to be applied to the initials text.
+ * @param isShowingOnlineIndicator Flag used to display/hide the "is online" indicator. `False` by default.
+ * @param onlineIndicatorAlignment Alignment of the "is online" indicator. `TopEnd` by default.
+ * @param onlineIndicator A custom composable to represent the "is online" indicator. [DefaultOnlineIndicator] by default.
+ * @param onClick Handler to be called when the user clicks on the avatar.
  *
- * @param userName The user name whose avatar we want to show.
- * @param userImage The user image whose avatar we want to show.
- * @param modifier Modifier for styling.
- * @param shape The shape of the avatar.
- * @param textStyle The [TextStyle] that will be used for the initials.
- * @param imageScale The scale option used for the content.
- * @param imageDescription The content description of the avatar.
- * @param imageRequestSize The actual request size.
- * @param previewPlaceholder A placeholder that will be displayed on the Compose preview (IDE).
- * @param loadingPlaceholder A placeholder that will be displayed while loading an image.
- * @param isShowingOnlineIndicator Represents to show an online indicator.
- * @param onlineIndicatorAlignment An alignment for positioning the online indicator.
- * @param onlineIndicator A custom composable to represent an online indicator.
- * @param textOffset The initials offset to apply to the avatar.
- * @param onClick The handler when the user clicks on the avatar.
+ * @see [ParticipantAvatars]
+ * @see [UserAvatarBackground]
  */
 @Composable
 public fun UserAvatar(
@@ -103,7 +108,7 @@ public fun UserAvatar(
 }
 
 /**
- * The default online indicator for channel members.
+ * The default "is online" indicator for [UserAvatar].
  */
 @Composable
 internal fun BoxScope.DefaultOnlineIndicator(onlineIndicatorAlignment: OnlineIndicatorAlignment) {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
@@ -34,7 +34,6 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewParticipantsList
 import io.getstream.video.android.model.User
@@ -50,30 +49,30 @@ import io.getstream.video.android.ui.common.R
  * @param modifier Modifier for styling.
  * @param shape The shape of the avatar.
  * @param textStyle The [TextStyle] that will be used for the initials.
- * @param contentScale The scale option used for the content.
- * @param contentDescription The content description of the avatar.
- * @param requestSize The actual request size.
+ * @param imageScale The scale option used for the content.
+ * @param imageDescription The content description of the avatar.
+ * @param imageRequestSize The actual request size.
  * @param previewPlaceholder A placeholder that will be displayed on the Compose preview (IDE).
  * @param loadingPlaceholder A placeholder that will be displayed while loading an image.
  * @param isShowingOnlineIndicator Represents to show an online indicator.
  * @param onlineIndicatorAlignment An alignment for positioning the online indicator.
  * @param onlineIndicator A custom composable to represent an online indicator.
- * @param initialsAvatarOffset The initials offset to apply to the avatar.
+ * @param textOffset The initials offset to apply to the avatar.
  * @param onClick The handler when the user clicks on the avatar.
  */
 @Composable
 public fun UserAvatar(
-    userName: String?,
-    userImage: String?,
     modifier: Modifier = Modifier,
+    userImage: String?,
+    userName: String?,
     shape: Shape = VideoTheme.shapes.circle,
-    contentScale: ContentScale = ContentScale.Crop,
-    contentDescription: String? = null,
-    textSize: StyleSize = StyleSize.XL,
-    requestSize: IntSize = IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE),
+    imageScale: ContentScale = ContentScale.Crop,
+    imageDescription: String? = null,
+    imageRequestSize: IntSize = IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE),
     @DrawableRes previewPlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
     @DrawableRes loadingPlaceholder: Int? = LocalAvatarPreviewProvider.getLocalAvatarLoadingPlaceholder(),
-    initialsAvatarOffset: DpOffset = DpOffset(0.dp, 0.dp),
+    textStyle: TextStyle = VideoTheme.typography.titleM,
+    textOffset: DpOffset = DpOffset(0.dp, 0.dp),
     isShowingOnlineIndicator: Boolean = false,
     onlineIndicatorAlignment: OnlineIndicatorAlignment = OnlineIndicatorAlignment.TopEnd,
     onlineIndicator: @Composable BoxScope.() -> Unit = {
@@ -84,17 +83,17 @@ public fun UserAvatar(
     Box(modifier = modifier) {
         Avatar(
             modifier = Modifier.fillMaxSize(),
-            textSize = textSize,
             imageUrl = userImage,
-            initials = userName,
+            fallbackText = userName,
             shape = shape,
-            contentScale = contentScale,
-            contentDescription = contentDescription,
-            requestSize = requestSize,
-            loadingPlaceholder = loadingPlaceholder,
+            imageScale = imageScale,
+            imageDescription = imageDescription,
+            imageRequestSize = imageRequestSize,
             previewPlaceholder = previewPlaceholder,
+            loadingPlaceholder = loadingPlaceholder,
+            textStyle = textStyle,
+            textOffset = textOffset,
             onClick = onClick,
-            initialsAvatarOffset = initialsAvatarOffset,
         )
 
         if (isShowingOnlineIndicator) {
@@ -121,11 +120,11 @@ private fun UserAvatarPreview() {
         val userName by participant.userNameOrId.collectAsStateWithLifecycle()
 
         UserAvatar(
+            modifier = Modifier.size(82.dp),
             userImage = userImage,
             userName = userName,
-            modifier = Modifier.size(82.dp),
-            isShowingOnlineIndicator = true,
             previewPlaceholder = R.drawable.stream_video_call_sample,
+            isShowingOnlineIndicator = true,
         )
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
@@ -34,11 +34,11 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
+import io.getstream.video.android.compose.ui.components.participants.ParticipantAvatars
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewParticipantsList
 import io.getstream.video.android.model.User
 import io.getstream.video.android.ui.common.R
-import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantAvatars
 
 /**
  * Component that renders an image as an avatar. If the image is unavailable, it uses name initials as a fallback.

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatar.kt
@@ -69,8 +69,8 @@ public fun UserAvatar(
     imageScale: ContentScale = ContentScale.Crop,
     imageDescription: String? = null,
     imageRequestSize: IntSize = IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE),
-    @DrawableRes previewPlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
     @DrawableRes loadingPlaceholder: Int? = LocalAvatarPreviewProvider.getLocalAvatarLoadingPlaceholder(),
+    @DrawableRes previewModePlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
     textStyle: TextStyle = VideoTheme.typography.titleM,
     textOffset: DpOffset = DpOffset(0.dp, 0.dp),
     isShowingOnlineIndicator: Boolean = false,
@@ -89,8 +89,8 @@ public fun UserAvatar(
             imageScale = imageScale,
             imageDescription = imageDescription,
             imageRequestSize = imageRequestSize,
-            previewPlaceholder = previewPlaceholder,
             loadingPlaceholder = loadingPlaceholder,
+            previewModePlaceholder = previewModePlaceholder,
             textStyle = textStyle,
             textOffset = textOffset,
             onClick = onClick,
@@ -123,7 +123,7 @@ private fun UserAvatarPreview() {
             modifier = Modifier.size(82.dp),
             userImage = userImage,
             userName = userName,
-            previewPlaceholder = R.drawable.stream_video_call_sample,
+            previewModePlaceholder = R.drawable.stream_video_call_sample,
             isShowingOnlineIndicator = true,
         )
     }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
@@ -51,9 +51,9 @@ import io.getstream.video.android.ui.common.R
  */
 @Composable
 public fun UserAvatarBackground(
-    userName: String?,
-    userImage: String?,
     modifier: Modifier = Modifier,
+    userImage: String?,
+    userName: String?,
     shape: Shape = VideoTheme.shapes.circle,
     avatarSize: Dp = VideoTheme.dimens.genericMax,
     contentScale: ContentScale = ContentScale.Crop,
@@ -70,15 +70,15 @@ public fun UserAvatarBackground(
                 .align(Alignment.Center),
         ) {
             UserAvatar(
-                userName = userName,
                 userImage = userImage,
+                userName = userName,
                 shape = shape,
-                contentScale = contentScale,
-                contentDescription = contentDescription,
-                requestSize = requestSize,
-                initialsAvatarOffset = initialsAvatarOffset,
+                imageScale = contentScale,
+                imageDescription = contentDescription,
+                imageRequestSize = requestSize,
                 previewPlaceholder = previewPlaceholder,
                 loadingPlaceholder = loadingPlaceholder,
+                textOffset = initialsAvatarOffset,
             )
         }
     }
@@ -91,9 +91,9 @@ private fun UserAvatarBackgroundPreview() {
     VideoTheme {
         val user = previewUsers[0]
         UserAvatarBackground(
-            userName = user.name.ifBlank { user.id },
-            userImage = user.image,
             modifier = Modifier.fillMaxSize(),
+            userImage = user.image,
+            userName = user.name.ifBlank { user.id },
             previewPlaceholder = R.drawable.stream_video_call_sample,
         )
     }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
@@ -56,12 +57,13 @@ public fun UserAvatarBackground(
     userName: String?,
     shape: Shape = VideoTheme.shapes.circle,
     avatarSize: Dp = VideoTheme.dimens.genericMax,
-    contentScale: ContentScale = ContentScale.Crop,
-    contentDescription: String? = null,
-    requestSize: IntSize = IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE),
-    initialsAvatarOffset: DpOffset = DpOffset(0.dp, 0.dp),
-    @DrawableRes previewPlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
+    imageScale: ContentScale = ContentScale.Crop,
+    imageDescription: String? = null,
+    imageRequestSize: IntSize = IntSize(DEFAULT_IMAGE_SIZE, DEFAULT_IMAGE_SIZE),
     @DrawableRes loadingPlaceholder: Int? = LocalAvatarPreviewProvider.getLocalAvatarLoadingPlaceholder(),
+    @DrawableRes previewModePlaceholder: Int = LocalAvatarPreviewProvider.getLocalAvatarPreviewPlaceholder(),
+    textStyle: TextStyle = VideoTheme.typography.titleM,
+    textOffset: DpOffset = DpOffset(0.dp, 0.dp),
 ) {
     Box(modifier = modifier.fillMaxSize()) {
         Box(
@@ -73,12 +75,13 @@ public fun UserAvatarBackground(
                 userImage = userImage,
                 userName = userName,
                 shape = shape,
-                imageScale = contentScale,
-                imageDescription = contentDescription,
-                imageRequestSize = requestSize,
-                previewPlaceholder = previewPlaceholder,
+                imageScale = imageScale,
+                imageDescription = imageDescription,
+                imageRequestSize = imageRequestSize,
                 loadingPlaceholder = loadingPlaceholder,
-                textOffset = initialsAvatarOffset,
+                previewModePlaceholder = previewModePlaceholder,
+                textStyle = textStyle,
+                textOffset = textOffset,
             )
         }
     }
@@ -94,7 +97,7 @@ private fun UserAvatarBackgroundPreview() {
             modifier = Modifier.fillMaxSize(),
             userImage = user.image,
             userName = user.name.ifBlank { user.id },
-            previewPlaceholder = R.drawable.stream_video_call_sample,
+            previewModePlaceholder = R.drawable.stream_video_call_sample,
         )
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
@@ -35,20 +35,27 @@ import androidx.compose.ui.unit.dp
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewUsers
+import io.getstream.video.android.model.User
 import io.getstream.video.android.ui.common.R
 
 /**
- * A background that displays a user avatar and a background that reflects the avatar.
+ * Component that displays a user avatar and a background that reflects the avatar.
  *
- * @param modifier Modifier for styling.
- * @param shape The shape of the avatar.
- * @param avatarSize The size to decide avatar image.
- * @param contentScale The scale option used for the content.
- * @param contentDescription The content description of the avatar.
- * @param requestSize The actual request size.
- * @param initialsAvatarOffset The initials offset to apply to the avatar.
- * @param previewPlaceholder A placeholder that will be displayed on the Compose preview (IDE).
- * @param loadingPlaceholder A placeholder that will be displayed while loading an image.
+ * @param modifier Modifier used for styling.
+ * @param userImage The URL of the image to be displayed. Usually [User.image].
+ * @param userName The name to be used for the initials fallback. Usually [User.name].
+ * @param shape The shape of the avatar. `CircleShape` by default.
+ * @param avatarSize The size of the avatar.
+ * @param imageScale The scale rule used for the image. `Crop` by default.
+ * @param imageDescription The image content description for accessibility. `Null` by default.
+ * @param imageRequestSize The image size to be requested. Original size by default.
+ * @param loadingPlaceholder Placeholder image to be displayed while loading the remote image.
+ * @param previewModePlaceholder Placeholder image to be displayed in Compose previews (IDE).
+ * @param textStyle The [TextStyle] to be used for the initials text fallback. The `fontSize`, `fontFamily` and `fontWeight` properties are used.
+ * If the font size is too large, it will be gradually decreased automatically.
+ * @param textOffset Offset to be applied to the initials text.
+ *
+ * @see [UserAvatar]
  */
 @Composable
 public fun UserAvatarBackground(

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/AudioCallContent.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/activecall/AudioCallContent.kt
@@ -38,7 +38,7 @@ import io.getstream.video.android.compose.ui.components.call.activecall.internal
 import io.getstream.video.android.compose.ui.components.call.controls.actions.DefaultOnCallActionHandler
 import io.getstream.video.android.compose.ui.components.call.ringing.outgoingcall.OutgoingCallContent
 import io.getstream.video.android.compose.ui.components.call.ringing.outgoingcall.OutgoingCallControls
-import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantAvatars
+import io.getstream.video.android.compose.ui.components.participants.ParticipantAvatars
 import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantInformation
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.MemberState

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/ParticipantVideo.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/ParticipantVideo.kt
@@ -128,7 +128,7 @@ public fun ParticipantVideo(
     videoFallbackContent: @Composable (Call) -> Unit = {
         val userName by participant.userNameOrId.collectAsStateWithLifecycle()
         val userImage by participant.image.collectAsStateWithLifecycle()
-        UserAvatarBackground(userName = userName, userImage = userImage)
+        UserAvatarBackground(userImage = userImage, userName = userName)
     },
     reactionContent: @Composable BoxScope.(ParticipantState) -> Unit = {
         DefaultReaction(
@@ -228,7 +228,7 @@ public fun ParticipantVideoRenderer(
     videoFallbackContent: @Composable (Call) -> Unit = {
         val userName by participant.userNameOrId.collectAsStateWithLifecycle()
         val userImage by participant.image.collectAsStateWithLifecycle()
-        UserAvatarBackground(userName = userName, userImage = userImage)
+        UserAvatarBackground(userImage = userImage, userName = userName)
     },
 ) {
     if (LocalInspectionMode.current) {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallDetails.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallDetails.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import io.getstream.video.android.compose.theme.VideoTheme
-import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantAvatars
+import io.getstream.video.android.compose.ui.components.participants.ParticipantAvatars
 import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantInformation
 import io.getstream.video.android.core.MemberState
 import io.getstream.video.android.core.model.CallStatus

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/outgoingcall/OutgoingCallDetails.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/outgoingcall/OutgoingCallDetails.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.video.android.compose.theme.VideoTheme
-import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantAvatars
+import io.getstream.video.android.compose.ui.components.participants.ParticipantAvatars
 import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantInformation
 import io.getstream.video.android.core.MemberState
 import io.getstream.video.android.core.model.CallStatus

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/ParticipantAvatars.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/ParticipantAvatars.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.getstream.video.android.compose.ui.components.participants.internal
+package io.getstream.video.android.compose.ui.components.participants
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/CallParticipantsList.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/CallParticipantsList.kt
@@ -45,7 +45,6 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.UserAvatar
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewParticipantsList
@@ -123,10 +122,9 @@ private fun CallParticipantInfoItem(
         val userName by participant.userNameOrId.collectAsStateWithLifecycle()
         val userImage by participant.image.collectAsStateWithLifecycle()
         UserAvatar(
-            textSize = StyleSize.S,
             modifier = Modifier.size(VideoTheme.dimens.genericL),
-            userName = userName,
             userImage = userImage,
+            userName = userName,
             isShowingOnlineIndicator = true,
         )
 

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/InviteUserList.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/InviteUserList.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.UserAvatar
-import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
 import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewParticipantsList
@@ -106,9 +105,8 @@ internal fun InviteUserItem(
 
         UserAvatar(
             modifier = Modifier.size(VideoTheme.dimens.componentHeightL),
-            userName = userName,
-            textSize = StyleSize.S,
             userImage = userImage,
+            userName = userName,
             isShowingOnlineIndicator = true,
         )
 

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/ParticipantAvatars.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/participants/internal/ParticipantAvatars.kt
@@ -35,6 +35,13 @@ import io.getstream.video.android.core.MemberState
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewMemberListState
 
+/**
+ * Component that renders user avatars for call participants.
+ *
+ * @param participants The list of participants to render avatars for.
+ *
+ * @see [UserAvatar]
+ */
 @Composable
 public fun ParticipantAvatars(
     participants: List<MemberState>,

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/utils/ImageUtils.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/utils/ImageUtils.kt
@@ -25,11 +25,11 @@ import kotlin.math.abs
 
 @Composable
 @ReadOnlyComposable
-internal fun initialsColors(initials: String): Pair<Color, Color> {
+internal fun initialsColors(text: String): Pair<Color, Color> {
     val gradientBaseColors =
         LocalContext.current.resources.getIntArray(R.array.stream_video_avatar_gradient_colors)
 
-    val baseColorIndex = abs(initials.hashCode()) % gradientBaseColors.size
+    val baseColorIndex = abs(text.hashCode()) % gradientBaseColors.size
     val baseColor = Color(gradientBaseColors[baseColorIndex])
     return Pair(baseColor, baseColor.copy(alpha = 0.16f))
 }

--- a/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/AvatarTest.kt
+++ b/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/AvatarTest.kt
@@ -42,7 +42,7 @@ internal class AvatarTest : BaseComposeTest() {
         snapshot {
             Avatar(
                 modifier = Modifier.size(72.dp),
-                initials = "Thierry",
+                fallbackText = "Thierry",
             )
         }
     }
@@ -53,9 +53,9 @@ internal class AvatarTest : BaseComposeTest() {
             val name by previewParticipant.name.collectAsStateWithLifecycle()
             val image by previewParticipant.image.collectAsStateWithLifecycle()
             UserAvatar(
+                modifier = Modifier.size(82.dp),
                 userImage = image,
                 userName = name,
-                modifier = Modifier.size(82.dp),
                 isShowingOnlineIndicator = true,
             )
         }

--- a/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/ParticipantsPortraitTest.kt
+++ b/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/ParticipantsPortraitTest.kt
@@ -33,11 +33,11 @@ import io.getstream.video.android.compose.ui.components.call.renderer.RegularVid
 import io.getstream.video.android.compose.ui.components.call.renderer.internal.LazyColumnVideoRenderer
 import io.getstream.video.android.compose.ui.components.call.renderer.internal.PortraitScreenSharingVideoRenderer
 import io.getstream.video.android.compose.ui.components.call.renderer.internal.PortraitVideoRenderer
+import io.getstream.video.android.compose.ui.components.participants.ParticipantAvatars
 import io.getstream.video.android.compose.ui.components.participants.internal.CallParticipantListAppBar
 import io.getstream.video.android.compose.ui.components.participants.internal.CallParticipantsInfoActions
 import io.getstream.video.android.compose.ui.components.participants.internal.CallParticipantsList
 import io.getstream.video.android.compose.ui.components.participants.internal.InviteUserList
-import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantAvatars
 import io.getstream.video.android.compose.ui.components.participants.internal.ParticipantInformation
 import io.getstream.video.android.core.model.CallStatus
 import io.getstream.video.android.core.model.ScreenSharingSession


### PR DESCRIPTION
### 🎯 Goal

Improve avatar components:
- reviewed avatar components and possible usages
- auto font size adjustment for initials avatars
- clean up parameter lists
- change visibility for similar components
- add/improve KDocs.

### 🛠 Implementation details

- Detected when text is overflowing in `Text` composable in `InitialsAvatar` and gradually decreased font size if needed (decrease step can be added as parameter in the future). Parameter with type `TextStyle.fontSize` is used as starting size.
- Changed `Avatar` visibility to `internal`, as we also have `UserAvatar` that basically does the same thing.
- Improved naming and order of parameters.
- Improved KDocs in several components as we had references to Chat components (probably copy-pasted from Chat).

### 🎨 UI Changes

| Before | After |
| --- | --- |
| Passed-in (or default) font size is too big, so the text overflows | The font size is decreased automatically until no more overflow |
| ![before-1](https://github.com/GetStream/stream-video-android/assets/65943217/519ab754-f1cc-4aa4-9708-9f24e841f44f) | ![Screenshot_20240419_135722](https://github.com/GetStream/stream-video-android/assets/65943217/18f9d80d-099c-4ed2-a94e-bd066d7a8ee6) |
| ![before-2](https://github.com/GetStream/stream-video-android/assets/65943217/73534aa0-ca17-4496-83bb-a9bc9728ad11) | ![Screenshot_20240419_135747](https://github.com/GetStream/stream-video-android/assets/65943217/27f723a9-a1b9-4291-837e-8c70562dd3c5) |
| ![before-3](https://github.com/GetStream/stream-video-android/assets/65943217/67110daf-4652-47d7-86c4-7e95e232b062) | ![Screenshot_20240419_135753](https://github.com/GetStream/stream-video-android/assets/65943217/0749afbf-6a33-486c-a74e-8add1255f6b3) |
| ![Screenshot 2024-04-19 at 14 49 31](https://github.com/GetStream/stream-video-android/assets/65943217/dc3c8524-ff3f-441f-8c03-bf65ce3ff0c1) | ![Screenshot 2024-04-19 at 14 47 53](https://github.com/GetStream/stream-video-android/assets/65943217/74d8e181-34dd-4f0a-99c0-61950f52c77f) |

### 🧪 Testing

Check both image & initials avatars with different sizes. Can be done throughout the demo app and the audio call sample app.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs