### PR TITLE
[PBE-3993] Fix infinite reconnection calls for CoordinatorSocket

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -366,7 +366,8 @@ public open class PersistentSocket<T>(
     }
 
     internal fun sendHealthCheck() {
-        println("sending health check")
+        logger.d { "sending health check" }
+
         val healthCheckRequest = HealthCheckRequest()
         socket?.send(healthCheckRequest.encodeByteString())
     }
@@ -375,6 +376,7 @@ public open class PersistentSocket<T>(
         object : HealthMonitor.HealthCallback {
             override suspend fun reconnect() {
                 logger.i { "health monitor triggered a reconnect" }
+
                 val state = connectionState.value
                 if (state is SocketState.DisconnectedTemporarily) {
                     this@PersistentSocket.reconnect()
@@ -382,8 +384,10 @@ public open class PersistentSocket<T>(
             }
 
             override fun check() {
-                logger.d { "health monitor ping" }
                 val state = connectionState.value
+
+                logger.d { "health monitor ping. Socket state: $state" }
+
                 (state as? SocketState.Connected)?.let {
                     sendHealthCheck()
                 }


### PR DESCRIPTION
### 🎫 Jira Issue

https://stream-io.atlassian.net/browse/PBE-3993

### 🎯 Goal

Fix problem: Coordinator socket reconnects infinitely after token refresh.

### 🛠 Implementation details

Refresh token when receiving `ConnectionErrorEvent`. `ConnectionErrorEvent` is received in `onMessage` when trying to authenticate with an expired token.

### 🧪 Testing

<details>

<summary>Useful logs</summary>

```
Index: stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt	(revision 591f773b74912ecbc5cfd551979aca37b76f0fe6)
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt	(date 1718208672838)
@@ -17,6 +17,7 @@
 package io.getstream.video.android.core
 
 import android.content.Context
+import android.util.Log
 import androidx.lifecycle.Lifecycle
 import io.getstream.android.push.PushDevice
 import io.getstream.log.taggedLogger
@@ -499,6 +500,8 @@
      */
     internal fun fireEvent(event: VideoEvent, cid: String = "") {
         logger.d { "Event received $event" }
+        Log.i("ReconnectDebug", "Event received $event")
+
         // update state for the client
         state.handleEvent(event)
 
Index: stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt	(revision 591f773b74912ecbc5cfd551979aca37b76f0fe6)
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt	(date 1718208672842)
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.socket
 
+import android.util.Log
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
@@ -189,6 +190,8 @@
      */
     suspend fun reconnect(timeout: Long = reconnectTimeout) {
         logger.i { "[reconnect] reconnectionAttempts: $reconnectionAttempts" }
+        Log.d("ReconnectDebug", "Reconnect. reconnectionAttempts: $reconnectionAttempts")
+
         if (destroyed) {
             logger.d { "[reconnect] Can't reconnect socket - it was already destroyed" }
             return
@@ -248,6 +251,7 @@
 
     private fun createSocket(): WebSocket {
         logger.d { "[createSocket] url: $url" }
+        Log.d("ReconnectDebug", "[createSocket] url: $url")
 
         val request = Request.Builder()
             .url(url)
@@ -362,6 +366,7 @@
      */
     override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
         logger.d { "[onFailure] t: $t, response: $response" }
+        Log.d("ReconnectDebug", "[onFailure] t: $t, response: $response")
         handleError(t)
     }
 
@@ -376,6 +381,7 @@
         object : HealthMonitor.HealthCallback {
             override suspend fun reconnect() {
                 logger.i { "health monitor triggered a reconnect" }
+                Log.d("ReconnectDebug", "Health Monitor Reconnect")
 
                 val state = connectionState.value
                 if (state is SocketState.DisconnectedTemporarily) {
@@ -387,6 +393,7 @@
                 val state = connectionState.value
 
                 logger.d { "health monitor ping. Socket state: $state" }
+                Log.d("ReconnectDebug", "Health Monitor Ping. Socket state: $state")
 
                 (state as? SocketState.Connected)?.let {
                     sendHealthCheck()
```

</details>