### PR TITLE
[PBE-5116] Prevent exception when resuming already completed continuation

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/PersistentSocket.kt
@@ -287,7 +287,12 @@ public open class PersistentSocket<T>(
 
         if (!connectContinuationCompleted) {
             connectContinuationCompleted = true
-            connectContinuation.resume(message as T)
+            try {
+                connectContinuation.resume(message as T)
+            } catch (e: IllegalStateException) {
+                // Continuation is already resumed (possible in a race condition scenario)
+                logger.d { "[setConnectedStateAndContinue] continuation already resumed" }
+            }
         }
     }
 
@@ -372,7 +377,12 @@ public open class PersistentSocket<T>(
 
     private fun resumeConnectionPhaseWithException(error: Throwable) {
         connectContinuationCompleted = true
-        connectContinuation.resumeWithException(error)
+        try {
+            connectContinuation.resumeWithException(error)
+        } catch (e: IllegalStateException) {
+            // Continuation is already resumed (possible in a race condition scenario)
+            logger.d { "[resumeConnectionPhaseWithException] continuation already resumed" }
+        }
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Prevent fatal exception when `connectContinuation` is resumed while already completed and throws `IllegalStateException`.

### 🛠 Implementation details

~~Catch exception when continuation is resumed. Did not reproduce, but easier to validate.~~
Use `tryResume` and `tryResumeWithException`.