### PR TITLE
[PBE-4216] Fix potential ANR caused by lazy initialization of MediaManager-related Call properties

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -133,10 +133,10 @@ public class Call(
     private val network by lazy { clientImpl.connectionModule.networkStateProvider }
 
     /** Camera gives you access to the local camera */
-    val camera by lazy { mediaManager.camera }
-    val microphone by lazy { mediaManager.microphone }
-    val speaker by lazy { mediaManager.speaker }
-    val screenShare by lazy { mediaManager.screenShare }
+    val camera by lazy(LazyThreadSafetyMode.PUBLICATION) { mediaManager.camera }
+    val microphone by lazy(LazyThreadSafetyMode.PUBLICATION) { mediaManager.microphone }
+    val speaker by lazy(LazyThreadSafetyMode.PUBLICATION) { mediaManager.speaker }
+    val screenShare by lazy(LazyThreadSafetyMode.PUBLICATION) { mediaManager.screenShare }
 
     /** The cid is type:id */
     val cid = "$type:$id"


### PR DESCRIPTION
### 🎯 Goal

Fix potential ANR caused by lazy initialization of `call.camera`, `call.microphone`, `call.speaker`, `call.screenShare`.

### 🛠 Implementation details

Use `LazyThreadSafetyMode.PUBLICATION` thread-safety mode for those `Call` properties.