### PR TITLE
[PBE 5272] Stop foreground service when uninstalling StreamVideo instance

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -42,6 +42,7 @@ import io.getstream.video.android.core.model.VideoTrack
 import io.getstream.video.android.core.model.toIceServer
 import io.getstream.video.android.core.socket.SocketState
 import io.getstream.video.android.core.utils.RampValueUpAndDownHelper
+import io.getstream.video.android.core.utils.safeCall
 import io.getstream.video.android.core.utils.toQueriedMembers
 import io.getstream.video.android.model.User
 import io.getstream.webrtc.android.ui.VideoTextureViewRenderer
@@ -601,7 +602,7 @@ public class Call(
         leave(disconnectionReason = null)
     }
 
-    private fun leave(disconnectionReason: Throwable?) {
+    private fun leave(disconnectionReason: Throwable?) = safeCall {
         logger.v { "[leave] #ringing; disconnectionReason: $disconnectionReason" }
         if (isDestroyed) {
             logger.w { "[leave] #ringing; Call already destroyed, ignoring" }
@@ -616,7 +617,7 @@ public class Call(
             RealtimeConnection.Disconnected
         }
         stopScreenSharing()
-        client.state.removeActiveCall()
+        client.state.removeActiveCall() // Will also stop CallService
         client.state.removeRingingCall()
         (client as StreamVideoImpl).onCallCleanUp(this)
         camera.disable()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -204,7 +204,7 @@ internal class StreamVideoImpl internal constructor(
         socketImpl.cleanup()
         // call cleanup on the active call
         val activeCall = state.activeCall.value
-        activeCall?.cleanup()
+        activeCall?.leave()
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Calling `StreamVideo.removeClient()` doesn’t end up calling `maybeStopForegroundService()`, so any ongoing call notification will still show after removeClient()

Ideally all calls are explicitly left first, but it would be nice if `removeClient()` was a reliable way to fully nuke everything Stream Video related.

### 🎫 JIRA Issue

https://stream-io.atlassian.net/browse/PBE-5272

### 🛠 Implementation details

- Called `leave` instead of `cleanup` for active call in `StreamVideoImpl#cleanup`.
- `leave` will eventually stop the foreground service. 
- Added `safeCall` to `Call#leave()`.

### 🎉 GIF

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTF4OWRuenVjcHp3MXYzaHB4cTFkbjlwZWZxYWdnd21zcnloeGhudSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/VL06VWVoKXCBx3czZa/giphy.gif)