### PR TITLE
Add tests for event parsing in CoordinatorSocket

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -97,8 +97,7 @@ public class CoordinatorSocket(
                 }
             } catch (e: Throwable) {
                 if (e.cause is UnsupportedVideoEventException) {
-                    val ex = e.cause as UnsupportedVideoEventException
-                    logger.w { "[onMessage] Received unsupported VideoEvent type: ${ex.type}. Ignoring." }
+                    handleUnsupportedEvent(e.cause as UnsupportedVideoEventException)
                 } else {
                     val eventType = extractEventType(text)
                     val errorMessage = "Error when parsing VideoEvent with type: $eventType. Cause: ${e.message}."
@@ -131,6 +130,11 @@ public class CoordinatorSocket(
 
         ackHealthMonitor()
         events.emit(parsedEvent)
+    }
+
+    // TODO: Enough for testing this path?
+    private fun handleUnsupportedEvent(e: UnsupportedVideoEventException) {
+        logger.w { "[onMessage] Received unsupported VideoEvent type: ${e.type}. Ignoring." }
     }
 
     private fun extractEventType(json: String): String = safeCall("Unknown") {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/CoordinatorSocket.kt
@@ -97,7 +97,7 @@ public class CoordinatorSocket(
                 }
             } catch (e: Throwable) {
                 if (e.cause is UnsupportedVideoEventException) {
-                    handleUnsupportedEvent(e.cause as UnsupportedVideoEventException)
+                    logUnsupportedEvent(e.cause as UnsupportedVideoEventException)
                 } else {
                     val eventType = extractEventType(text)
                     val errorMessage = "Error when parsing VideoEvent with type: $eventType. Cause: ${e.message}."
@@ -133,7 +133,7 @@ public class CoordinatorSocket(
     }
 
     // TODO: Enough for testing this path?
-    private fun handleUnsupportedEvent(e: UnsupportedVideoEventException) {
+    private fun logUnsupportedEvent(e: UnsupportedVideoEventException) {
         logger.w { "[onMessage] Received unsupported VideoEvent type: ${e.type}. Ignoring." }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Add tests for event parsing in `CoordinatorSocket#onMessage`.

### 🛠 Implementation details

- Added tests:
  - `onMessage_withValidEventJson_emitsEvent` for valid JSON as input
  - `onMessage_withInvalidEventJson_emitsError` for invalid JSON as input
  - `onMessage_withUnsupportedEventJson_skipsEventProcessingAndErrorEmission` for valid JSON but representing unsupported event as input
- ❗ TODO: Cover SDK/app crash in tests

### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExc2I4eXBxZ3M2cXd1Mm9kcGcxcDMyNTAxZnFteDZxbmt4YnVmZzNiZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/B4xdycvhDq7qM3cdh2/giphy.gif)