### PR TITLE
Fix push-related exceptions

### DIFF
--- a/stream-video-android-core/consumer-proguard-rules.pro
+++ b/stream-video-android-core/consumer-proguard-rules.pro
@@ -67,3 +67,5 @@
 # Prevent R8 from stripping notification-handling classes.
 -keep class io.getstream.video.android.core.notifications.internal.VideoPushDelegate { *; }
 -keep class io.getstream.android.push.delegate.PushDelegate { *; }
+-keep class io.getstream.android.push.delegate.PushDelegateProvider { *; }
+-keep class io.getstream.android.push.permissions.PushPermissionsInitializer { *; }


### PR DESCRIPTION
### 🎯 Goal

Fix exceptions like:

> Unable to get provider androidx.startup.InitializationProvider: androidx.startup.StartupException: java.lang.ClassNotFoundException: io.getstream.android.push.permissions.PushPermissionsInitializer
> 
> Unable to get provider io.getstream.android.push.delegate.PushDelegateProvider

### 🛠 Implementation details

Added consumer keep rules for `PushDelegateProvider` and `PushPermissionsInitializer`.

