### PR TITLE
[PBE-3941] Fix event deserialization issues

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -10063,6 +10063,11 @@ public final class org/openapitools/client/models/UnpinResponse {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/openapitools/client/models/UnsupportedVideoEventException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getType ()Ljava/lang/String;
+}
+
 public final class org/openapitools/client/models/UpdateCallMembersRequest {
 	public fun <init> ()V
 	public fun <init> (Ljava/util/List;Ljava/util/List;)V

--- a/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
@@ -163,7 +163,7 @@ class VideoEventAdapter : JsonAdapter<VideoEvent>() {
             "user.reactivated" -> UserReactivatedEvent::class.java
             "user.unbanned" -> UserUnbannedEvent::class.java
             "user.updated" -> UserUpdatedEvent::class.java
-            else -> UnknownVideoEvent(type)::class.java
+            else -> throw UnsupportedVideoEventException(type)
         }
     }
 }

--- a/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
@@ -168,8 +168,4 @@ class VideoEventAdapter : JsonAdapter<VideoEvent>() {
     }
 }
 
-data class UnknownVideoEvent(
-    @Json(name = "type") val expectedType: String
-) : VideoEvent() {
-    override fun getEventType() = "unknown"
-}
+class UnsupportedVideoEventException(val type: String) : Exception()

--- a/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
@@ -144,13 +144,13 @@ class VideoEventAdapter : JsonAdapter<VideoEvent>() {
             "call.session_participant_joined" -> CallSessionParticipantJoinedEvent::class.java
             "call.session_participant_left" -> CallSessionParticipantLeftEvent::class.java
             "call.session_started" -> CallSessionStartedEvent::class.java
-            "call.transcription_failed" -> CallTranscriptionFailedEvent::class.java
-            "call.transcription_ready" -> CallTranscriptionReadyEvent::class.java
-            "call.transcription_started" -> CallTranscriptionStartedEvent::class.java
-            "call.transcription_stopped" -> CallTranscriptionStoppedEvent::class.java
             "call.unblocked_user" -> UnblockedUserEvent::class.java
             "call.updated" -> CallUpdatedEvent::class.java
             "call.user_muted" -> CallUserMutedEvent::class.java
+            "call.transcription_started" -> CallTranscriptionStartedEvent::class.java
+            "call.transcription_stopped" -> CallTranscriptionStoppedEvent::class.java
+            "call.transcription_ready" -> CallTranscriptionReadyEvent::class.java
+            "call.transcription_failed" -> CallTranscriptionFailedEvent::class.java
             "connection.error" -> ConnectionErrorEvent::class.java
             "connection.ok" -> ConnectedEvent::class.java
             "custom" -> CustomVideoEvent::class.java
@@ -163,7 +163,13 @@ class VideoEventAdapter : JsonAdapter<VideoEvent>() {
             "user.reactivated" -> UserReactivatedEvent::class.java
             "user.unbanned" -> UserUnbannedEvent::class.java
             "user.updated" -> UserUpdatedEvent::class.java
-            else -> throw IllegalArgumentException("Unknown type: $type")
+            else -> UnknownVideoEvent(type)::class.java
         }
     }
+}
+
+data class UnknownVideoEvent(
+    @Json(name = "type") val expectedType: String
+) : VideoEvent() {
+    override fun getEventType() = "unknown"
 }


### PR DESCRIPTION
### 🎯 Goal

Deserialization error is printed in the logs multiple times when a received event could not be mapped with one of our classes. The `CoordinatorSocket.onMessage()` deserialization logic needs to be refactored.

Patreon Zendesk ticket [here](https://getstream.zendesk.com/agent/tickets/50731).

### 🛠 Implementation details

- Added `UnsupportedVideoEventException` to separately handle the "cannot map with class" case.
- Added handling for `ConnectionErrorEvent` and removed `SocketError` handling. We never get a message that can be mapped to `SocketError` with field `error`. ❓ 
- Added transcription event classes.

### 🧪 Testing

- Check `CoordinatorSocket.onMessage()`.
- Run app and follow logs.
- Check OpenAPI [specs](https://github.com/GetStream/protocol/blob/987d88ad275cdd138fb9eb59b741629719ce205b/openapi/video-openapi-clientside.yaml) to confirm that trying to map to `SocketError` is not good. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs