### PR TITLE
Handle incoming call accept in "same user on multiple devices & incoming call activity" scenario

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -1016,7 +1016,6 @@ public class Call(
 
     suspend fun accept(): Result<AcceptCallResponse> {
         state.acceptedOnThisDevice = true
-        logger.d { "[accept] acceptedOnThisDevice: ${state.acceptedOnThisDevice}" }
 
         clientImpl.state.removeRingingCall()
         clientImpl.state.maybeStopForegroundService()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -1015,6 +1015,9 @@ public class Call(
     }
 
     suspend fun accept(): Result<AcceptCallResponse> {
+        state.acceptedOnThisDevice = true
+        logger.d { "[accept] acceptedOnThisDevice: ${state.acceptedOnThisDevice}" }
+
         clientImpl.state.removeRingingCall()
         clientImpl.state.maybeStopForegroundService()
         return clientImpl.accept(type, id)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -557,10 +557,6 @@ public class CallState(
 
     internal var acceptedOnThisDevice: Boolean = false
 
-    init {
-        logger.d { "[init] acceptedOnThisDevice: $acceptedOnThisDevice" }
-    }
-
     fun handleEvent(event: VideoEvent) {
         logger.d { "Updating call state with event ${event::class.java}" }
         when (event) {
@@ -603,7 +599,6 @@ public class CallState(
                 } else if (callRingState is RingingState.Incoming && event.user.id == client.userId) {
                     // Call accepted by me + this device is Incoming => I accepted on another device
                     // Then leave the call on this device
-                    logger.d { "[CallAcceptedEvent] acceptedOnThisDevice: $acceptedOnThisDevice" }
                     if (!acceptedOnThisDevice) call.leave()
                 }
             }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -555,6 +555,12 @@ public class CallState(
     private var autoJoiningCall: Job? = null
     private var ringingTimerJob: Job? = null
 
+    internal var acceptedOnThisDevice: Boolean = false
+
+    init {
+        logger.d { "[init] acceptedOnThisDevice: $acceptedOnThisDevice" }
+    }
+
     fun handleEvent(event: VideoEvent) {
         logger.d { "Updating call state with event ${event::class.java}" }
         when (event) {
@@ -594,6 +600,9 @@ public class CallState(
                         call.join()
                         autoJoiningCall = null
                     }
+                } else if (callRingState is RingingState.Incoming) {
+                    logger.d { "[CallAcceptedEvent] acceptedOnThisDevice: $acceptedOnThisDevice" }
+                    if (!acceptedOnThisDevice) call.leave()
                 }
             }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -600,7 +600,9 @@ public class CallState(
                         call.join()
                         autoJoiningCall = null
                     }
-                } else if (callRingState is RingingState.Incoming) {
+                } else if (callRingState is RingingState.Incoming && event.user.id == client.userId) {
+                    // Call accepted by me + this device is Incoming => I accepted on another device
+                    // Then leave the call on this device
                     logger.d { "[CallAcceptedEvent] acceptedOnThisDevice: $acceptedOnThisDevice" }
                     if (!acceptedOnThisDevice) call.leave()
                 }


### PR DESCRIPTION
### 🎯 Goal

User is logged in on multiple devices; incoming call is received; incoming call activity is visible (not the notification). When the call is accepted on one of the ringing devices, the incoming call activity incorrectly switches to an Active state on the other devices as well, but actually it should finish and the call should not be accepted.

### 🛠 Implementation details

- Added an internal `acceptedOnThisDevice` boolean flag in `CallState`
- Set this flag to `true` when calling `call.accept()`
- Added a check in `CallState.handleEvent()` that calls `call.leave()` when this condition is met: _call accepted by me + this device is Incoming => I accepted on another device_
- Checked when the flag is cleared: the call is removed from the client's call map in `StreamVideoImpl.onCallCleanUp()`, which is called in `call.leave()`. A new `CallState` is instantiated when a new `Call` is created, so the flag is initialized to `false`.

### 🧪 Testing

Use the Audio Call Sample app to call the same user on 2+ receiving devices. Make the _Incoming Call_ activity start by having the app in the foreground or having the receiving devices locked or by tapping on the notification to trigger its `contentIntent`. Then accept on one of the devices. The others should finish the activity and no call should be active.