### PR TITLE
Relax session id validation

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1096,7 +1096,7 @@ public class CallState(
     internal fun getOrCreateParticipant(participant: Participant): ParticipantState {
         if (participant.session_id.isEmpty()) {
             // Empty session ID is technically allowed but should not happen.
-            logger.w { "A user with empty session ID joined the call." }
+            logger.w { "A user [id:${participant.user_id}] is in the call with empty session_id" }
         }
 
         val participantState = getOrCreateParticipant(participant.session_id, participant.user_id)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1094,11 +1094,6 @@ public class CallState(
     }
 
     internal fun getOrCreateParticipant(participant: Participant): ParticipantState {
-        // get or create the participant and update them
-        if (participant.session_id.isEmpty()) {
-            throw IllegalStateException("Participant session id is empty")
-        }
-
         val participantState = getOrCreateParticipant(participant.session_id, participant.user_id)
         participantState.updateFromParticipantInfo(participant)
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1094,6 +1094,11 @@ public class CallState(
     }
 
     internal fun getOrCreateParticipant(participant: Participant): ParticipantState {
+        if (participant.session_id.isEmpty()) {
+            // Empty session ID is technically allowed but should not happen.
+            logger.w { "A user with empty session ID joined the call." }
+        }
+
         val participantState = getOrCreateParticipant(participant.session_id, participant.user_id)
         participantState.updateFromParticipantInfo(participant)
 


### PR DESCRIPTION
# Goal
The goal of this PR is to relax the validation of the session_id and allow for an empty one which is technically allowed.