### PR TITLE
Allow null User fields

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
@@ -237,7 +237,7 @@ private fun CallJoinHeader(
         Text(
             modifier = Modifier.weight(1f),
             color = Color.White,
-            text = user?.name?.ifBlank { user?.id }?.ifBlank { user!!.custom["email"] }.orEmpty(),
+            text = user?.userNameOrId ?: "",
             maxLines = 1,
             fontSize = 16.sp,
         )

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
@@ -237,7 +237,7 @@ private fun CallJoinHeader(
         Text(
             modifier = Modifier.weight(1f),
             color = Color.White,
-            text = user?.userNameOrId ?: "",
+            text = user?.userNameOrId.orEmpty(),
             maxLines = 1,
             fontSize = 16.sp,
         )

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/login/LoginScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/login/LoginScreen.kt
@@ -426,7 +426,7 @@ private fun BuiltInUsersLoginDialog(
                         Spacer(modifier = Modifier.width(16.dp))
                         Text(
                             modifier = Modifier.align(Alignment.CenterVertically),
-                            text = user.name,
+                            text = user.name.orEmpty(),
                             color = VideoTheme.colors.basePrimary,
                             style = VideoTheme.typography.subtitleS,
                         )

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/outgoing/DirectCallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/outgoing/DirectCallJoinScreen.kt
@@ -215,7 +215,7 @@ private fun UserList(entries: List<UserUiState>, onUserClick: (Int) -> Unit) {
             with(entries[index]) {
                 UserRow(
                     index = index,
-                    name = user.name,
+                    name = user.name.orEmpty(),
                     avatarUrl = user.image,
                     isSelected = isSelected,
                     onClick = { onUserClick(index) },

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/outgoing/DirectCallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/outgoing/DirectCallJoinScreen.kt
@@ -107,7 +107,7 @@ private fun Header(user: User?) {
             Text(
                 modifier = Modifier.weight(1f),
                 color = Color.White,
-                text = user?.name?.ifBlank { user.id }?.ifBlank { user.custom["email"] }.orEmpty(),
+                text = user?.userNameOrId ?: "",
                 maxLines = 1,
                 fontSize = 16.sp,
             )

--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
@@ -168,8 +168,8 @@ object StreamVideoInitHelper {
 
         val chatUser = io.getstream.chat.android.models.User(
             id = user.id,
-            name = user.name ?: "",
-            image = user.image ?: "",
+            name = user.name.orEmpty(),
+            image = user.image.orEmpty(),
         )
 
         chatClient.connectUser(

--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
@@ -168,8 +168,8 @@ object StreamVideoInitHelper {
 
         val chatUser = io.getstream.chat.android.models.User(
             id = user.id,
-            name = user.name,
-            image = user.image,
+            name = user.name ?: "",
+            image = user.image ?: "",
         )
 
         chatClient.connectUser(
@@ -199,7 +199,7 @@ object StreamVideoInitHelper {
                 ),
             ),
             tokenProvider = {
-                val email = user.custom["email"]
+                val email = user.custom?.get("email")
                 val authData = StreamService.instance.getAuthData(
                     environment = AppConfig.currentEnvironment.value!!.env,
                     userId = email,

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -3646,6 +3646,7 @@ public final class io/getstream/video/android/core/model/CallStatus$Outgoing : i
 
 public final class io/getstream/video/android/core/model/CallUser : java/io/Serializable {
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/video/android/core/model/CallUserState;Ljava/util/Date;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/video/android/core/model/CallUserState;Ljava/util/Date;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -123,7 +123,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             )
         }
 
-        if (user.role.isEmpty()) {
+        if (user.role.isNullOrBlank()) {
             user = user.copy(role = "user")
         }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -461,9 +461,9 @@ internal class StreamVideoImpl internal constructor(
             val response = createGuestUser(
                 userRequest = UserRequest(
                     id = user.id,
-                    image = user.image.takeUnless { it.isBlank() },
-                    name = user.name.takeUnless { it.isBlank() },
-                    custom = user.custom.takeUnless { it.isEmpty() },
+                    image = user.image,
+                    name = user.name,
+                    custom = user.custom,
                 ),
             )
             if (response.isFailure) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/VideoModel.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/VideoModel.kt
@@ -27,10 +27,10 @@ import java.util.Date
 @Stable
 public data class CallUser(
     val id: String,
-    val name: String,
-    val role: String,
-    val imageUrl: String,
-    val teams: List<String>,
+    val name: String? = null,
+    val role: String? = null,
+    val imageUrl: String? = null,
+    val teams: List<String>? = null,
     val state: CallUserState?,
     val createdAt: Date?,
     val updatedAt: Date?,
@@ -133,13 +133,13 @@ public infix fun CallUser.merge(that: CallUser?): CallUser = when (that) {
     null -> this
     else -> copy(
         id = that.id.ifEmpty { this.id },
-        name = that.name.ifEmpty { this.name },
-        role = that.role.ifEmpty { this.role },
-        imageUrl = that.imageUrl.ifEmpty { this.imageUrl },
+        name = that.name.takeUnless { it.isNullOrBlank() } ?: this.name,
+        role = that.role.takeUnless { it.isNullOrBlank() } ?: this.role,
+        imageUrl = that.imageUrl.takeUnless { it.isNullOrBlank() } ?: this.imageUrl,
         state = that.state merge this.state,
         createdAt = that.createdAt ?: this.createdAt,
         updatedAt = that.updatedAt ?: this.updatedAt,
-        teams = (that.teams + this.teams).distinct(),
+        teams = (that.teams.orEmpty() + this.teams.orEmpty()).distinct(),
     )
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -68,9 +68,9 @@ public class CoordinatorSocket(
             token = token,
             userDetails = ConnectUserDetailsRequest(
                 id = user.id,
-                name = user.name.takeUnless { it.isBlank() },
-                image = user.image.takeUnless { it.isBlank() },
-                custom = user.custom.takeUnless { it.isEmpty() },
+                name = user.name,
+                image = user.image,
+                custom = user.custom,
             ),
         )
         val message = adapter.toJson(authRequest)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -20,6 +20,7 @@ import com.squareup.moshi.JsonAdapter
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
+import io.getstream.video.android.core.utils.isWhitespaceOnly
 import io.getstream.video.android.model.User
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -68,8 +69,8 @@ public class CoordinatorSocket(
             token = token,
             userDetails = ConnectUserDetailsRequest(
                 id = user.id,
-                name = user.name,
-                image = user.image,
+                name = user.name.takeUnless { it.isWhitespaceOnly() },
+                image = user.image.takeUnless { it.isWhitespaceOnly() },
                 custom = user.custom,
             ),
         )

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/DomainUtils.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/DomainUtils.kt
@@ -94,8 +94,8 @@ internal fun UserResponse.toUser(): User {
     return User(
         id = id,
         role = role,
-        name = name ?: "",
-        image = image ?: "",
+        name = name,
+        image = image,
         teams = teams,
         custom = custom.mapValues { it.value.toString() },
     )
@@ -182,4 +182,4 @@ internal fun EdgeResponse.toEdge(): EdgeData {
 
 @JvmSynthetic
 @InternalStreamVideoApi
-fun CallUser.getNameOrId(): String = name.ifEmpty { id }
+fun CallUser.getNameOrId(): String = name.takeUnless { it.isNullOrBlank() } ?: id

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/StringUtils.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/StringUtils.kt
@@ -28,3 +28,7 @@ internal fun StreamPeerType.stringify() = when (this) {
     StreamPeerType.PUBLISHER -> "publisher"
     StreamPeerType.SUBSCRIBER -> "subscriber"
 }
+
+internal fun String?.isWhitespaceOnly(): Boolean {
+    return !this.isNullOrEmpty() && this.all { it.isWhitespace() }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/UserUtils.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/UserUtils.kt
@@ -23,11 +23,11 @@ import org.threeten.bp.OffsetDateTime
 internal fun User.toResponse(): UserResponse {
     return UserResponse(
         id = id,
-        role = role,
+        role = role ?: "user",
         name = name,
         image = image,
-        teams = teams,
-        custom = custom,
+        teams = teams ?: emptyList(),
+        custom = custom ?: emptyMap(),
         createdAt = createdAt ?: OffsetDateTime.now(),
         updatedAt = updatedAt ?: OffsetDateTime.now(),
         deletedAt = deletedAt,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/model/User.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/model/User.kt
@@ -70,12 +70,12 @@ public object OffsetDateTimeSerializer : KSerializer<OffsetDateTime> {
 public data class User(
     /** ID is required, the rest is optional */
     val id: String = "",
-    val role: String = "user",
+    val role: String? = null,
     val type: UserType = UserType.Authenticated,
-    val name: String = "",
-    val image: String = "",
-    val teams: List<String> = emptyList(),
-    val custom: Map<String, String> = emptyMap(),
+    val name: String? = null,
+    val image: String? = null,
+    val teams: List<String>? = null,
+    val custom: Map<String, String>? = null,
     @Serializable(with = OffsetDateTimeSerializer::class)
     val createdAt: OffsetDateTime? = null,
     @Serializable(with = OffsetDateTimeSerializer::class)
@@ -88,7 +88,7 @@ public data class User(
     }
 
     public val userNameOrId: String
-        inline get() = name.ifEmpty { id }
+        inline get() = name.takeUnless { it.isNullOrBlank() } ?: id
 
     companion object {
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/model/User.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/model/User.kt
@@ -70,12 +70,12 @@ public object OffsetDateTimeSerializer : KSerializer<OffsetDateTime> {
 public data class User(
     /** ID is required, the rest is optional */
     val id: String = "",
-    val role: String? = null,
+    val role: String? = "user",
     val type: UserType = UserType.Authenticated,
     val name: String? = null,
     val image: String? = null,
-    val teams: List<String>? = null,
-    val custom: Map<String, String>? = null,
+    val teams: List<String>? = emptyList(),
+    val custom: Map<String, String>? = emptyMap(),
     @Serializable(with = OffsetDateTimeSerializer::class)
     val createdAt: OffsetDateTime? = null,
     @Serializable(with = OffsetDateTimeSerializer::class)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/EventTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/EventTest.kt
@@ -317,11 +317,11 @@ class EventTest : IntegrationTestBase(connectCoordinatorWS = false) {
 private fun io.getstream.video.android.model.User.toUserResponse(): UserResponse {
     return UserResponse(
         id = id,
-        role = role,
-        teams = teams,
+        role = role ?: "user",
+        teams = teams ?: emptyList(),
         image = image,
         name = name,
-        custom = custom,
+        custom = custom ?: emptyMap(),
         createdAt = OffsetDateTime.now(),
         updatedAt = OffsetDateTime.now(),
         deletedAt = OffsetDateTime.now(),

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/avatar/UserAvatarBackground.kt
@@ -103,7 +103,7 @@ private fun UserAvatarBackgroundPreview() {
         UserAvatarBackground(
             modifier = Modifier.fillMaxSize(),
             userImage = user.image,
-            userName = user.name.ifBlank { user.id },
+            userName = user.name.takeUnless { it.isNullOrBlank() } ?: user.id,
             previewModePlaceholder = R.drawable.stream_video_call_sample,
         )
     }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
@@ -206,7 +206,7 @@ private fun OnDisabledContent(user: User) {
                 .size(VideoTheme.dimens.genericMax)
                 .align(Alignment.Center),
             userImage = user.image,
-            userName = user.name.ifBlank { user.id },
+            userName = user.name.takeUnless { it.isNullOrBlank() } ?: user.id,
         )
     }
 }

--- a/stream-video-android-ui-xml/src/main/kotlin/io/getstream/video/android/xml/widget/avatar/AvatarView.kt
+++ b/stream-video-android-ui-xml/src/main/kotlin/io/getstream/video/android/xml/widget/avatar/AvatarView.kt
@@ -86,7 +86,7 @@ public class AvatarView : ShapeableImageView {
             data = user.imageUrl,
             placeholderDrawable = AvatarPlaceholderDrawable(
                 context = context,
-                initials = user.name.ifEmpty { user.id }.initials(),
+                initials = (user.name.takeUnless { it.isNullOrBlank() } ?: user.id).initials(),
                 initialsTextStyle = avatarStyle.avatarInitialsTextStyle,
             ),
         )


### PR DESCRIPTION
### 🎯 Goal

Made some of `User` fields nullable and `null` by default.

In `CoordinatorSocket.authenticate()` we pass:
- `null` if we don't want the field's value to change
- `""` or `emptyMap()` or `emptyList()` if we want to reset the field
- a `value` if we want to set the field
- `null` if the field is blank (whitespace)

### 🧪 Testing

❗ Needs testing