### PR TITLE
Add audio only `CallService` to avoid requiring `CAMERA` permission

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4238,6 +4238,7 @@ public final class io/getstream/video/android/core/notifications/internal/servic
 
 public final class io/getstream/video/android/core/notifications/internal/service/CallServiceConfigKt {
 	public static final fun callServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
+	public static final fun livestreamAudioCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamGuestCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 }

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -104,6 +104,11 @@
             android:exported="false" />
 
         <service
+            android:name=".notifications.internal.service.LivestreamAudioCallService"
+            android:foregroundServiceType="microphone"
+            android:exported="false" />
+
+        <service
             android:name=".notifications.internal.service.LivestreamViewerService"
             android:foregroundServiceType="mediaPlayback"
             android:exported="false" />

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
@@ -63,6 +63,19 @@ public fun livestreamCallServiceConfig(): CallServiceConfig {
 }
 
 /**
+ * Return a default configuration for the call service configuration for livestream which has no camera
+ */
+public fun livestreamAudioCallServiceConfig(): CallServiceConfig {
+    return CallServiceConfig(
+        runCallServiceInForeground = true,
+        callServicePerType = mapOf(
+            Pair(ANY_MARKER, CallService::class.java),
+            Pair("livestream", LivestreamAudioCallService::class.java),
+        ),
+    )
+}
+
+/**
  * Return a default configuration for the call service configuration.
  */
 public fun livestreamGuestCallServiceConfig(): CallServiceConfig {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/LivestreamCallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/LivestreamCallService.kt
@@ -31,6 +31,14 @@ internal open class LivestreamCallService : CallService() {
 /**
  * Due to the nature of the livestream calls, the service that is used is of different type.
  */
+internal open class LivestreamAudioCallService : CallService() {
+    override val logger: TaggedLogger by taggedLogger("LivestreamHostCallService")
+    override val serviceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+}
+
+/**
+ * Due to the nature of the livestream calls, the service that is used is of different type.
+ */
 internal class LivestreamViewerService : LivestreamCallService() {
     override val logger: TaggedLogger by taggedLogger("LivestreamHostCallService")
     override val serviceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfigTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfigTest.kt
@@ -124,4 +124,24 @@ class CallServiceConfigTest {
         assertEquals(LivestreamViewerService::class.java, livestreamServiceClass)
         assertEquals(AudioAttributes.USAGE_MEDIA, audioUsage)
     }
+
+    @Test
+    fun `livestreamAudioCallServiceConfig should return correct default configuration`() {
+        // Given
+        val config = livestreamAudioCallServiceConfig()
+
+        // When
+        val runInForeground = config.runCallServiceInForeground
+        val servicePerTypeSize = config.callServicePerType.size
+        val hostServiceClass = config.callServicePerType[ANY_MARKER]
+        val livestreamServiceClass = config.callServicePerType["livestream"]
+        val audioUsage = config.audioUsage
+
+        // Then
+        assertEquals(true, runInForeground)
+        assertEquals(2, servicePerTypeSize)
+        assertEquals(CallService::class.java, hostServiceClass)
+        assertEquals(LivestreamAudioCallService::class.java, livestreamServiceClass)
+        assertEquals(AudioAttributes.USAGE_VOICE_COMMUNICATION, audioUsage)
+    }
 }


### PR DESCRIPTION
# Goal
Add an `audio only` service type for livestream to avoid requiring the `CAMERA` permission.