### PR TITLE
[PBE-3935] Fix RtcSession.connect() indefinite suspend bug

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -75,7 +75,7 @@ public open class PersistentSocket<T>(
     var reconnectTimeout: Long = 500
 
     /** flow with all the events, listen to this */
-    val events = MutableSharedFlow<VideoEvent>()
+    val events = MutableSharedFlow<VideoEvent>(replay = 3)
 
     /** flow with temporary and permanent errors */
     val errors = MutableSharedFlow<Throwable>()


### PR DESCRIPTION
### 🎯 Goal

`RtcSession.connect()` waits for a call join event to be received before establishing the peer connections. Sometimes, it misses the event and it hangs indefinitely, which causes `call.join()` to suspend forever. It should always receive the event and also throw an exception if the event doesn't come in at all.

### 🛠 Implementation details

- Increased the replay value of the `PersistentSocket.events` `SharedFlow` to 3.
- Replaced `joinEventResponse` flow with a `Mutex`, which is more descriptive for the task of synchronizing code execution.
- Added a timeout with a descriptive exception for `RtcSession.connect()`.