### PR TITLE
Extend state management for compose

### DIFF
--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -363,7 +363,7 @@ public final class io/getstream/video/android/compose/ui/ComposableSingletons$St
 public class io/getstream/video/android/compose/ui/ComposeStreamCallActivity : io/getstream/video/android/ui/common/StreamCallActivity {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun uiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
+	public fun getUiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
 }
 
 public class io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate : io/getstream/video/android/compose/ui/StreamCallActivityComposeUi {

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -356,12 +356,8 @@ public final class io/getstream/video/android/compose/theme/VideoThemeKt {
 public final class io/getstream/video/android/compose/ui/ComposableSingletons$StreamCallActivityComposeDelegateKt {
 	public static final field INSTANCE Lio/getstream/video/android/compose/ui/ComposableSingletons$StreamCallActivityComposeDelegateKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
-	public static field lambda-2 Lkotlin/jvm/functions/Function2;
-	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-3$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public class io/getstream/video/android/compose/ui/ComposeStreamCallActivity : io/getstream/video/android/ui/common/StreamCallActivity {
@@ -370,23 +366,36 @@ public class io/getstream/video/android/compose/ui/ComposeStreamCallActivity : i
 	public fun uiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
 }
 
-public class io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate : io/getstream/video/android/ui/common/StreamActivityUiDelegate {
+public class io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate : io/getstream/video/android/compose/ui/StreamCallActivityComposeUi {
 	public static final field $stable I
 	public static final field Companion Lio/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate$Companion;
 	public fun <init> ()V
 	public fun AudioCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
-	public fun DefaultCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
+	public fun IncomingCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public fun LoadingContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
 	public fun NoAnswerContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
-	public fun NoPermissions (Lio/getstream/video/android/ui/common/StreamCallActivity;Ljava/util/List;Ljava/util/List;ZLandroidx/compose/runtime/Composer;II)V
-	public fun OnIncomingCallContent (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
-	public fun OnOutgoingCallContent (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
+	public fun OutgoingCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public fun PermissionsRationaleContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Ljava/util/List;Ljava/util/List;ZLandroidx/compose/runtime/Composer;I)V
 	public fun RejectedContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
 	public fun RootContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
+	public fun VideoCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
 	public fun loadingContent (Lio/getstream/video/android/ui/common/StreamCallActivity;)V
 	public fun setContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;)V
 }
 
 public final class io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate$Companion {
+}
+
+public abstract interface class io/getstream/video/android/compose/ui/StreamCallActivityComposeUi : io/getstream/video/android/ui/common/StreamActivityUiDelegate {
+	public abstract fun AudioCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun IncomingCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public abstract fun LoadingContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun NoAnswerContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun OutgoingCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public abstract fun PermissionsRationaleContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Ljava/util/List;Ljava/util/List;ZLandroidx/compose/runtime/Composer;I)V
+	public abstract fun RejectedContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun RootContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
+	public abstract fun VideoCallContent (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/audio/AudioAppBarKt {
@@ -1582,16 +1591,18 @@ public final class io/getstream/video/android/compose/ui/components/call/ringing
 	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public static field lambda-4 Lkotlin/jvm/functions/Function2;
 	public static field lambda-5 Lkotlin/jvm/functions/Function2;
+	public static field lambda-6 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-3$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-4$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-5$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-6$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/ringing/RingingCallContentKt {
-	public static final fun RingingCallContent (Lio/getstream/video/android/core/Call;Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function11;Lkotlin/jvm/functions/Function11;Landroidx/compose/runtime/Composer;III)V
+	public static final fun RingingCallContent (Lio/getstream/video/android/core/Call;Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function11;Lkotlin/jvm/functions/Function11;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/ComposableSingletons$IncomingCallContentKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/ComposeStreamCallActivity.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/ComposeStreamCallActivity.kt
@@ -25,8 +25,6 @@ import io.getstream.video.android.ui.common.StreamCallActivity
  */
 public open class ComposeStreamCallActivity : StreamCallActivity() {
 
-    @Suppress("UNCHECKED_CAST")
-    override fun <T : StreamCallActivity> uiDelegate(): StreamActivityUiDelegate<T> {
-        return StreamCallActivityComposeDelegate() as StreamActivityUiDelegate<T>
-    }
+    override val uiDelegate: StreamActivityUiDelegate<StreamCallActivity>
+        get() = StreamCallActivityComposeDelegate()
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -131,7 +131,6 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         VideoTheme {
             LaunchPermissionRequest(listOf(Manifest.permission.RECORD_AUDIO)) {
                 AllPermissionsGranted {
-                    val configuration = configuration()
                     // All permissions granted
                     RingingCallContent(
                         isVideoType = isVideoCall(call),

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -40,10 +40,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -53,7 +51,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -72,11 +69,7 @@ import io.getstream.video.android.compose.ui.components.call.ringing.incomingcal
 import io.getstream.video.android.compose.ui.components.call.ringing.outgoingcall.OutgoingCallContent
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.MemberState
-import io.getstream.video.android.core.RealtimeConnection
 import io.getstream.video.android.core.call.state.CallAction
-import io.getstream.video.android.core.call.state.DeclineCall
-import io.getstream.video.android.core.call.state.LeaveCall
-import io.getstream.video.android.ui.common.StreamActivityUiDelegate
 import io.getstream.video.android.ui.common.StreamCallActivity
 import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
 
@@ -111,7 +104,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     IndeterminateProgressBar(
                         modifier = Modifier
                             .align(Alignment.Center)
-                            .padding(16.dp)
+                            .padding(16.dp),
                     )
                 }
             }
@@ -154,10 +147,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                                 isShowingHeader: Boolean,
                                 headerContent: @Composable (ColumnScope.() -> Unit)?,
                                 detailsContent: @Composable (
-                                ColumnScope.(
-                                    participants: List<MemberState>,
-                                    topPadding: Dp,
-                                ) -> Unit
+                                    ColumnScope.(
+                                        participants: List<MemberState>,
+                                        topPadding: Dp,
+                                    ) -> Unit
                                 )?,
                                 controlsContent: @Composable (BoxScope.() -> Unit)?,
                                 onBackPressed: () -> Unit,
@@ -181,10 +174,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                                 isVideoType: Boolean, isShowingHeader: Boolean,
                                 headerContent: @Composable (ColumnScope.() -> Unit)?,
                                 detailsContent: @Composable (
-                                ColumnScope.(
-                                    participants: List<MemberState>,
-                                    topPadding: Dp,
-                                ) -> Unit
+                                    ColumnScope.(
+                                        participants: List<MemberState>,
+                                        topPadding: Dp,
+                                    ) -> Unit
                                 )?,
                                 controlsContent: @Composable (BoxScope.() -> Unit)?,
                                 onBackPressed: () -> Unit,
@@ -240,12 +233,12 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(VideoTheme.colors.baseSheetPrimary)
+                .background(VideoTheme.colors.baseSheetPrimary),
         ) {
             IndeterminateProgressBar(
                 modifier = Modifier
                     .align(Alignment.Center)
-                    .padding(16.dp)
+                    .padding(16.dp),
             )
         }
     }
@@ -285,10 +278,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-        @Composable ColumnScope.(
-            participants: List<MemberState>,
-            topPadding: Dp,
-        ) -> Unit
+            @Composable ColumnScope.(
+                participants: List<MemberState>,
+                topPadding: Dp,
+            ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,
@@ -315,10 +308,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-        @Composable ColumnScope.(
-            participants: List<MemberState>,
-            topPadding: Dp,
-        ) -> Unit
+            @Composable ColumnScope.(
+                participants: List<MemberState>,
+                topPadding: Dp,
+            ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,
@@ -356,7 +349,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         call: Call,
         granted: List<String>,
         notGranted: List<String>,
-        showRationale: Boolean
+        showRationale: Boolean,
     ) {
         if (!showRationale) {
             logger.w { "Permissions were not granted, but rationale is required to be skipped." }
@@ -421,8 +414,9 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
             targetValue = 1f,
             animationSpec = infiniteRepeatable(
                 animation = tween(durationMillis = 1000, easing = LinearEasing),
-                repeatMode = RepeatMode.Restart
-            ), label = ""
+                repeatMode = RepeatMode.Restart,
+            ),
+            label = "",
         )
 
         Box(
@@ -430,16 +424,19 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                 .height(4.dp)
                 .fillMaxWidth()
                 .background(
-                    shape = CircleShape, color = VideoTheme.colors.baseSheetSecondary
+                    shape = CircleShape,
+                    color = VideoTheme.colors.baseSheetSecondary,
                 )
-                .clip(CircleShape)
+                .clip(CircleShape),
         ) {
             Box(
                 modifier = Modifier
                     .height(8.dp)
                     .width(50.dp)
                     .background(VideoTheme.colors.brandPrimary)
-                    .offset(x = (translateAnim.value * with(LocalDensity.current) { 300.dp.toPx() }).dp)
+                    .offset(
+                        x = (translateAnim.value * with(LocalDensity.current) { 300.dp.toPx() }).dp,
+                    ),
             )
         }
     }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -21,13 +21,25 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import androidx.activity.compose.setContent
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
@@ -35,10 +47,13 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -73,16 +88,18 @@ import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
 // We suppress build fails since we do not have default parameters in our abstract @Composable
 // Remove the @Suppress line once the listed issue is fixed.
 // https://issuetracker.google.com/issues/322121224
+@OptIn(StreamCallActivityDelicateApi::class)
 @Suppress("ABSTRACT_COMPOSABLE_DEFAULT_PARAMETER_VALUE")
-public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<StreamCallActivity> {
+public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeUi {
 
     public companion object {
-        private val logger by taggedLogger("StreamCallActivityUiDelegate")
+        private val logger by taggedLogger("StreamCallActivityComposeDelegate")
     }
 
     /**
      * Shows a progressbar until everything is set.
      */
+    @StreamCallActivityDelicateApi
     override fun loadingContent(activity: StreamCallActivity) {
         activity.setContent {
             VideoTheme {
@@ -91,9 +108,10 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
                         .fillMaxSize()
                         .background(VideoTheme.colors.baseSheetPrimary),
                 ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.align(Alignment.Center),
-                        color = VideoTheme.colors.brandPrimary,
+                    IndeterminateProgressBar(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .padding(16.dp)
                     )
                 }
             }
@@ -107,38 +125,21 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
      * @param call the call
      */
     override fun setContent(activity: StreamCallActivity, call: Call) {
-        logger.d { "[onCreate(activity, call)] invoked from compose delegate." }
+        logger.d { "[setContent(activity, call)] invoked from compose delegate." }
         activity.setContent {
             logger.d { "[setContent] with RootContent" }
             activity.RootContent(call = call)
         }
     }
 
-    /**
-     * Root content of the screen.
-     *
-     * @param call the call object.
-     */
-    @OptIn(StreamCallActivityDelicateApi::class)
+    @StreamCallActivityDelicateApi
     @Composable
-    public open fun StreamCallActivity.RootContent(call: Call) {
+    override fun StreamCallActivity.RootContent(call: Call) {
         VideoTheme {
             LaunchPermissionRequest(listOf(Manifest.permission.RECORD_AUDIO)) {
                 AllPermissionsGranted {
+                    val configuration = configuration()
                     // All permissions granted
-                    val connection by call.state.connection.collectAsStateWithLifecycle()
-                    LaunchedEffect(key1 = connection) {
-                        if (connection == RealtimeConnection.Disconnected) {
-                            logger.w { "Call disconnected." }
-                            finish()
-                        } else if (connection is RealtimeConnection.Failed) {
-                            // Safely cast, no need to crash if the error message is missing
-                            val conn = connection as? RealtimeConnection.Failed
-                            logger.e(Exception("${conn?.error}")) { "Call connection failed." }
-                            finish()
-                        }
-                    }
-
                     RingingCallContent(
                         isVideoType = isVideoCall(call),
                         call = call,
@@ -146,22 +147,23 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
                         onBackPressed = {
                             onBackPressed(call)
                         },
-                        onOutgoingContent = { modifier: Modifier,
-                                              call: Call,
-                                              isVideoType: Boolean,
-                                              isShowingHeader: Boolean,
-                                              headerContent: @Composable (ColumnScope.() -> Unit)?,
-                                              detailsContent: @Composable (
-                                                  ColumnScope.(
-                                                      participants: List<MemberState>,
-                                                      topPadding: Dp,
-                                                  ) -> Unit
-                                              )?,
-                                              controlsContent: @Composable (BoxScope.() -> Unit)?,
-                                              onBackPressed: () -> Unit,
-                                              onCallAction: (CallAction) -> Unit,
+                        onOutgoingContent = {
+                                modifier: Modifier,
+                                call: Call,
+                                isVideoType: Boolean,
+                                isShowingHeader: Boolean,
+                                headerContent: @Composable (ColumnScope.() -> Unit)?,
+                                detailsContent: @Composable (
+                                ColumnScope.(
+                                    participants: List<MemberState>,
+                                    topPadding: Dp,
+                                ) -> Unit
+                                )?,
+                                controlsContent: @Composable (BoxScope.() -> Unit)?,
+                                onBackPressed: () -> Unit,
+                                onCallAction: (CallAction) -> Unit,
                             ->
-                            OnOutgoingCallContent(
+                            OutgoingCallContent(
                                 call = call,
                                 isVideoType = isVideoType,
                                 modifier = modifier,
@@ -173,21 +175,22 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
                                 onCallAction = onCallAction,
                             )
                         },
-                        onIncomingContent = { modifier: Modifier,
-                                              call: Call,
-                                              isVideoType: Boolean, isShowingHeader: Boolean,
-                                              headerContent: @Composable (ColumnScope.() -> Unit)?,
-                                              detailsContent: @Composable (
-                                                  ColumnScope.(
-                                                      participants: List<MemberState>,
-                                                      topPadding: Dp,
-                                                  ) -> Unit
-                                              )?,
-                                              controlsContent: @Composable (BoxScope.() -> Unit)?,
-                                              onBackPressed: () -> Unit,
-                                              onCallAction: (CallAction) -> Unit,
+                        onIncomingContent = {
+                                modifier: Modifier,
+                                call: Call,
+                                isVideoType: Boolean, isShowingHeader: Boolean,
+                                headerContent: @Composable (ColumnScope.() -> Unit)?,
+                                detailsContent: @Composable (
+                                ColumnScope.(
+                                    participants: List<MemberState>,
+                                    topPadding: Dp,
+                                ) -> Unit
+                                )?,
+                                controlsContent: @Composable (BoxScope.() -> Unit)?,
+                                onBackPressed: () -> Unit,
+                                onCallAction: (CallAction) -> Unit,
                             ->
-                            OnIncomingCallContent(
+                            IncomingCallContent(
                                 call = call,
                                 isVideoType = isVideoType,
                                 modifier = modifier,
@@ -201,7 +204,7 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
                         },
                         onAcceptedContent = {
                             if (isVideoCall(call)) {
-                                DefaultCallContent(call = call)
+                                VideoCallContent(call = call)
                             } else {
                                 AudioCallContent(call = call)
                             }
@@ -215,119 +218,40 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
                         onCallAction = {
                             onCallAction(call, it)
                         },
+                        onIdle = {
+                            LoadingContent(call)
+                        },
                     )
                 }
 
                 SomeGranted { granted, notGranted, showRationale ->
-                    // Some of the permissions were granted, you can check which ones.
-                    if (showRationale) {
-                        NoPermissions(granted, notGranted, true)
-                    } else {
-                        logger.w { "No permission, closing activity without rationale! [notGranted: [$notGranted]" }
-                        finish()
-                    }
+                    PermissionsRationaleContent(call, granted, notGranted, showRationale)
                 }
+
                 NoneGranted {
-                    // None of the permissions were granted.
-                    if (it) {
-                        NoPermissions(showRationale = true)
-                    } else {
-                        logger.w { "No permission, closing activity without rationale!" }
-                        finish()
-                    }
+                    PermissionsRationaleContent(call, emptyList(), emptyList(), it)
                 }
             }
         }
     }
 
     @Composable
-    public open fun OnOutgoingCallContent(
-        modifier: Modifier,
-        call: Call,
-        isVideoType: Boolean,
-        isShowingHeader: Boolean,
-        headerContent: (@Composable ColumnScope.() -> Unit)?,
-        detailsContent: (
-            @Composable ColumnScope.(
-                participants: List<MemberState>,
-                topPadding: Dp,
-            ) -> Unit
-        )?,
-        controlsContent: (@Composable BoxScope.() -> Unit)?,
-        onBackPressed: () -> Unit,
-        onCallAction: (CallAction) -> Unit,
-    ) {
-        OutgoingCallContent(
-            call = call,
-            isVideoType = isVideoType,
-            modifier = modifier,
-            isShowingHeader = isShowingHeader,
-            headerContent = headerContent,
-            detailsContent = detailsContent,
-            controlsContent = controlsContent,
-            onBackPressed = onBackPressed,
-            onCallAction = onCallAction,
-        )
+    override fun StreamCallActivity.LoadingContent(call: Call) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(VideoTheme.colors.baseSheetPrimary)
+        ) {
+            IndeterminateProgressBar(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .padding(16.dp)
+            )
+        }
     }
 
     @Composable
-    public open fun OnIncomingCallContent(
-        modifier: Modifier,
-        call: Call,
-        isVideoType: Boolean,
-        isShowingHeader: Boolean,
-        headerContent: (@Composable ColumnScope.() -> Unit)?,
-        detailsContent: (
-            @Composable ColumnScope.(
-                participants: List<MemberState>,
-                topPadding: Dp,
-            ) -> Unit
-        )?,
-        controlsContent: (@Composable BoxScope.() -> Unit)?,
-        onBackPressed: () -> Unit,
-        onCallAction: (CallAction) -> Unit,
-    ) {
-        IncomingCallContent(
-            call = call,
-            isVideoType = isVideoType,
-            modifier = modifier,
-            isShowingHeader = isShowingHeader,
-            headerContent = headerContent,
-            detailsContent = detailsContent,
-            controlsContent = controlsContent,
-            onBackPressed = onBackPressed,
-            onCallAction = onCallAction,
-        )
-    }
-
-    /**
-     * Content when the call is not answered.
-     *
-     * @param call the call.
-     */
-    @Composable
-    public open fun StreamCallActivity.NoAnswerContent(call: Call) {
-        onCallAction(call, LeaveCall)
-    }
-
-    /**
-     * Content when the call is rejected.
-     *
-     * @param call the call.
-     */
-    @Composable
-    public open fun StreamCallActivity.RejectedContent(call: Call) {
-        onCallAction(call, DeclineCall)
-    }
-
-    /**
-     * Content for audio calls.
-     * Call type must be "audio_call"
-     *
-     * @param call the call.
-     */
-    @Composable
-    public open fun StreamCallActivity.AudioCallContent(call: Call) {
+    override fun StreamCallActivity.AudioCallContent(call: Call) {
         val micEnabled by call.microphone.isEnabled.collectAsStateWithLifecycle()
         val duration by call.state.durationInDateFormat.collectAsStateWithLifecycle()
         io.getstream.video.android.compose.ui.components.call.activecall.AudioCallContent(
@@ -344,13 +268,8 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
         )
     }
 
-    /**
-     * Content for all other calls.
-     *
-     * @param call the call.
-     */
     @Composable
-    public open fun StreamCallActivity.DefaultCallContent(call: Call) {
+    override fun StreamCallActivity.VideoCallContent(call: Call) {
         CallContent(call = call, onCallAction = {
             onCallAction(call, it)
         }, onBackPressed = {
@@ -358,15 +277,93 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
         })
     }
 
-    /**
-     * Content when permissions are missing.
-     */
     @Composable
-    public open fun StreamCallActivity.NoPermissions(
-        granted: List<String> = emptyList(),
-        notGranted: List<String> = emptyList(),
-        showRationale: Boolean,
+    override fun StreamCallActivity.OutgoingCallContent(
+        modifier: Modifier,
+        call: Call,
+        isVideoType: Boolean,
+        isShowingHeader: Boolean,
+        headerContent: (@Composable ColumnScope.() -> Unit)?,
+        detailsContent: (
+        @Composable ColumnScope.(
+            participants: List<MemberState>,
+            topPadding: Dp,
+        ) -> Unit
+        )?,
+        controlsContent: (@Composable BoxScope.() -> Unit)?,
+        onBackPressed: () -> Unit,
+        onCallAction: (CallAction) -> Unit,
     ) {
+        io.getstream.video.android.compose.ui.components.call.ringing.outgoingcall.OutgoingCallContent(
+            call = call,
+            isVideoType = isVideoType,
+            modifier = modifier,
+            isShowingHeader = isShowingHeader,
+            headerContent = headerContent,
+            detailsContent = detailsContent,
+            controlsContent = controlsContent,
+            onBackPressed = onBackPressed,
+            onCallAction = onCallAction,
+        )
+    }
+
+    @Composable
+    override fun StreamCallActivity.IncomingCallContent(
+        modifier: Modifier,
+        call: Call,
+        isVideoType: Boolean,
+        isShowingHeader: Boolean,
+        headerContent: (@Composable ColumnScope.() -> Unit)?,
+        detailsContent: (
+        @Composable ColumnScope.(
+            participants: List<MemberState>,
+            topPadding: Dp,
+        ) -> Unit
+        )?,
+        controlsContent: (@Composable BoxScope.() -> Unit)?,
+        onBackPressed: () -> Unit,
+        onCallAction: (CallAction) -> Unit,
+    ) {
+        io.getstream.video.android.compose.ui.components.call.ringing.incomingcall.IncomingCallContent(
+            call = call,
+            isVideoType = isVideoType,
+            modifier = modifier,
+            isShowingHeader = isShowingHeader,
+            headerContent = headerContent,
+            detailsContent = detailsContent,
+            controlsContent = controlsContent,
+            onBackPressed = onBackPressed,
+            onCallAction = onCallAction,
+        )
+    }
+
+    @Composable
+    override fun StreamCallActivity.NoAnswerContent(call: Call) {
+        // By default we finish the activity regardless of config.
+        // There is not default UI for no-answer content.
+        finish()
+    }
+
+    @Composable
+    override fun StreamCallActivity.RejectedContent(call: Call) {
+        // By default we finish the activity regardless of config.
+        // There is not default UI for rejected content.
+        finish()
+    }
+
+    @Composable
+    override fun StreamCallActivity.PermissionsRationaleContent(
+        call: Call,
+        granted: List<String>,
+        notGranted: List<String>,
+        showRationale: Boolean
+    ) {
+        if (!showRationale) {
+            logger.w { "Permissions were not granted, but rationale is required to be skipped." }
+            finish()
+            return
+        }
+        // Proceed as normal
         StreamDialogPositiveNegative(
             content = {
                 Text(
@@ -412,5 +409,38 @@ public open class StreamCallActivityComposeDelegate : StreamActivityUiDelegate<S
                 finish()
             },
         )
+    }
+
+    // To not depend on the Compose progress bar due to this
+    // https://issuetracker.google.com/issues/322214617
+    @Composable
+    private fun IndeterminateProgressBar(modifier: Modifier = Modifier) {
+        val infiniteTransition = rememberInfiniteTransition(label = "")
+        val translateAnim = infiniteTransition.animateFloat(
+            initialValue = 0f,
+            targetValue = 1f,
+            animationSpec = infiniteRepeatable(
+                animation = tween(durationMillis = 1000, easing = LinearEasing),
+                repeatMode = RepeatMode.Restart
+            ), label = ""
+        )
+
+        Box(
+            modifier = modifier
+                .height(4.dp)
+                .fillMaxWidth()
+                .background(
+                    shape = CircleShape, color = VideoTheme.colors.baseSheetSecondary
+                )
+                .clip(CircleShape)
+        ) {
+            Box(
+                modifier = Modifier
+                    .height(8.dp)
+                    .width(50.dp)
+                    .background(VideoTheme.colors.brandPrimary)
+                    .offset(x = (translateAnim.value * with(LocalDensity.current) { 300.dp.toPx() }).dp)
+            )
+        }
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeUi.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeUi.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.video.android.compose.ui
 
 import androidx.compose.foundation.layout.BoxScope
@@ -23,7 +39,6 @@ public interface StreamCallActivityComposeUi : StreamActivityUiDelegate<StreamCa
     @StreamCallActivityDelicateApi
     @Composable
     public fun StreamCallActivity.RootContent(call: Call)
-
 
     /**
      * Content shown when there is data to be loaded.
@@ -69,10 +84,10 @@ public interface StreamCallActivityComposeUi : StreamActivityUiDelegate<StreamCa
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-        @Composable ColumnScope.(
-            participants: List<MemberState>,
-            topPadding: Dp,
-        ) -> Unit
+            @Composable ColumnScope.(
+                participants: List<MemberState>,
+                topPadding: Dp,
+            ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,
@@ -94,14 +109,14 @@ public interface StreamCallActivityComposeUi : StreamActivityUiDelegate<StreamCa
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-        @Composable ColumnScope.(
-            participants: List<MemberState>,
-            topPadding: Dp,
-        ) -> Unit
+            @Composable ColumnScope.(
+                participants: List<MemberState>,
+                topPadding: Dp,
+            ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,
-        onCallAction: (CallAction) -> Unit
+        onCallAction: (CallAction) -> Unit,
     )
 
     /**

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeUi.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeUi.kt
@@ -1,0 +1,135 @@
+package io.getstream.video.android.compose.ui
+
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.MemberState
+import io.getstream.video.android.core.call.state.CallAction
+import io.getstream.video.android.ui.common.StreamActivityUiDelegate
+import io.getstream.video.android.ui.common.StreamCallActivity
+import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
+
+public interface StreamCallActivityComposeUi : StreamActivityUiDelegate<StreamCallActivity> {
+
+    /**
+     * Root content of the UI. If you override this, the rest might not work as expected and need to
+     * be called from this method.
+     *
+     * @param call the call.
+     */
+    @StreamCallActivityDelicateApi
+    @Composable
+    public fun StreamCallActivity.RootContent(call: Call)
+
+
+    /**
+     * Content shown when there is data to be loaded.
+     *
+     * @param call the call.
+     */
+    @Composable
+    public fun StreamCallActivity.LoadingContent(call: Call)
+
+    /**
+     * Content for in-call audio-only calls.
+     * Audio call is a call which returns `false` for [Call.hasCapability] when the argument is `SendVideo`
+     *
+     * @param call the call.
+     */
+    @Composable
+    public fun StreamCallActivity.AudioCallContent(call: Call)
+
+    /**
+     * Content for in-call for every other call that has video capabilities.
+     * Default call is a call which returns `true` for [Call.hasCapability] when the argument is `SendVideo`
+     *
+     * @param call the call.
+     */
+    @Composable
+    public fun StreamCallActivity.VideoCallContent(call: Call)
+
+    /**
+     * Content for outgoing call.
+     *
+     * @param call the call.
+     * @param modifier the UI modifier
+     * @param isVideoType if the call is video or not
+     * @param isShowingHeader if the header will be shown
+     * @param headerContent the content of the header
+     * @param detailsContent the details content (participant avatars etc..)
+     */
+    @Composable
+    public fun StreamCallActivity.OutgoingCallContent(
+        modifier: Modifier,
+        call: Call,
+        isVideoType: Boolean,
+        isShowingHeader: Boolean,
+        headerContent: (@Composable ColumnScope.() -> Unit)?,
+        detailsContent: (
+        @Composable ColumnScope.(
+            participants: List<MemberState>,
+            topPadding: Dp,
+        ) -> Unit
+        )?,
+        controlsContent: (@Composable BoxScope.() -> Unit)?,
+        onBackPressed: () -> Unit,
+        onCallAction: (CallAction) -> Unit,
+    )
+
+    /**
+     * Content for incoming call.
+     *
+     * @param call the call.
+     * @param modifier the modifier
+     * @param isVe
+     */
+    @Composable
+    public fun StreamCallActivity.IncomingCallContent(
+        modifier: Modifier,
+        call: Call,
+        isVideoType: Boolean,
+        isShowingHeader: Boolean,
+        headerContent: (@Composable ColumnScope.() -> Unit)?,
+        detailsContent: (
+        @Composable ColumnScope.(
+            participants: List<MemberState>,
+            topPadding: Dp,
+        ) -> Unit
+        )?,
+        controlsContent: (@Composable BoxScope.() -> Unit)?,
+        onBackPressed: () -> Unit,
+        onCallAction: (CallAction) -> Unit
+    )
+
+    /**
+     * Content for when the call was not answered.
+     *
+     * @param call the call.
+     */
+    @Composable
+    public fun StreamCallActivity.NoAnswerContent(call: Call)
+
+    /**
+     * Call when the call was rejected.
+     *
+     * @param call the call.
+     */
+    @Composable
+    public fun StreamCallActivity.RejectedContent(call: Call)
+
+    /**
+     * Content shown when the required permissions are not granted and the call cannot happen.
+     * Note: There are other places that permissions are required like in the service etc..
+     * Best practice is to request these permissions a screen before starting the call.
+     */
+    @Composable
+    public fun StreamCallActivity.PermissionsRationaleContent(
+        call: Call,
+        granted: List<String>,
+        notGranted: List<String>,
+        showRationale: Boolean,
+    )
+}

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/RingingCallContent.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/RingingCallContent.kt
@@ -110,7 +110,7 @@ public fun RingingCallContent(
             onCallAction: (CallAction) -> Unit,
         ) -> Unit
     )? = null,
-    onIdle: @Composable () -> Unit = {}
+    onIdle: @Composable () -> Unit = {},
 ) {
     val ringingState by call.state.ringingState.collectAsStateWithLifecycle()
 

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/RingingCallContent.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/RingingCallContent.kt
@@ -110,6 +110,7 @@ public fun RingingCallContent(
             onCallAction: (CallAction) -> Unit,
         ) -> Unit
     )? = null,
+    onIdle: @Composable () -> Unit = {}
 ) {
     val ringingState by call.state.ringingState.collectAsStateWithLifecycle()
 
@@ -174,12 +175,9 @@ public fun RingingCallContent(
             onAcceptedContent.invoke()
         }
 
-        RingingState.Idle -> {
-            // Call state is not ready yet? Show loading?
-        }
-
         else -> {
-            // Unknown
+            // Includes Idle
+            onIdle.invoke()
         }
     }
 }

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -33,7 +33,6 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public static synthetic fun call$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/model/StreamCallId;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public fun cancel (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun cancel$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public fun configuration ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	public fun create (Lio/getstream/video/android/core/Call;ZLjava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun create$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;ZLjava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public fun end (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
@@ -41,6 +40,8 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public final fun enterPictureInPicture ()V
 	public fun get (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun get$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public fun getConfiguration ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
+	public abstract fun getUiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
 	public fun isVideoCall (Lio/getstream/video/android/core/Call;)Z
 	public fun join (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun join$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
@@ -68,7 +69,6 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun onStop (Lio/getstream/video/android/core/Call;)V
 	public fun reject (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun reject$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public abstract fun uiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
 }
 
 public final class io/getstream/video/android/ui/common/StreamCallActivity$Companion {

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -33,6 +33,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public static synthetic fun call$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/model/StreamCallId;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public fun cancel (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun cancel$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public fun configuration ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	public fun create (Lio/getstream/video/android/core/Call;ZLjava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun create$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;ZLjava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public fun end (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
@@ -48,9 +49,12 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun onBackPressed (Lio/getstream/video/android/core/Call;)V
 	public fun onCallAction (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/call/state/CallAction;)V
 	public fun onCallEvent (Lio/getstream/video/android/core/Call;Lorg/openapitools/client/models/VideoEvent;)V
+	public fun onConnectionEvent (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/RealtimeConnection;)V
 	public final fun onCreate (Landroid/os/Bundle;)V
 	public final fun onCreate (Landroid/os/Bundle;Landroid/os/PersistableBundle;)V
 	public fun onCreate (Landroid/os/Bundle;Landroid/os/PersistableBundle;Lio/getstream/video/android/core/Call;)V
+	public fun onEnded (Lio/getstream/video/android/core/Call;)V
+	public fun onFailed (Ljava/lang/Exception;)V
 	public fun onIntentAction (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun onIntentAction$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public fun onLastParticipant (Lio/getstream/video/android/core/Call;)V
@@ -68,8 +72,30 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 }
 
 public final class io/getstream/video/android/ui/common/StreamCallActivity$Companion {
-	public final fun callIntent (Landroid/content/Context;Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLjava/lang/String;Ljava/lang/Class;)Landroid/content/Intent;
-	public static synthetic fun callIntent$default (Lio/getstream/video/android/ui/common/StreamCallActivity$Companion;Landroid/content/Context;Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLjava/lang/String;Ljava/lang/Class;ILjava/lang/Object;)Landroid/content/Intent;
+	public final fun callIntent (Landroid/content/Context;Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLjava/lang/String;Ljava/lang/Class;Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;)Landroid/content/Intent;
+	public static synthetic fun callIntent$default (Lio/getstream/video/android/ui/common/StreamCallActivity$Companion;Landroid/content/Context;Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLjava/lang/String;Ljava/lang/Class;Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;ILjava/lang/Object;)Landroid/content/Intent;
+}
+
+public final class io/getstream/video/android/ui/common/StreamCallActivityConfiguration {
+	public fun <init> ()V
+	public fun <init> (ZZLandroid/os/Bundle;)V
+	public synthetic fun <init> (ZZLandroid/os/Bundle;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Landroid/os/Bundle;
+	public final fun copy (ZZLandroid/os/Bundle;)Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
+	public static synthetic fun copy$default (Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;ZZLandroid/os/Bundle;ILjava/lang/Object;)Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCloseScreenOnCallEnded ()Z
+	public final fun getCloseScreenOnError ()Z
+	public final fun getCustom ()Landroid/os/Bundle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/video/android/ui/common/StreamCallActivityConfigurationKt {
+	public static final fun extractStreamActivityConfig (Landroid/os/Bundle;)Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
+	public static final fun toBundle (Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;)Landroid/os/Bundle;
 }
 
 public final class io/getstream/video/android/ui/common/databinding/StreamVideoContentParticipantBinding : androidx/viewbinding/ViewBinding {

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -34,6 +34,7 @@ import io.getstream.result.onErrorSuspend
 import io.getstream.result.onSuccessSuspend
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.EventSubscription
+import io.getstream.video.android.core.RealtimeConnection
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.call.RtcSession
 import io.getstream.video.android.core.call.state.AcceptCall
@@ -51,6 +52,8 @@ import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.streamCallId
 import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.openapitools.client.models.CallEndedEvent
@@ -87,12 +90,16 @@ public abstract class StreamCallActivity : ComponentActivity() {
             leaveWhenLastInCall: Boolean = DEFAULT_LEAVE_WHEN_LAST,
             action: String? = null,
             clazz: Class<T>,
+            configuration: StreamCallActivityConfiguration = StreamCallActivityConfiguration()
         ): Intent {
             return Intent(context, clazz).apply {
                 // Setup the outgoing call action
                 action?.let {
                     this.action = it
                 }
+                val config = configuration.toBundle()
+                // Add the config
+                putExtra(StreamCallActivityConfigStrings.EXTRA_STREAM_CONFIG, config)
                 // Add the generated call ID and other params
                 putExtra(NotificationHandler.INTENT_EXTRA_CALL_CID, cid)
                 putExtra(EXTRA_LEAVE_WHEN_LAST, leaveWhenLastInCall)
@@ -107,22 +114,28 @@ public abstract class StreamCallActivity : ComponentActivity() {
     }
 
     // Internal state
-    private var subscription: EventSubscription? = null
+    private var callEventSubscription: EventSubscription? = null
+    private var callSocketConnectionMonitor: Job? = null
     private lateinit var cachedCall: Call
-    private val onSuccessFinish: suspend (Call) -> Unit = {
+    private lateinit var config: StreamCallActivityConfiguration
+    private val onSuccessFinish: suspend (Call) -> Unit = { call ->
         logger.w { "The call was successfully finished! Closing activity" }
-        finish()
+        onEnded(call)
+        if (configuration().closeScreenOnCallEnded) {
+            finish()
+        }
     }
-    private val onErrorFinish: suspend (Exception) -> Unit = {
-        logger.e(it) { "Something went wrong, finishing the activity!" }
-        finish()
+    private val onErrorFinish: suspend (Exception) -> Unit = { error ->
+        logger.e(error) { "Something went wrong, finishing the activity!" }
+        onFailed(error)
+        if (configuration().closeScreenOnError) {
+            finish()
+        }
     }
 
     // Platform restriction
     public final override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val uiDelegate = uiDelegate<StreamCallActivity>()
-        uiDelegate.loadingContent(this)
         onPreCreate(savedInstanceState, null)
         logger.d { "Entered [onCreate(Bundle?)" }
         initializeCallOrFail(
@@ -131,11 +144,11 @@ public abstract class StreamCallActivity : ComponentActivity() {
             onSuccess = { instanceState, persistentState, call, action ->
                 logger.d { "Calling [onCreate(Call)], because call is initialized $call" }
                 onCreate(instanceState, persistentState, call)
-                onIntentAction(call, action, onError = {
-                    finish()
-                })
+                onIntentAction(call, action, onError = onErrorFinish)
             },
             onError = {
+                // We are not calling onErrorFinish here on purpose
+                // we want to crash if we cannot initialize the call
                 logger.e(it) { "Failed to initialize call." }
                 throw it
             },
@@ -147,8 +160,6 @@ public abstract class StreamCallActivity : ComponentActivity() {
         persistentState: PersistableBundle?,
     ) {
         super.onCreate(savedInstanceState)
-        val uiDelegate = uiDelegate<StreamCallActivity>()
-        uiDelegate.loadingContent(this)
         onPreCreate(savedInstanceState, persistentState)
         logger.d { "Entered [onCreate(Bundle, PersistableBundle?)" }
         initializeCallOrFail(
@@ -157,11 +168,11 @@ public abstract class StreamCallActivity : ComponentActivity() {
             onSuccess = { instanceState, persistedState, call, action ->
                 logger.d { "Calling [onCreate(Call)], because call is initialized $call" }
                 onCreate(instanceState, persistedState, call)
-                onIntentAction(call, action, onError = {
-                    finish()
-                })
+                onIntentAction(call, action, onError = onErrorFinish)
             },
             onError = {
+                // We are not calling onErrorFinish here on purpose
+                // we want to crash if we cannot initialize the call
                 logger.e(it) { "Failed to initialize call." }
                 throw it
             },
@@ -252,11 +263,17 @@ public abstract class StreamCallActivity : ComponentActivity() {
     }
 
     /**
-     * Called when the activity is created, but the SDK is not yet initialized and the call is not retrieved.
-     * Can be used to show loading progress bar or some loading gradient instead of white screen.
+     * Called when the activity is created, but the SDK is not yet initialized.
+     * Initializes the configuration and UI delegates.
      */
+    @CallSuper
+    @StreamCallActivityDelicateApi
     public open fun onPreCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
-        logger.d { "Set pre-init content." }
+        logger.d { "Pre-create" }
+        val config = configuration() // Called before the delegate because
+        logger.d { "Activity pre-created with configuration [$config]" }
+        val uiDelegate = uiDelegate<StreamCallActivity>()
+        uiDelegate.loadingContent(this)
     }
 
     /**
@@ -282,6 +299,27 @@ public abstract class StreamCallActivity : ComponentActivity() {
     public abstract fun <T : StreamCallActivity> uiDelegate(): StreamActivityUiDelegate<T>
 
     /**
+     * A configuration object returned for this activity controlling various behaviors of the activity.
+     * Can be overridden for further control on the behavior.
+     */
+    @StreamCallActivityDelicateApi
+    public open fun configuration(): StreamCallActivityConfiguration {
+        if (!::config.isInitialized) {
+            try {
+                val bundledConfig =
+                    intent.getBundleExtra(StreamCallActivityConfigStrings.EXTRA_STREAM_CONFIG)
+                config =
+                    bundledConfig?.extractStreamActivityConfig()
+                        ?: StreamCallActivityConfiguration()
+            } catch (e: Exception) {
+                config = StreamCallActivityConfiguration()
+                logger.e(e) { "Failed to load config using default!" }
+            }
+        }
+        return config
+    }
+
+    /**
      * Called when the activity is resumed. Makes sure the call object is available.
      *
      * @param call
@@ -301,6 +339,23 @@ public abstract class StreamCallActivity : ComponentActivity() {
             enterPictureInPicture()
         }
         logger.d { "DefaultCallActivity - Paused (call -> $call)" }
+    }
+
+    /**
+     * Called when the activity has failed for any reason.
+     * The activity will finish after this call, to prevent the `finish()` provide a different [StreamCallActivityConfiguration].
+     */
+    public open fun onFailed(exception: Exception) {
+        // No - op
+    }
+
+    /**
+     * Called when call has ended successfully, either by action from the user or
+     * backend event. The activity will finish after this call.
+     * To prevent it, provide a different [StreamCallActivityConfiguration]
+     */
+    public open fun onEnded(call: Call) {
+        // No-op
     }
 
     /**
@@ -328,7 +383,8 @@ public abstract class StreamCallActivity : ComponentActivity() {
 
     // Decision making
     @StreamCallActivityDelicateApi
-    public open fun isVideoCall(call: Call): Boolean = call.hasCapability(OwnCapability.SendVideo)
+    public open fun isVideoCall(call: Call): Boolean =
+        call.hasCapability(OwnCapability.SendVideo)
 
     // Picture in picture (for Video calls)
     /**
@@ -561,6 +617,9 @@ public abstract class StreamCallActivity : ComponentActivity() {
     @CallSuper
     public open fun onCallAction(call: Call, action: CallAction) {
         logger.d { "======-- Action --======\n$action\n================" }
+        val onSuccess = {
+
+        }
         when (action) {
             is LeaveCall -> {
                 leave(call, onSuccessFinish, onErrorFinish)
@@ -609,11 +668,7 @@ public abstract class StreamCallActivity : ComponentActivity() {
         when (event) {
             is CallEndedEvent -> {
                 // In any case finish the activity, the call is done for
-                leave(call, onSuccess = {
-                    finish()
-                }, onError = {
-                    finish()
-                })
+                leave(call, onSuccess = onSuccessFinish, onError = onErrorFinish)
             }
 
             is ParticipantLeftEvent, is CallSessionParticipantLeftEvent -> {
@@ -651,6 +706,35 @@ public abstract class StreamCallActivity : ComponentActivity() {
         // No-op by default
     }
 
+    /**
+     * Called when there has been a new event from the socket.
+     *
+     * @param call the call
+     * @param state the state
+     */
+    @CallSuper
+    @StreamCallActivityDelicateApi
+    public open fun onConnectionEvent(call: Call, state: RealtimeConnection) {
+        when (state) {
+            RealtimeConnection.Disconnected -> {
+                lifecycleScope.launch {
+                    onSuccessFinish.invoke(call)
+                }
+            }
+            is RealtimeConnection.Failed -> {
+                lifecycleScope.launch {
+                    val conn = state as? RealtimeConnection.Failed
+                    val throwable = Exception("${conn?.error}")
+                    logger.e(throwable) { "Call connection failed." }
+                    onErrorFinish.invoke(throwable)
+                }
+            }
+            else -> {
+                // No-op
+            }
+        }
+    }
+
     // Internal logic
     private fun initializeCallOrFail(
         savedInstanceState: Bundle?,
@@ -676,9 +760,14 @@ public abstract class StreamCallActivity : ComponentActivity() {
             cid,
             onSuccess = { call ->
                 cachedCall = call
-                subscription?.dispose()
-                subscription = cachedCall.subscribe { event ->
+                callEventSubscription?.dispose()
+                callEventSubscription = cachedCall.subscribe { event ->
                     onCallEvent(cachedCall, event)
+                }
+                callSocketConnectionMonitor = lifecycleScope.launch(Dispatchers.IO) {
+                    cachedCall.state.connection.collectLatest {
+                        onConnectionEvent(call, it)
+                    }
                 }
                 onSuccess?.invoke(
                     savedInstanceState,

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -90,7 +90,7 @@ public abstract class StreamCallActivity : ComponentActivity() {
             leaveWhenLastInCall: Boolean = DEFAULT_LEAVE_WHEN_LAST,
             action: String? = null,
             clazz: Class<T>,
-            configuration: StreamCallActivityConfiguration = StreamCallActivityConfiguration()
+            configuration: StreamCallActivityConfiguration = StreamCallActivityConfiguration(),
         ): Intent {
             return Intent(context, clazz).apply {
                 // Setup the outgoing call action
@@ -618,7 +618,6 @@ public abstract class StreamCallActivity : ComponentActivity() {
     public open fun onCallAction(call: Call, action: CallAction) {
         logger.d { "======-- Action --======\n$action\n================" }
         val onSuccess = {
-
         }
         when (action) {
             is LeaveCall -> {

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivityConfiguration.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivityConfiguration.kt
@@ -1,0 +1,53 @@
+package io.getstream.video.android.ui.common
+
+import android.os.Bundle
+
+
+internal object StreamCallActivityConfigStrings {
+    const val EXTRA_STREAM_CONFIG = "stream-activity-config"
+    const val EXTRA_CLOSE_ON_ERROR = "close-on-error"
+    const val EXTRA_CLOSE_ON_ENDED = "close-on-ended"
+    const val EXTRA_CUSTOM = "custom-fields"
+}
+
+/**
+ * A configuration that controls various behaviors of the [StreamCallActivity].
+ */
+public data class StreamCallActivityConfiguration(
+    /** When there has been a technical error, close the screen. */
+    val closeScreenOnError: Boolean = true,
+    /** When the call has ended for any reason, close the screen */
+    val closeScreenOnCallEnded: Boolean = true,
+    /**
+     * Custom configuration extension for any extending classes.
+     * Can be used same as normal extras.
+     */
+    val custom: Bundle? = null
+)
+
+/**
+ * Extract a [StreamCallActivityConfigStrings] from bundle.
+ */
+public fun Bundle.extractStreamActivityConfig(): StreamCallActivityConfiguration {
+    val closeScreenOnError =
+        getBoolean(StreamCallActivityConfigStrings.EXTRA_CLOSE_ON_ERROR, true)
+    val closeScreenOnCallEnded =
+        getBoolean(StreamCallActivityConfigStrings.EXTRA_CLOSE_ON_ENDED, true)
+    val custom = getBundle(StreamCallActivityConfigStrings.EXTRA_CUSTOM)
+    return StreamCallActivityConfiguration(
+        closeScreenOnError = closeScreenOnError,
+        closeScreenOnCallEnded = closeScreenOnCallEnded,
+        custom = custom
+    )
+}
+
+/**
+ * Add a [StreamCallActivityConfiguration] into a bundle.
+ */
+public fun StreamCallActivityConfiguration.toBundle(): Bundle {
+    val bundle = Bundle()
+    bundle.putBoolean(StreamCallActivityConfigStrings.EXTRA_CLOSE_ON_ERROR, closeScreenOnError)
+    bundle.putBoolean(StreamCallActivityConfigStrings.EXTRA_CLOSE_ON_ENDED, closeScreenOnCallEnded)
+    bundle.putBundle(StreamCallActivityConfigStrings.EXTRA_CUSTOM, custom)
+    return bundle
+}

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivityConfiguration.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivityConfiguration.kt
@@ -1,7 +1,22 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.video.android.ui.common
 
 import android.os.Bundle
-
 
 internal object StreamCallActivityConfigStrings {
     const val EXTRA_STREAM_CONFIG = "stream-activity-config"
@@ -22,7 +37,7 @@ public data class StreamCallActivityConfiguration(
      * Custom configuration extension for any extending classes.
      * Can be used same as normal extras.
      */
-    val custom: Bundle? = null
+    val custom: Bundle? = null,
 )
 
 /**
@@ -37,7 +52,7 @@ public fun Bundle.extractStreamActivityConfig(): StreamCallActivityConfiguration
     return StreamCallActivityConfiguration(
         closeScreenOnError = closeScreenOnError,
         closeScreenOnCallEnded = closeScreenOnCallEnded,
-        custom = custom
+        custom = custom,
     )
 }
 

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/StreamCallActivityDelicateApi.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/StreamCallActivityDelicateApi.kt
@@ -21,7 +21,9 @@ package io.getstream.video.android.ui.common.util
 @Target(
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.FIELD,
     AnnotationTarget.PROPERTY_SETTER,
+    AnnotationTarget.PROPERTY,
 )
 @RequiresOptIn(
     level = RequiresOptIn.Level.WARNING,


### PR DESCRIPTION
This PR adds support for configuring the `StreamCallActivity` with some boolean flags. Also extracts a `compose` interface for more flexibility when overriding. Additionally it exposes the `Idle` and `unknown` states under a callback in `RingingCallContent`