### PR TITLE
Fix upload artifact and distribution CI jobs

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Assemble
         run: bash ./gradlew :demo-app:assembleRelease --stacktrace
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: demo-app-release
           path: demo-app/build/outputs/apk/demo-app/release/

--- a/.github/workflows/artifact-upload.yaml
+++ b/.github/workflows/artifact-upload.yaml
@@ -35,7 +35,7 @@ jobs:
         run: ./gradlew bundleRelease --stacktrace
 
       - name: Upload AAB as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: app-bundle
           path: demo-app/build/outputs/bundle/productionRelease/demo-app-production-release.aab


### PR DESCRIPTION
### 🎯 Goal

Fix upload artifact CI job

### 🛠 Implementation details

Use `v4` of `upload-artifact` action instead of `v2` (deprecated)