### PR TITLE
[PBE-4237] Handle WebSocket connection failure

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -297,6 +297,7 @@ public final class io/getstream/video/android/core/ConnectionState$Disconnected 
 
 public final class io/getstream/video/android/core/ConnectionState$Failed : io/getstream/video/android/core/ConnectionState {
 	public fun <init> (Ljava/lang/Error;)V
+	public final fun getError ()Ljava/lang/Error;
 }
 
 public final class io/getstream/video/android/core/ConnectionState$Loading : io/getstream/video/android/core/ConnectionState {
@@ -824,7 +825,6 @@ public final class io/getstream/video/android/core/StreamVideoBuilder {
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;ZLjava/lang/String;Lio/getstream/video/android/core/sounds/Sounds;ZLio/getstream/video/android/core/permission/android/StreamPermissionCheck;I)V
 	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/video/android/core/GEO;Lio/getstream/video/android/model/User;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/video/android/core/notifications/NotificationConfig;Lkotlin/jvm/functions/Function1;JZLjava/lang/String;ZLjava/lang/String;Lio/getstream/video/android/core/sounds/Sounds;ZLio/getstream/video/android/core/permission/android/StreamPermissionCheck;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Lio/getstream/video/android/core/StreamVideo;
-	public final fun getScope ()Lkotlinx/coroutines/CoroutineScope;
 }
 
 public abstract interface class io/getstream/video/android/core/StreamVideoConfig {
@@ -4295,7 +4295,7 @@ public final class io/getstream/video/android/core/socket/ErrorResponse$Companio
 }
 
 public class io/getstream/video/android/core/socket/PersistentSocket : okhttp3/WebSocketListener {
-	public field connected Lkotlinx/coroutines/CancellableContinuation;
+	public field connectContinuation Lkotlinx/coroutines/CancellableContinuation;
 	public fun <init> (Ljava/lang/String;Lokhttp3/OkHttpClient;Lio/getstream/video/android/core/internal/network/NetworkStateProvider;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ljava/lang/String;Lokhttp3/OkHttpClient;Lio/getstream/video/android/core/internal/network/NetworkStateProvider;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun ackHealthMonitor ()V
@@ -4304,7 +4304,7 @@ public class io/getstream/video/android/core/socket/PersistentSocket : okhttp3/W
 	public fun connect (Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun connect$default (Lio/getstream/video/android/core/socket/PersistentSocket;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun disconnect (Lio/getstream/video/android/core/socket/PersistentSocket$DisconnectReason;)V
-	public final fun getConnected ()Lkotlinx/coroutines/CancellableContinuation;
+	public final fun getConnectContinuation ()Lkotlinx/coroutines/CancellableContinuation;
 	public final fun getConnectionId ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;
 	protected final fun getDestroyed ()Z
@@ -4319,7 +4319,7 @@ public class io/getstream/video/android/core/socket/PersistentSocket : okhttp3/W
 	public fun onOpen (Lokhttp3/WebSocket;Lokhttp3/Response;)V
 	public final fun reconnect (JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun reconnect$default (Lio/getstream/video/android/core/socket/PersistentSocket;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun setConnected (Lkotlinx/coroutines/CancellableContinuation;)V
+	public final fun setConnectContinuation (Lkotlinx/coroutines/CancellableContinuation;)V
 	protected final fun setConnectedStateAndContinue (Lorg/openapitools/client/models/VideoEvent;)V
 	protected final fun setDestroyed (Z)V
 	public final fun setReconnectTimeout (J)V

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -202,22 +202,16 @@ public class StreamVideoBuilder @JvmOverloads constructor(
         // Establish a WS connection with the coordinator (we don't support this for anonymous users)
         if (user.type != UserType.Anonymous) {
             scope.launch {
-                val createConnectionFailedException = { cause: String ->
-                    ConnectException("Failed to establish a WebSocket connection: $cause")
-                }
-
                 try {
                     val result = client.connectAsync().await()
                     result.onSuccess {
                         streamLog { "Connection succeeded! (duration: ${result.getOrNull()})" }
                     }.onError {
                         streamLog { it.message }
-                        throw createConnectionFailedException(it.message)
                     }
                 } catch (e: Exception) {
-                    // If the connect continuation was resumed with an exception, handle it here.
+                    // If the connect continuation was resumed with an exception, we catch it here.
                     streamLog { e.message.orEmpty() }
-                    throw createConnectionFailedException(e.message.orEmpty())
                 }
             }
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -100,8 +100,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
     private val audioUsage: Int = defaultAudioUsage,
 ) {
     private val context: Context = context.applicationContext
-
-    val scope = CoroutineScope(DispatcherProvider.IO)
+    private val scope = CoroutineScope(DispatcherProvider.IO)
 
     /**
      * Builds the [StreamVideo] client.
@@ -144,11 +143,11 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             user = user.copy(role = "user")
         }
 
-        /** initialize Stream internal loggers. */
+        // Initialize Stream internal loggers
         StreamLog.install(AndroidStreamLogger())
         StreamLog.setValidator { priority, _ -> priority.level >= loggingLevel.priority.level }
 
-        /** android JSR-310 backport backport. */
+        // Android JSR-310 backport backport
         AndroidThreeTen.init(context)
 
         // This connection module class exposes the connections to the various retrofit APIs.
@@ -165,7 +164,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
 
         val deviceTokenStorage = DeviceTokenStorage(context)
 
-        // install the StreamNotificationManager to configure push notifications.
+        // Install the StreamNotificationManager to configure push notifications.
         val streamNotificationManager = StreamNotificationManager.install(
             context = context,
             scope = scope,
@@ -174,7 +173,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             deviceTokenStorage = deviceTokenStorage,
         )
 
-        // create the client
+        // Create the client
         val client = StreamVideoImpl(
             context = context,
             _scope = scope,
@@ -200,7 +199,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             connectionModule.updateAuthType("anonymous")
         }
 
-        // establish a ws connection with the coordinator (we don't support this for anonymous users)
+        // Establish a WS connection with the coordinator (we don't support this for anonymous users)
         if (user.type != UserType.Anonymous) {
             scope.launch {
                 val createConnectionFailedException = { cause: String ->
@@ -223,13 +222,13 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             }
         }
 
-        // see which location is best to connect to
+        // See which location is best to connect to
         scope.launch {
             val location = client.loadLocationAsync().await()
             streamLog { "location initialized: ${location.getOrNull()}" }
         }
 
-        // installs Stream Video instance
+        // Installs Stream Video instance
         StreamVideo.install(client)
 
         // Needs to be started after the client is initialised because the VideoPushDelegate

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -38,6 +38,8 @@ import io.getstream.video.android.model.UserToken
 import io.getstream.video.android.model.UserType
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.lang.RuntimeException
+import java.net.ConnectException
 
 /**
  * The [StreamVideoBuilder] is used to create a new instance of the [StreamVideo] client. This is the
@@ -50,28 +52,32 @@ import kotlinx.coroutines.launch
  *      geo = GEO.GlobalEdgeNetwork,
  *      user = user,
  *      token = token,
- *      loggingLevel = LoggingLevel.BODY
- *  )
+ *      loggingLevel = LoggingLevel.BODY,
+ *      // ...
+ * ).build()
  *```
  *
  * @property context Android [Context] to be used for initializing Android resources.
- * @property apiKey Your Stream API Key, you can find it in the dashboard.
- * @property geo Your GEO routing policy, supports geofencing for privacy concerns.
- * @property user The user object, can be a regular user, guest user or anonymous.
- * @property token The token for this user generated using your API secret on your server.
- * @property tokenProvider If a token is expired, the token provider makes a request to your backend for a new token.
+ * @property apiKey Your Stream API Key. You can find it in the dashboard.
+ * @property geo Your GEO routing policy. Supports geofencing for privacy concerns.
+ * @property user The user object. Can be an authenticated user, guest user or anonymous.
+ * @property token The token for this user, generated using your API secret on your server.
+ * @property tokenProvider Used to make a request to your backend for a new token when the token has expired.
  * @property loggingLevel Represents and wraps the HTTP logging level for our API service.
  * @property notificationConfig The configurations for handling push notification.
  * @property ringNotification Overwrite the default notification logic for incoming calls.
  * @property connectionTimeoutInMs Connection timeout in seconds.
- * @property ensureSingleInstance Verify that only 1 version of the video client exists, prevents integration mistakes.
+ * @property ensureSingleInstance Verify that only 1 version of the video client exists. Prevents integration mistakes.
  * @property videoDomain URL overwrite to allow for testing against a local instance of video.
  * @property runForegroundServiceForCalls If set to true, when there is an active call the SDK will run a foreground service to keep the process alive. (default: true)
  * @property localSfuAddress Local SFU address (IP:port) to be used for testing. Leave null if not needed.
  * @property sounds Overwrite the default SDK sounds. See [Sounds].
- * @property crashOnMissingPermission if [permissionCheck] returns false there will be an exception.
- * @property permissionCheck used to check for system permission based on call capabilities. See [StreamPermissionCheck].
- * @property audioUsage used to signal to the system how to treat the audio tracks (voip or media).
+ * @property crashOnMissingPermission If [permissionCheck] returns false there will be an exception.
+ * @property permissionCheck Used to check for system permission based on call capabilities. See [StreamPermissionCheck].
+ * @property audioUsage Used to signal to the system how to treat the audio tracks (voip or media).
+ *
+ * @see build method
+ *
  */
 public class StreamVideoBuilder @JvmOverloads constructor(
     context: Context,
@@ -97,18 +103,29 @@ public class StreamVideoBuilder @JvmOverloads constructor(
 
     val scope = CoroutineScope(DispatcherProvider.IO)
 
+    /**
+     * Builds the [StreamVideo] client.
+     *
+     * @return The [StreamVideo] client.
+     *
+     * @throws RuntimeException If an instance of the client already exists and [ensureSingleInstance] is set to true.
+     * @throws IllegalArgumentException If [apiKey] is blank.
+     * @throws IllegalArgumentException If [user] type is [UserType.Authenticated] and the [user] id is blank.
+     * @throws IllegalArgumentException If [user] type is [UserType.Authenticated] and both [token] and [tokenProvider] are empty.
+     * @throws ConnectException If the WebSocket connection fails.
+     */
     public fun build(): StreamVideo {
         val lifecycle = ProcessLifecycleOwner.get().lifecycle
 
         val existingInstance = StreamVideo.instanceOrNull()
         if (existingInstance != null && ensureSingleInstance) {
-            throw IllegalArgumentException(
+            throw RuntimeException(
                 "Creating 2 instance of the video client will cause bugs with call.state. Before creating a new client, please remove the old one. You can remove the old client using StreamVideo.removeClient()",
             )
         }
 
         if (apiKey.isBlank()) {
-            throw IllegalArgumentException("The API key can not be empty")
+            throw IllegalArgumentException("The API key cannot be blank")
         }
 
         if (token.isBlank() && tokenProvider == null && user.type == UserType.Authenticated) {
@@ -117,9 +134,9 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             )
         }
 
-        if (user.type == UserType.Authenticated && user.id.isEmpty()) {
+        if (user.type == UserType.Authenticated && user.id.isBlank()) {
             throw IllegalArgumentException(
-                "Please specify the user id for authenticated users",
+                "The user ID cannot be empty for authenticated users",
             )
         }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -76,7 +76,8 @@ import java.net.ConnectException
  * @property permissionCheck Used to check for system permission based on call capabilities. See [StreamPermissionCheck].
  * @property audioUsage Used to signal to the system how to treat the audio tracks (voip or media).
  *
- * @see build method
+ * @see build
+ * @see ClientState.connection
  *
  */
 public class StreamVideoBuilder @JvmOverloads constructor(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -121,6 +121,7 @@ import org.openapitools.client.models.UserRequest
 import org.openapitools.client.models.VideoEvent
 import org.openapitools.client.models.WSCallEvent
 import retrofit2.HttpException
+import java.net.ConnectException
 import java.util.*
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.resumeWithException
@@ -356,8 +357,12 @@ internal class StreamVideoImpl internal constructor(
         }
         scope.launch {
             connectionModule.coordinatorSocket.errors.collect { throwable ->
-                (throwable as? ErrorResponse)?.let {
-                    if (it.code == VideoErrorCode.TOKEN_EXPIRED.code) refreshToken(it)
+                if (throwable is ConnectException) {
+                    state.handleError(throwable)
+                } else {
+                    (throwable as? ErrorResponse)?.let {
+                        if (it.code == VideoErrorCode.TOKEN_EXPIRED.code) refreshToken(it)
+                    }
                 }
             }
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -88,10 +88,18 @@ public class CoordinatorSocket(
             return
         }
 
+        val changedText = if (text.contains("banned")) {
+            text.replace("\"banned\":false,", "")
+        } else {
+            text
+        }
+
         scope.launch(singleThreadDispatcher) {
             try {
                 Serializer.moshi.adapter(VideoEvent::class.java).let { eventAdapter ->
-                    eventAdapter.fromJson(text)?.let { parsedEvent -> processEvent(parsedEvent) }
+                    eventAdapter.fromJson(
+                        changedText,
+                    )?.let { parsedEvent -> processEvent(parsedEvent) }
                 }
             } catch (e: Throwable) {
                 if (e.cause is UnsupportedVideoEventException) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -88,18 +88,10 @@ public class CoordinatorSocket(
             return
         }
 
-        val changedText = if (text.contains("banned")) {
-            text.replace("\"banned\":false,", "")
-        } else {
-            text
-        }
-
         scope.launch(singleThreadDispatcher) {
             try {
                 Serializer.moshi.adapter(VideoEvent::class.java).let { eventAdapter ->
-                    eventAdapter.fromJson(
-                        changedText,
-                    )?.let { parsedEvent -> processEvent(parsedEvent) }
+                    eventAdapter.fromJson(text)?.let { parsedEvent -> processEvent(parsedEvent) }
                 }
             } catch (e: Throwable) {
                 if (e.cause is UnsupportedVideoEventException) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -282,6 +282,7 @@ public open class PersistentSocket<T>(
 
     private fun setPermanentFailureAndContinue(error: Throwable) {
         _connectionState.value = SocketState.DisconnectedPermanently(error)
+
         if (!continuationCompleted) {
             continuationCompleted = true
             connected.resumeWithException(error)
@@ -323,13 +324,13 @@ public open class PersistentSocket<T>(
         if (permanentError) {
             // close the connection loop
             setPermanentFailureAndContinue(error)
-            logger.e { "[handleError] permanent error: $error" }
+            logger.e { "[handleError] Permanent error: $error" }
             // mark us permanently disconnected
             scope.launch {
                 errors.emit(error)
             }
         } else {
-            logger.w { "[handleError] temporary error: $error" }
+            logger.w { "[handleError] Temporary error: $error" }
             _connectionState.value = SocketState.DisconnectedTemporarily(error)
             scope.launch { reconnect(reconnectTimeout) }
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -105,7 +105,11 @@ public open class PersistentSocket<T>(
     internal var reconnectionAttempts = 0
 
     /**
-     * Connect the socket, authenticate, start the healthmonitor and see if the network is online
+     * Connect the socket, authenticate, start the health monitor and see if the network is online
+     * @param invocation Provides a way to extend the [connect] method with additional behavior.
+     * This can be useful in cases where additional setup or checks need to be performed
+     * once the socket is connected but before the [connect] method returns.
+     * To return from [connect] and to resume the enclosing coroutine, use the provided [CancellableContinuation] parameter.
      */
     open suspend fun connect(
         invocation: (CancellableContinuation<T>) -> Unit = {},

--- a/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/UserResponse.kt
+++ b/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/UserResponse.kt
@@ -59,7 +59,7 @@ import org.openapitools.client.infrastructure.Serializer
 data class UserResponse (
 
     @Json(name = "banned")
-    val banned: kotlin.Boolean,
+    val banned: kotlin.Boolean = false,
 
     /* Date/time of creation */
     @Json(name = "created_at")

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
@@ -208,7 +208,7 @@ class ClientAndAuthTest : TestBase() {
 //        }
     }
 
-    @Test(expected = IllegalArgumentException::class)
+    @Test(expected = RuntimeException::class)
     fun `two clients is not allowed`() = runTest {
         val builder = StreamVideoBuilder(
             context = context,

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/SocketTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/SocketTest.kt
@@ -197,7 +197,7 @@ class CoordinatorSocketTest : SocketTestBase() {
         )
 
         socket.connect()
-        socket.connected.cancel()
+        socket.connectContinuation.cancel()
 
         // create a VideoEvent type that resembles a real one, but doesn't contain the necessary fields
         val testJson = "{\"type\":\"health.check\"}"


### PR DESCRIPTION
### 🎫  JIRA issue

https://stream-io.atlassian.net/browse/PBE-4237

### 🎯 Goal

If we get an error when the coordinator socket is connecting, the exception is propagated to the app and causes a crash. It happens because `connect()` uses a `continuation` that's `resumedWithException()`.

### 🛠 Implementation details

- Changed `PersistentSocket.handleError()` to emit a `ConnectException` to the `errors` flow when we're in the _connection phase_.
- Collected that error in `StreamVideoImpl` and passed it to `ClientState`.
- `ClientState` handles the error and sets `connection` to `Failed`. `connection` already exists and it's docs say _Shows the Coordinator connection state_, so it can be used by client apps.
- `reconnect` will be triggered because no events will be received anymore. At each reconnect, if an error appears, `connection` is set as `Failed` again.
- Refactored the `StreamVideoBuilder.build()` docs and exceptions to mention what it throws and have better messages.

### 🧪 Testing

- An error that happens when connecting, e.g. a json exception when deserializing the `ConnectedEvent` (like Aflagift had) - it should cause `connection` to be `Failed` and not crash.
- An error that happens after a successful connection, like an unsupported event or a json exception - it should just log the error.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs