### PR TITLE
[PBE-2772] Support multiple call notifications in CallService

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -710,6 +710,7 @@ public final class io/getstream/video/android/core/RingingState$Outgoing : io/ge
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAcceptedByCallee ()Z
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/getstream/video/android/core/RingingState$RejectedByAll : io/getstream/video/android/core/RingingState {

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4085,7 +4085,7 @@ public class io/getstream/video/android/core/notifications/DefaultNotificationHa
 	public final fun getHideRingingNotificationInForeground ()Z
 	public final fun getNotificationIconRes ()I
 	public fun getOngoingCallNotification (Ljava/lang/String;Lio/getstream/video/android/model/StreamCallId;)Landroid/app/Notification;
-	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
+	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
 	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
 	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
 	public fun onPermissionDenied ()V
@@ -4132,7 +4132,8 @@ public abstract interface class io/getstream/video/android/core/notifications/No
 	public static final field INTENT_EXTRA_CALL_DISPLAY_NAME Ljava/lang/String;
 	public static final field INTENT_EXTRA_NOTIFICATION_ID Ljava/lang/String;
 	public abstract fun getOngoingCallNotification (Ljava/lang/String;Lio/getstream/video/android/model/StreamCallId;)Landroid/app/Notification;
-	public abstract fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
+	public abstract fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
+	public static synthetic fun getRingingCallNotification$default (Lio/getstream/video/android/core/notifications/NotificationHandler;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/lang/Object;)Landroid/app/Notification;
 	public abstract fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
 	public abstract fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
 	public abstract fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -710,7 +710,6 @@ public final class io/getstream/video/android/core/RingingState$Outgoing : io/ge
 	public fun <init> (Z)V
 	public synthetic fun <init> (ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAcceptedByCallee ()Z
-	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/getstream/video/android/core/RingingState$RejectedByAll : io/getstream/video/android/core/RingingState {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -25,6 +25,7 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import androidx.annotation.DrawableRes
 import androidx.core.app.NotificationChannelCompat
 import androidx.core.app.NotificationCompat
@@ -84,14 +85,8 @@ public open class DefaultNotificationHandler(
     }
 
     override fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
-        val serviceIntent = CallService.buildStartIntent(
-            this.application,
-            callId,
-            CallService.TRIGGER_INCOMING_CALL,
-            callDisplayName,
-        )
-//        ContextCompat.startForegroundService(application.applicationContext, serviceIntent)
-        application.startService(serviceIntent)
+        Log.d("ServiceDebug", "[onRingingCall] callId: ${callId.id}")
+        CallService.showIncomingCall(application, callId, callDisplayName)
     }
 
     override fun getRingingCallNotification(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -31,7 +31,6 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationCompat.CallStyle
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.app.Person
-import androidx.core.content.ContextCompat
 import io.getstream.android.push.permissions.DefaultNotificationPermissionHandler
 import io.getstream.android.push.permissions.NotificationPermissionHandler
 import io.getstream.log.TaggedLogger
@@ -91,7 +90,8 @@ public open class DefaultNotificationHandler(
             CallService.TRIGGER_INCOMING_CALL,
             callDisplayName,
         )
-        ContextCompat.startForegroundService(application.applicationContext, serviceIntent)
+//        ContextCompat.startForegroundService(application.applicationContext, serviceIntent)
+        application.startService(serviceIntent)
     }
 
     override fun getRingingCallNotification(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -24,6 +24,7 @@ import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
+import android.content.Intent
 import android.os.Build
 import android.util.Log
 import androidx.annotation.DrawableRes
@@ -93,6 +94,7 @@ public open class DefaultNotificationHandler(
         ringingState: RingingState,
         callId: StreamCallId,
         callDisplayName: String,
+        shouldHaveContentIntent: Boolean,
     ): Notification? {
         return if (ringingState is RingingState.Incoming) {
             val fullScreenPendingIntent = intentResolver.searchIncomingCallPendingIntent(callId)
@@ -105,6 +107,7 @@ public open class DefaultNotificationHandler(
                     acceptCallPendingIntent,
                     rejectCallPendingIntent,
                     callDisplayName,
+                    shouldHaveContentIntent,
                 )
             } else {
                 logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -134,6 +137,7 @@ public open class DefaultNotificationHandler(
         acceptCallPendingIntent: PendingIntent,
         rejectCallPendingIntent: PendingIntent,
         callDisplayName: String,
+        shouldHaveContentIntent: Boolean,
     ): Notification {
         // if the app is in foreground then don't interrupt the user with a high priority
         // notification (popup). The application will display an incoming ringing call
@@ -177,9 +181,20 @@ public open class DefaultNotificationHandler(
             setContentText(callDisplayName)
             setChannelId(channelId)
             setOngoing(false)
-            setContentIntent(fullScreenPendingIntent)
-            setFullScreenIntent(fullScreenPendingIntent, true)
             setCategory(NotificationCompat.CATEGORY_CALL)
+            setFullScreenIntent(fullScreenPendingIntent, true)
+            if (shouldHaveContentIntent) {
+                setContentIntent(fullScreenPendingIntent)
+            } else {
+                val emptyIntent = PendingIntent.getActivity(
+                    application,
+                    0,
+                    Intent(),
+                    PendingIntent.FLAG_IMMUTABLE,
+                )
+                setContentIntent(emptyIntent)
+                setAutoCancel(false)
+            }
             addCallActions(acceptCallPendingIntent, rejectCallPendingIntent, callDisplayName)
         }
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationHandler.kt
@@ -30,6 +30,7 @@ public interface NotificationHandler : NotificationPermissionHandler {
         ringingState: RingingState,
         callId: StreamCallId,
         callDisplayName: String,
+        shouldHaveContentIntent: Boolean = true,
     ): Notification?
 
     companion object {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
@@ -33,6 +33,7 @@ internal object NoOpNotificationHandler : NotificationHandler {
         ringingState: RingingState,
         callId: StreamCallId,
         callDisplayName: String,
+        shouldHaveContentIntent: Boolean,
     ): Notification? = null
 
     override fun onPermissionDenied() { /* NoOp */ }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/RejectCallBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/RejectCallBroadcastReceiver.kt
@@ -18,11 +18,10 @@ package io.getstream.video.android.core.notifications.internal.receivers
 
 import android.content.Context
 import android.content.Intent
-import androidx.core.app.NotificationManagerCompat
+import android.util.Log
 import io.getstream.log.taggedLogger
 import io.getstream.result.Result
 import io.getstream.video.android.core.Call
-import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_REJECT_CALL
 import io.getstream.video.android.core.notifications.internal.service.CallService
 import io.getstream.video.android.model.StreamCallId
@@ -42,13 +41,7 @@ internal class RejectCallBroadcastReceiver : GenericCallActionBroadcastReceiver(
             is Result.Success -> logger.d { "[onReceive] rejectCall, Success: $rejectResult" }
             is Result.Failure -> logger.d { "[onReceive] rejectCall, Failure: $rejectResult" }
         }
-        val serviceIntent = CallService.buildStopIntent(context)
-//        context.stopService(serviceIntent)
-        CallService.removeCall(context, StreamCallId.fromCallCid(call.cid))
-
-        // As a second precaution cancel also the notification
-        NotificationManagerCompat.from(
-            context,
-        ).cancel(NotificationHandler.INCOMING_CALL_NOTIFICATION_ID)
+        Log.d("ServiceDebug", "[reject onReceive] callId: ${call.id}")
+        CallService.removeIncomingCall(context, StreamCallId.fromCallCid(call.cid))
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/RejectCallBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/RejectCallBroadcastReceiver.kt
@@ -25,6 +25,7 @@ import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_REJECT_CALL
 import io.getstream.video.android.core.notifications.internal.service.CallService
+import io.getstream.video.android.model.StreamCallId
 
 /**
  * Used to process any pending intents that feature the [ACTION_REJECT_CALL] action. By consuming this
@@ -42,7 +43,8 @@ internal class RejectCallBroadcastReceiver : GenericCallActionBroadcastReceiver(
             is Result.Failure -> logger.d { "[onReceive] rejectCall, Failure: $rejectResult" }
         }
         val serviceIntent = CallService.buildStopIntent(context)
-        context.stopService(serviceIntent)
+//        context.stopService(serviceIntent)
+        CallService.removeCall(context, StreamCallId.fromCallCid(call.cid))
 
         // As a second precaution cancel also the notification
         NotificationManagerCompat.from(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -256,6 +256,7 @@ internal class CallService : Service() {
                         ringingState = RingingState.Incoming(),
                         callId = intentCallId,
                         callDisplayName = intentCallDisplayName!!,
+                        shouldHaveContentIntent = streamVideo.state.activeCall.value == null,
                     ),
                     second = INCOMING_CALL_NOTIFICATION_ID,
                 )


### PR DESCRIPTION
### 🎯 Goal

Currently a new incoming call would dismiss the ongoing call notification. We should be able to accept or decline another call without losing the “ongoing call” notification.