### PR TITLE
[PBE-5431] Meet Android 14 foreground service requirements

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -36,7 +36,7 @@ import io.getstream.video.android.core.notifications.NotificationHandler.Compani
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.INTENT_EXTRA_CALL_CID
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.INTENT_EXTRA_CALL_DISPLAY_NAME
 import io.getstream.video.android.core.notifications.internal.receivers.ToggleCameraBroadcastReceiver
-import io.getstream.video.android.core.utils.customStartForeground
+import io.getstream.video.android.core.utils.startForegroundWithServiceType
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.streamCallDisplayName
 import io.getstream.video.android.model.streamCallId
@@ -245,7 +245,7 @@ internal class CallService : Service() {
                     )
                 } else {
                     callId = intentCallId
-                    customStartForeground(intentCallId.hashCode(), notification, trigger)
+                    startForegroundWithServiceType(intentCallId.hashCode(), notification, trigger)
                 }
                 true
             } else {
@@ -297,7 +297,7 @@ internal class CallService : Service() {
 
         if (!hasActiveCall) {
             videoClient.getSettingUpCallNotification()?.let {
-                customStartForeground(notificationId, it, trigger)
+                startForegroundWithServiceType(notificationId, it, trigger)
             }
         }
     }
@@ -306,7 +306,7 @@ internal class CallService : Service() {
     private fun showIncomingCall(notificationId: Int, notification: Notification) {
         if (callId == null) { // If there isn't another call in progress (callId is set in onStartCommand())
             // The service was started with startForegroundService() (from companion object), so we need to call startForeground().
-            customStartForeground(notificationId, notification, TRIGGER_INCOMING_CALL)
+            startForegroundWithServiceType(notificationId, notification, TRIGGER_INCOMING_CALL)
         } else {
             // Else, we show a simple notification (the service was already started as a foreground service).
             NotificationManagerCompat

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -22,13 +22,10 @@ import android.app.Service
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
-import android.content.pm.ServiceInfo
 import android.media.MediaPlayer
-import android.os.Build
 import android.os.IBinder
 import androidx.annotation.RawRes
 import androidx.core.app.NotificationManagerCompat
-import androidx.core.app.ServiceCompat
 import androidx.core.content.ContextCompat
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.R
@@ -39,6 +36,7 @@ import io.getstream.video.android.core.notifications.NotificationHandler.Compani
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.INTENT_EXTRA_CALL_CID
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.INTENT_EXTRA_CALL_DISPLAY_NAME
 import io.getstream.video.android.core.notifications.internal.receivers.ToggleCameraBroadcastReceiver
+import io.getstream.video.android.core.utils.customStartForeground
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.streamCallDisplayName
 import io.getstream.video.android.model.streamCallId
@@ -301,28 +299,6 @@ internal class CallService : Service() {
             videoClient.getSettingUpCallNotification()?.let {
                 customStartForeground(notificationId, it, trigger)
             }
-        }
-    }
-
-    private fun customStartForeground(
-        notificationId: Int,
-        notification: Notification,
-        trigger: String,
-    ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            val foregroundServiceType = when (trigger) {
-                TRIGGER_ONGOING_CALL -> ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
-                TRIGGER_OUTGOING_CALL, TRIGGER_INCOMING_CALL -> ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
-                else -> ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
-            }
-            ServiceCompat.startForeground(
-                this@CallService,
-                notificationId,
-                notification,
-                foregroundServiceType,
-            )
-        } else {
-            startForeground(notificationId, notification)
         }
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/screenshare/StreamScreenShareService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/screenshare/StreamScreenShareService.kt
@@ -28,6 +28,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import io.getstream.video.android.core.R
 import io.getstream.video.android.core.notifications.internal.receivers.StopScreenshareBroadcastReceiver
+import io.getstream.video.android.core.utils.customStartForeground
 
 /**
  * Screen-sharing in Android requires a ForegroundService (with type foregroundServiceType set to "mediaProjection").
@@ -102,7 +103,7 @@ internal class StreamScreenShareService : Service() {
             )
         }
 
-        startForeground(NOTIFICATION_ID, builder.build())
+        customStartForeground(NOTIFICATION_ID, builder.build(), TRIGGER_SHARE_SCREEN)
         return super.onStartCommand(intent, flags, startId)
     }
 
@@ -111,6 +112,7 @@ internal class StreamScreenShareService : Service() {
         internal const val EXTRA_CALL_ID = "EXTRA_CALL_ID"
         internal const val BROADCAST_CANCEL_ACTION = "io.getstream.video.android.action.CANCEL_SCREEN_SHARE"
         internal const val INTENT_EXTRA_CALL_ID = "io.getstream.video.android.intent-extra.call_cid"
+        internal const val TRIGGER_SHARE_SCREEN = "share_screen"
 
         fun createIntent(context: Context, callId: String) =
             Intent(context, StreamScreenShareService::class.java).apply {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/screenshare/StreamScreenShareService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/screenshare/StreamScreenShareService.kt
@@ -28,7 +28,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import io.getstream.video.android.core.R
 import io.getstream.video.android.core.notifications.internal.receivers.StopScreenshareBroadcastReceiver
-import io.getstream.video.android.core.utils.customStartForeground
+import io.getstream.video.android.core.utils.startForegroundWithServiceType
 
 /**
  * Screen-sharing in Android requires a ForegroundService (with type foregroundServiceType set to "mediaProjection").
@@ -103,7 +103,7 @@ internal class StreamScreenShareService : Service() {
             )
         }
 
-        customStartForeground(NOTIFICATION_ID, builder.build(), TRIGGER_SHARE_SCREEN)
+        startForegroundWithServiceType(NOTIFICATION_ID, builder.build(), TRIGGER_SHARE_SCREEN)
         return super.onStartCommand(intent, flags, startId)
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AndroidUtils.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AndroidUtils.kt
@@ -171,7 +171,14 @@ inline fun <T> safeCall(default: T, block: () -> T): T {
     }
 }
 
-internal fun Service.customStartForeground(
+/**
+ * Start a foreground service with a service type to meet requirements introduced in Android 14.
+ *
+ * @param notificationId The notification ID
+ * @param notification The notification to show
+ * @param trigger The trigger that started the service: [TRIGGER_ONGOING_CALL], [TRIGGER_OUTGOING_CALL], [TRIGGER_INCOMING_CALL], [TRIGGER_SHARE_SCREEN]
+ */
+internal fun Service.startForegroundWithServiceType(
     notificationId: Int,
     notification: Notification,
     trigger: String,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AndroidUtils.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AndroidUtils.kt
@@ -183,20 +183,25 @@ internal fun Service.startForegroundWithServiceType(
     notification: Notification,
     trigger: String,
 ) {
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-        val foregroundServiceType = when (trigger) {
-            TRIGGER_ONGOING_CALL -> ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
-            TRIGGER_OUTGOING_CALL, TRIGGER_INCOMING_CALL -> ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
-            TRIGGER_SHARE_SCREEN -> ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
-            else -> ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+        startForeground(notificationId, notification)
+    } else {
+        val beforeOrAfterAndroid14Type = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
+        } else {
+            ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
         }
+
         ServiceCompat.startForeground(
             this,
             notificationId,
             notification,
-            foregroundServiceType,
+            when (trigger) {
+                TRIGGER_ONGOING_CALL -> ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
+                TRIGGER_OUTGOING_CALL, TRIGGER_INCOMING_CALL -> beforeOrAfterAndroid14Type
+                TRIGGER_SHARE_SCREEN -> ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PROJECTION
+                else -> beforeOrAfterAndroid14Type
+            },
         )
-    } else {
-        startForeground(notificationId, notification)
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Meet foreground service requirements introduced in Android 14.


### 🛠 Implementation details

- Create new utility extension function that calls `startForeground` with a service type for Android 14+.
- Use this function where needed in `CallService` and `StreamScreenShareService`
- Checked manifest, `startForeground` calls and permissions.
- Checked:
  - `foregroundServiceType` in `Manifest`
  - Foreground service permissions
  - `serviceType` in `startForeground` calls
  - Related runtime permissions: `MANAGE_OWN_CALLS`, calling `createScreenCaptureIntent()`.