### PR TITLE
Improve livestreaming responsiveness

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -283,6 +283,26 @@ public class CallState(
 
         // TODO: could optimize performance by subscribing only to relevant events
         call.subscribe {
+            if (it is TrackPublishedEvent) {
+                val participant = getOrCreateParticipant(it.sessionId, it.userId)
+
+                if (it.trackType == TrackType.TRACK_TYPE_VIDEO) {
+                    participant._videoEnabled.value = true
+                } else if (it.trackType == TrackType.TRACK_TYPE_AUDIO) {
+                    participant._audioEnabled.value = true
+                }
+            }
+
+            if (it is TrackUnpublishedEvent) {
+                val participant = getOrCreateParticipant(it.sessionId, it.userId)
+
+                if (it.trackType == TrackType.TRACK_TYPE_VIDEO) {
+                    participant._videoEnabled.value = false
+                } else if (it.trackType == TrackType.TRACK_TYPE_AUDIO) {
+                    participant._audioEnabled.value = false
+                }
+            }
+
             emitLivestreamVideo()
         }
 


### PR DESCRIPTION
### 🎯 Goal

When turning camera on/off, the event should be visible to the guests sooner.

### 🛠 Implementation details

Enable/disable tracks directly in livestreamFlow.