### PR TITLE
Add event type to parsing error messages

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -22,6 +22,7 @@ import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.getstream.video.android.core.utils.isWhitespaceOnly
+import io.getstream.video.android.core.utils.safeCall
 import io.getstream.video.android.model.User
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -99,7 +100,8 @@ public class CoordinatorSocket(
                     val ex = e.cause as UnsupportedVideoEventException
                     logger.w { "[onMessage] Received unsupported VideoEvent type: ${ex.type}. Ignoring." }
                 } else {
-                    val errorMessage = "Error when parsing VideoEvent with type: ${extractEventType(text)}. Cause: ${e.message}."
+                    val eventType = extractEventType(text)
+                    val errorMessage = "Error when parsing VideoEvent with type: $eventType. Cause: ${e.message}."
 
                     logger.e { "[onMessage] $errorMessage" }
                     handleError(JsonDataException(errorMessage))
@@ -131,9 +133,9 @@ public class CoordinatorSocket(
         events.emit(parsedEvent)
     }
 
-    private fun extractEventType(json: String): String {
+    private fun extractEventType(json: String): String = safeCall("Unknown") {
         val regex = """"type":"(.*?)"""".toRegex()
         val matchResult = regex.find(json)
-        return matchResult?.groups?.get(1)?.value ?: "unknown"
+        return matchResult?.groups?.get(1)?.value ?: "Unknown"
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -17,6 +17,7 @@
 package io.getstream.video.android.core.socket
 
 import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
@@ -98,8 +99,10 @@ public class CoordinatorSocket(
                     val ex = e.cause as UnsupportedVideoEventException
                     logger.w { "[onMessage] Received unsupported VideoEvent type: ${ex.type}. Ignoring." }
                 } else {
-                    logger.w { "[onMessage] VideoEvent parsing error ${e.message}." }
-                    handleError(e)
+                    val errorMessage = "Error when parsing VideoEvent with type: ${extractEventType(text)}. Cause: ${e.message}."
+
+                    logger.e { "[onMessage] $errorMessage" }
+                    handleError(JsonDataException(errorMessage))
                 }
             }
         }
@@ -126,5 +129,11 @@ public class CoordinatorSocket(
 
         ackHealthMonitor()
         events.emit(parsedEvent)
+    }
+
+    private fun extractEventType(json: String): String {
+        val regex = """"type":"(.*?)"""".toRegex()
+        val matchResult = regex.find(json)
+        return matchResult?.groups?.get(1)?.value ?: "unknown"
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Add more context when json event parsing error occurs.

### 🛠 Implementation details

Added the event type in the error message.