### PR TITLE
Fix notification issues when R8 is enabled

### DIFF
--- a/stream-video-android-core/consumer-proguard-rules.pro
+++ b/stream-video-android-core/consumer-proguard-rules.pro
@@ -63,3 +63,7 @@
 
 # With R8 full mode generic signatures are stripped for classes that are not kept.
 -keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+# Prevent R8 from stripping notification-handling classes.
+-keep class io.getstream.video.android.core.notifications.internal.VideoPushDelegate { *; }
+-keep class io.getstream.android.push.delegate.PushDelegate { *; }


### PR DESCRIPTION
### 🎯 Goal

Keep notification-related classes when R8 is enabled.

### 🛠 Implementation details

Added `keep` rules for `VideoPushDelegate` and `PushDelegate`.

### 🧪 Testing

Test in Audio Call Sample app with and without keep rules.