### PR TITLE
Do not leave the call when `StreamCallActivity` goes into background

### DIFF
--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -383,11 +383,8 @@ public abstract class StreamCallActivity : ComponentActivity() {
      * @param call the call
      */
     public open fun onStop(call: Call) {
+        // Extension point only.
         logger.d { "Default activity - stopped (call -> $call)" }
-        if (isVideoCall(call) && isInPictureInPictureMode) {
-            logger.d { "Default activity - stopped: PiP detected, will leave call. (call -> $call)" }
-            leave(call) // Already finishing
-        }
     }
 
     /**

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -384,8 +384,8 @@ public abstract class StreamCallActivity : ComponentActivity() {
      */
     public open fun onStop(call: Call) {
         logger.d { "Default activity - stopped (call -> $call)" }
-        if (isVideoCall(call) && !isInPictureInPictureMode) {
-            logger.d { "Default activity - stopped: No PiP detected, will leave call. (call -> $call)" }
+        if (isVideoCall(call) && isInPictureInPictureMode) {
+            logger.d { "Default activity - stopped: PiP detected, will leave call. (call -> $call)" }
             leave(call) // Already finishing
         }
     }


### PR DESCRIPTION
Fix a bug that would cause a call to `call.leave()` in `StreamCallActivity.onStop()`