### PR TITLE
[PBE 6041] Fix incoming call PN issue

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/PushNotifications.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/PushNotifications.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.util
+
+import android.util.Log
+import com.google.firebase.messaging.FirebaseMessaging
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.tasks.await
+
+val fcmToken: String?
+    get() = runBlocking {
+        try {
+            FirebaseMessaging.getInstance().token.await()
+        } catch (e: Exception) {
+            Log.e("FCM Token", "Failed to retrieve FCM token", e)
+            null
+        }
+    }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -239,14 +239,6 @@ public class StreamVideoBuilder @JvmOverloads constructor(
         // Installs Stream Video instance
         StreamVideo.install(client)
 
-        // Needs to be started after the client is initialised because the VideoPushDelegate
-        // is accessing the StreamVideo instance
-        scope.launch {
-            if (user.type == UserType.Authenticated) {
-                client.registerPushDevice()
-            }
-        }
-
         return client
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
@@ -48,7 +48,7 @@ internal class StreamNotificationManager private constructor(
     private val context: Context,
     private val scope: CoroutineScope,
     private val notificationConfig: NotificationConfig,
-    private val api: ProductvideoApi,
+    private var api: ProductvideoApi,
     internal val deviceTokenStorage: DeviceTokenStorage,
     private val notificationPermissionManager: NotificationPermissionManager?,
 ) : NotificationHandler by notificationConfig.notificationHandler {
@@ -123,6 +123,7 @@ internal class StreamNotificationManager private constructor(
             pushProvider = this.pushProvider.key,
             pushProviderName = this.providerName ?: "",
         )
+
     private fun PushDevice.toCreateDeviceRequest(): Result<CreateDeviceRequest> =
         when (pushProvider) {
             PushProvider.FIREBASE -> Result.Success(CreateDeviceRequest.PushProvider.Firebase)
@@ -138,10 +139,12 @@ internal class StreamNotificationManager private constructor(
         }
 
     internal companion object {
+
         private val logger: TaggedLogger by taggedLogger("StreamVideo:Notifications")
 
         @SuppressLint("StaticFieldLeak")
         private lateinit var internalStreamNotificationManager: StreamNotificationManager
+
         internal fun install(
             context: Context,
             scope: CoroutineScope,
@@ -151,10 +154,7 @@ internal class StreamNotificationManager private constructor(
         ): StreamNotificationManager {
             synchronized(this) {
                 if (Companion::internalStreamNotificationManager.isInitialized) {
-                    logger.e {
-                        "The $internalStreamNotificationManager is already installed but you've " +
-                            "tried to install a new one."
-                    }
+                    internalStreamNotificationManager.api = api
                 } else {
                     val application = context.applicationContext as? Application
                     val updatedNotificationConfig =


### PR DESCRIPTION
### 🎯 Goal

Fix issue that makes incoming call PN to not be delivered after user logs-out and a new user logs-in.

### 🛠 Implementation details

- Always re-assign the Retrofit API instance when `install`ing `StreamNotificationManager` so that the correct user token is used in the `AuthInterceptor` for `CreateDevice` and `DeleteDevice` requests.
- Register the push device only after getting `connection.ok` event to avoid race-condition between `VideoConnect` and `CreateDevice`.
- Fix the Demo App by calling `deleteDevice` at log-out.

### 🧪 Testing

- Sign in with a user and see if it receives incoming call PN.
- Sign out then sign in again with another user. The new user should also get the PN and be able to accept the call.
- Can be done in the Demo App or in the Audio Call Sample.