### PR TITLE
[PBE-3709] Assign correct value to ingress RTMP streamKey

### DIFF
--- a/stream-video-android-core/src/androidTest/kotlin/io/getstream/video/android/core/LivestreamTest.kt
+++ b/stream-video-android-core/src/androidTest/kotlin/io/getstream/video/android/core/LivestreamTest.kt
@@ -74,8 +74,12 @@ class LivestreamTest : IntegrationTestBase() {
         assertSuccess(response)
 
         val rtmp = call.state.ingress.value?.rtmp
+        println("client token: ${clientImpl.token}")
         println("rtmp address: ${rtmp?.address}")
         println("rtmp streamKey: ${rtmp?.streamKey}")
+
+        // streamKey should be just the token, not apiKey/token
+        assertThat(rtmp?.streamKey?.equals(clientImpl.token)).isTrue()
     }
 
     @Test

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -527,7 +527,7 @@ public class CallState(
         if (it != null) {
             val token = call.clientImpl.token
             val apiKey = call.clientImpl.apiKey
-            Ingress(rtmp = RTMP(address = it.rtmp.address, streamKey = "$apiKey/$token"))
+            Ingress(rtmp = RTMP(address = it.rtmp.address, streamKey = token))
         } else {
             null
         }


### PR DESCRIPTION
### 🎯 Goal

Change format for Egress RTMP StreamKey from _apiKey/token_ to just _token_.

### 🛠 Implementation details

Modify assignment in `CallState.ingress` flow and modify test.