### PR TITLE
Fix call reconnection issue

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoImpl.kt
@@ -178,7 +178,17 @@ internal class StreamVideoImpl internal constructor(
     /** if true we fail fast on errors instead of logging them */
 
     /** session id is generated client side */
-    public val sessionId = UUID.randomUUID().toString()
+    public var sessionId: String = ""
+        get() {
+            if (field.isEmpty()) generateNewSessionId()
+            return field
+        }
+        private set
+
+    internal fun generateNewSessionId() {
+        sessionId = UUID.randomUUID().toString()
+        logger.d { "[generateNewSessionId] sessionId: $sessionId" }
+    }
 
     internal var guestUserJob: Deferred<Unit>? = null
     private lateinit var connectContinuation: Continuation<Result<ConnectedEvent>>

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -127,6 +127,7 @@ import stream.video.sfu.signal.UpdateMuteStatesRequest
 import stream.video.sfu.signal.UpdateMuteStatesResponse
 import stream.video.sfu.signal.UpdateSubscriptionsRequest
 import stream.video.sfu.signal.UpdateSubscriptionsResponse
+import java.util.UUID
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 
@@ -210,7 +211,7 @@ public class RtcSession internal constructor(
             null,
         )
 
-    internal val sessionId = clientImpl.sessionId
+    internal val sessionId = UUID.randomUUID().toString()
 
     val trackDimensions =
         MutableStateFlow<Map<String, Map<TrackType, TrackDimensions>>>(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -127,7 +127,6 @@ import stream.video.sfu.signal.UpdateMuteStatesRequest
 import stream.video.sfu.signal.UpdateMuteStatesResponse
 import stream.video.sfu.signal.UpdateSubscriptionsRequest
 import stream.video.sfu.signal.UpdateSubscriptionsResponse
-import java.util.UUID
 import kotlin.math.absoluteValue
 import kotlin.random.Random
 
@@ -211,7 +210,7 @@ public class RtcSession internal constructor(
             null,
         )
 
-    internal val sessionId = UUID.randomUUID().toString()
+    internal val sessionId get() = clientImpl.sessionId
 
     val trackDimensions =
         MutableStateFlow<Map<String, Map<TrackType, TrackDimensions>>>(


### PR DESCRIPTION
### 🎯 Goal

Fix issue when call reconnects indefinitely when connectivity breaks and is restored.

### 🛠 Implementation details

- Changed `Call#handleSignalChannelDisconnect` to enable rejoin retries.
- Generating a new session id and using the client impl as a source of truth for it.

### 🧪 Testing

- Livestream
- Normal call