### PR TITLE
Handle RtcSession timeout exception properly

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -426,9 +426,13 @@ public class Call(
         }
         timer.split("rtc session init")
 
-        session?.connect()
-
-        timer.split("rtc connect completed")
+        try {
+            session?.connect()
+        } catch (e: Exception) {
+            return Failure(Error.GenericError(e.message ?: "RtcSession error occurred."))
+        } finally {
+            timer.split("rtc connect completed")
+        }
 
         scope.launch {
             // wait for the first stream to be added

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -28,7 +28,6 @@ import androidx.activity.ComponentActivity
 import androidx.annotation.CallSuper
 import androidx.lifecycle.lifecycleScope
 import io.getstream.log.taggedLogger
-import io.getstream.result.Error
 import io.getstream.result.Result
 import io.getstream.result.flatMap
 import io.getstream.result.onErrorSuspend
@@ -476,17 +475,13 @@ public abstract class StreamCallActivity : ComponentActivity() {
     ) {
         lifecycleScope.launch(Dispatchers.IO) {
             val instance = StreamVideo.instance()
-            try {
-                val result = call.create(
-                    // List of all users, containing the caller also
-                    memberIds = members + instance.userId,
-                    // If other users will get push notification.
-                    ring = ring,
-                )
-                result.onOutcome(call, onSuccess, onError)
-            } catch (e: Exception) {
-                onError?.invoke(e)
-            }
+            val result = call.create(
+                // List of all users, containing the caller also
+                memberIds = members + instance.userId,
+                // If other users will get push notification.
+                ring = ring,
+            )
+            result.onOutcome(call, onSuccess, onError)
         }
     }
 
@@ -524,11 +519,7 @@ public abstract class StreamCallActivity : ComponentActivity() {
     ) {
         acceptOrJoinNewCall(call, onSuccess, onError) {
             logger.d { "Join call, ${call.cid}" }
-            try {
-                it.join()
-            } catch (e: Exception) {
-                Result.Failure(Error.GenericError(e.message ?: "Something went wrong."))
-            }
+            it.join()
         }
     }
 
@@ -547,11 +538,7 @@ public abstract class StreamCallActivity : ComponentActivity() {
     ) {
         logger.d { "[accept] #ringing; call.cid: ${call.cid}" }
         acceptOrJoinNewCall(call, onSuccess, onError) {
-            try {
-                call.acceptThenJoin()
-            } catch (e: Exception) {
-                Result.Failure(Error.GenericError(e.message ?: "Something went wrong."))
-            }
+            call.acceptThenJoin()
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Handle `RtcSession` timeout (and other exceptions) to prevent integrating app from crashing.

### 🛠 Implementation details

- Catch RTC exceptions in `_join()` and return `Failure` result.
- `Failure` will also be returned by `call.join()` and `call.state.connection` will be set to `RealtimeConnection.Failed`.
- The `result` and the `connection` are used in `StreamCallActivity` to handle errors and to gracefully `finish()` the activity (or not, depending on the passed `configuration`).

### 🧪 Testing

Tested with normal call, ringing call incoming & ringing call outgoing.