### PR TITLE
Socket error issue fix

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -149,8 +149,6 @@ public open class PersistentSocket<T>(
         }
     }
 
-
-
     /**
      * Used for testing only - to bring down the socket connection immediately.
      */
@@ -304,7 +302,11 @@ public open class PersistentSocket<T>(
         val error = receivedError.let {
             // TODO Alex: This is a bad assumption, but necessary, needs to be checked against the backend
             if (it is EOFException) {
-                ErrorResponse(40, "Unknown error trying to refresh token and reconnect.", statusCode = 401)
+                ErrorResponse(
+                    40,
+                    "Unknown error trying to refresh token and reconnect.",
+                    statusCode = 401,
+                )
             } else {
                 it
             }


### PR DESCRIPTION
Fix an issue where a socket will fail to authenticate but will throw `EOFException` instead of `ErrorResponse` and this will cause the socket to fail to authenticate, but also throw an exception instead of going the usual flow.

The solution is to make an assumption that the `EOFException` on the socket `authenticate()` is caused by token expiry. This is a bad assumption, but currently the only one that triggers this flow thus we are going to assume that the `EOFexception` on the `authetnticate()` call is actually `ErrorResponse(code=40)` which is token expired and cause a token refresh instead of crash.