### PR TITLE
[PBE-6041] Fix mic muted in background bug

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4239,7 +4239,8 @@ public final class io/getstream/video/android/core/notifications/internal/servic
 }
 
 public final class io/getstream/video/android/core/notifications/internal/service/CallServiceConfigKt {
-	public static final fun callServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
+	public static final fun audioCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
+	public static final fun defaultCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamAudioCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamGuestCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -4240,7 +4240,7 @@ public final class io/getstream/video/android/core/notifications/internal/servic
 
 public final class io/getstream/video/android/core/notifications/internal/service/CallServiceConfigKt {
 	public static final fun audioCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
-	public static final fun defaultCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
+	public static final fun callServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamAudioCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;
 	public static final fun livestreamGuestCallServiceConfig ()Lio/getstream/video/android/core/notifications/internal/service/CallServiceConfig;

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -41,8 +41,6 @@
 
     <!-- Optional, if incoming / outgoing calls feature is used -->
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
-    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
 
     <!-- If the app is only livestream  host -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
@@ -91,7 +89,6 @@
             </intent-filter>
         </receiver>
 
-
         <service android:name=".notifications.internal.service.CallService"
             android:foregroundServiceType="shortService|camera|microphone"/>
 
@@ -111,6 +108,11 @@
         <service
             android:name=".notifications.internal.service.LivestreamViewerService"
             android:foregroundServiceType="mediaPlayback"
+            android:exported="false" />
+
+        <service
+            android:name=".notifications.internal.service.AudioCallService"
+            android:foregroundServiceType="microphone"
             android:exported="false" />
     </application>
 </manifest>

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -93,7 +93,7 @@
 
 
         <service android:name=".notifications.internal.service.CallService"
-            android:foregroundServiceType="shortService|phoneCall"/>
+            android:foregroundServiceType="shortService|camera|microphone"/>
 
         <service android:name=".screenshare.StreamScreenShareService"
             android:foregroundServiceType="mediaProjection"/>

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -86,7 +86,7 @@
         </receiver>
 
         <service android:name=".notifications.internal.service.CallService"
-            android:foregroundServiceType="shortService|camera|microphone"/>
+            android:foregroundServiceType="shortService|phoneCall"/>
 
         <service android:name=".screenshare.StreamScreenShareService"
             android:foregroundServiceType="mediaProjection"/>

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -26,35 +26,31 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
-
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <!-- Call service permission -->
+    <!-- Call foreground service permission -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-    <!-- Optional, if incoming / outgoing calls feature is used -->
+    <!-- Required if incoming & outgoing calls are used -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
-    <!-- If the app is only livestream  host -->
+    <!-- Required for calls involving microphone usage -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <!-- Required for calls involving camera usage -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- If the app is only livestream viewer/guest type -->
+    <!-- Required for viewer/listener-only calls -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
-    <!-- If the calls support screensharing -->
+    <!-- Required if calls support screensharing -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION"/>
 
-
     <application>
-
         <provider
             android:name="io.getstream.android.push.delegate.PushDelegateProvider"
             android:authorities="${applicationId}.io.getstream.android.push"

--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -29,22 +29,23 @@
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS" />
     <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
+    <uses-permission android:name="android.permission.CAMERA" />
 
     <!-- Call foreground service permission -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-    <!-- Required if incoming & outgoing calls are used -->
+    <!-- Optional, if incoming & outgoing calls are used -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_PHONE_CALL" />
+    <uses-permission android:name="android.permission.MANAGE_OWN_CALLS"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
-    <!-- Required for calls involving microphone usage -->
+    <!-- Use in a livestream host scenario -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
-    <uses-permission android:name="android.permission.RECORD_AUDIO" />
-    <!-- Required for calls involving camera usage -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
-    <uses-permission android:name="android.permission.CAMERA" />
 
-    <!-- Required for viewer/listener-only calls -->
+    <!-- Use in a livestream viewer/guest scenario -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
     <!-- Required if calls support screensharing -->

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -74,6 +74,7 @@ import java.net.ConnectException
  * @property ensureSingleInstance Verify that only 1 version of the video client exists. Prevents integration mistakes.
  * @property videoDomain URL overwrite to allow for testing against a local instance of video.
  * @property runForegroundServiceForCalls If set to true, when there is an active call the SDK will run a foreground service to keep the process alive. (default: true)
+ * @property callServiceConfig Configuration for the call foreground service. See [CallServiceConfig].
  * @property localSfuAddress Local SFU address (IP:port) to be used for testing. Leave null if not needed.
  * @property sounds Overwrite the default SDK sounds. See [Sounds].
  * @property permissionCheck Used to check for system permission based on call capabilities. See [StreamPermissionCheck].

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/AudioCallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/AudioCallService.kt
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications.internal.service
+
+import android.content.pm.ServiceInfo
+import io.getstream.log.TaggedLogger
+import io.getstream.log.taggedLogger
+
+internal class AudioCallService : CallService() {
+    override val logger: TaggedLogger by taggedLogger("AudioCallService")
+    override val serviceType = ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -67,8 +67,7 @@ internal open class CallService : Service() {
     internal open val logger by taggedLogger("CallService")
 
     // Service type
-    open val serviceType: Int = ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA or
-        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
+    open val serviceType: Int = ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
 
     // Data
     private var callId: StreamCallId? = null

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -67,7 +67,8 @@ internal open class CallService : Service() {
     internal open val logger by taggedLogger("CallService")
 
     // Service type
-    open val serviceType: Int = ServiceInfo.FOREGROUND_SERVICE_TYPE_PHONE_CALL
+    open val serviceType: Int = ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA or
+        ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
 
     // Data
     private var callId: StreamCallId? = null

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
@@ -25,9 +25,15 @@ internal const val ANY_MARKER = "ALL_CALL_TYPES"
 
 // API
 /**
- * Configuration class for the call service.
+ * Configuration class for the call foreground service.
  * @param runCallServiceInForeground If the call service should run in the foreground.
  * @param callServicePerType A map of call service per type.
+ *
+ * @see callServiceConfig
+ * @see livestreamCallServiceConfig
+ * @see livestreamAudioCallServiceConfig
+ * @see livestreamGuestCallServiceConfig
+ * @see audioCallServiceConfig
  */
 public data class CallServiceConfig(
     val runCallServiceInForeground: Boolean = true,
@@ -38,7 +44,7 @@ public data class CallServiceConfig(
 )
 
 /**
- * Return a default configuration for the call service configuration.
+ * Returns a default call foreground service configuration.
  */
 public fun callServiceConfig(): CallServiceConfig {
     return CallServiceConfig(
@@ -50,7 +56,8 @@ public fun callServiceConfig(): CallServiceConfig {
 }
 
 /**
- * Return a default configuration for the call service configuration.
+ * Returns a foreground service configuration appropriate for livestream hosts.
+ * Uses: `FOREGROUND_SERVICE_TYPE_CAMERA` and `FOREGROUND_SERVICE_TYPE_MICROPHONE`.
  */
 public fun livestreamCallServiceConfig(): CallServiceConfig {
     return CallServiceConfig(
@@ -63,7 +70,8 @@ public fun livestreamCallServiceConfig(): CallServiceConfig {
 }
 
 /**
- * Return a default configuration for the call service configuration for livestream which has no camera
+ * Returns a foreground service configuration appropriate for audio-only livestream hosts.
+ * Uses: `FOREGROUND_SERVICE_TYPE_MICROPHONE`.
  */
 public fun livestreamAudioCallServiceConfig(): CallServiceConfig {
     return CallServiceConfig(
@@ -76,7 +84,8 @@ public fun livestreamAudioCallServiceConfig(): CallServiceConfig {
 }
 
 /**
- * Return a default configuration for the call service configuration.
+ * Returns a foreground service configuration appropriate for livestream viewers.
+ * Uses: `FOREGROUND_SERVICE_TYPE_MEDIA_PLAYBACK`.
  */
 public fun livestreamGuestCallServiceConfig(): CallServiceConfig {
     return CallServiceConfig(
@@ -89,6 +98,10 @@ public fun livestreamGuestCallServiceConfig(): CallServiceConfig {
     )
 }
 
+/**
+ * Returns a foreground service configuration appropriate for audio-only calls.
+ * Uses: `FOREGROUND_SERVICE_TYPE_MICROPHONE`.
+ */
 public fun audioCallServiceConfig(): CallServiceConfig {
     return CallServiceConfig(
         runCallServiceInForeground = true,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
@@ -89,6 +89,16 @@ public fun livestreamGuestCallServiceConfig(): CallServiceConfig {
     )
 }
 
+public fun audioCallServiceConfig(): CallServiceConfig {
+    return CallServiceConfig(
+        runCallServiceInForeground = true,
+        callServicePerType = mapOf(
+            Pair(ANY_MARKER, CallService::class.java),
+            Pair("audio_call", AudioCallService::class.java),
+        ),
+    )
+}
+
 // Internal
 internal fun resolveServiceClass(callId: StreamCallId, config: CallServiceConfig): Class<*> {
     val callType = callId.type

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfig.kt
@@ -44,7 +44,8 @@ public data class CallServiceConfig(
 )
 
 /**
- * Returns a default call foreground service configuration.
+ * Returns the default call foreground service configuration.
+ * Uses: `FOREGROUND_SERVICE_TYPE_PHONE_CALL`.
  */
 public fun callServiceConfig(): CallServiceConfig {
     return CallServiceConfig(


### PR DESCRIPTION
### 🎯 Goal

Fix bug: microphone is muted when the app is in the background. Happens on some devices with Android 13 and 14.

### 🛠 Implementation details

- Changed `CallService` type from `PHONE_CALL` to `CAMERA` and `MICROPHONE`.
- Created new `AudioCallService` and related `audioCallServiceConfig`.
- Improved inline docs, naming and `AndroidManifest` comments.

### 🧪 Testing

- Test with default call type (camera + mic) to avoid regressions.
- Remove camera permissions and fg service type to simulate audio-only calls. App will crash when making call.
- Replace default config with new `audioCallServiceConfig` in `Builder`. App will not crash anymore.
- Test microphone while app is in background.