### PR TITLE
Allow for comparator to be updated in the `SortedParticipantState`

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -174,6 +174,7 @@ public final class io/getstream/video/android/core/CallState {
 	public final fun updateFromResponse (Lorg/openapitools/client/models/StopLiveResponse;)V
 	public final fun updateFromResponse (Lorg/openapitools/client/models/UpdateCallResponse;)V
 	public final fun updateParticipant (Lio/getstream/video/android/core/ParticipantState;)V
+	public final fun updateParticipantSortingOrder (Ljava/util/Comparator;)V
 	public final fun updateParticipantVisibility (Ljava/lang/String;Lio/getstream/video/android/core/model/VisibilityOnScreenState;)V
 	public final fun updateParticipantVisibilityFlow (Lkotlinx/coroutines/flow/Flow;)V
 	public final fun upsertParticipants (Ljava/util/List;)V

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sorting/SortedParticipantsState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sorting/SortedParticipantsState.kt
@@ -136,4 +136,11 @@ internal class SortedParticipantsState(
      * Get last sorted participants.
      */
     fun lastSortOrder() = lastSortOrder
+
+    /**
+     * Update the sorter with a new comparator.
+     */
+    fun updateComparator(comparator: Comparator<ParticipantState>) {
+        this.comparator = comparator
+    }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallStateTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallStateTest.kt
@@ -171,6 +171,35 @@ class CallStateTest : IntegrationTestBase() {
     }
 
     @Test
+    fun `Update sorting order`() = runTest {
+        val call = client.call("default", randomUUID())
+        val sortedParticipants = call.state.sortedParticipants.stateIn(
+            this,
+            SharingStarted.Eagerly,
+            emptyList(),
+        )
+        call.state.updateParticipantSortingOrder(
+            compareByDescending {
+                it.sessionId
+            },
+        )
+
+        call.state.updateParticipant(
+            ParticipantState("1", call, "1"),
+        )
+        call.state.updateParticipant(
+            ParticipantState("2", call, "2").apply { _screenSharingEnabled.value = true },
+        )
+        call.state.updateParticipant(
+            ParticipantState("3", call, "3").apply { _dominantSpeaker.value = true },
+        )
+
+        delay(1000)
+        val sorted = sortedParticipants.value.map { it.sessionId }
+        assertThat(sorted).isEqualTo(listOf("3", "2", "1"))
+    }
+
+    @Test
     fun `Querying calls should populate the state`() = runTest {
 //        val createResult = client.call("default", randomUUID()).create(custom=mapOf("color" to "green"))
 //        assertSuccess(createResult)


### PR DESCRIPTION
This PR exposes an API where the `SortedParticipantState` can receive an updated `comparator` used to sort the values.