### PR TITLE
[PBE-6219] Make number of participants more accurate in call session (lobby)

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
@@ -73,6 +73,7 @@ import io.getstream.video.android.compose.ui.components.call.lobby.CallLobby
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.call.state.ToggleCamera
 import io.getstream.video.android.core.call.state.ToggleMicrophone
+import io.getstream.video.android.core.events.ParticipantCount
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewCall
 import io.getstream.video.android.mock.previewUsers
@@ -270,10 +271,9 @@ private fun CallLobbyBody(
 private fun LobbyDescription(
     callLobbyViewModel: CallLobbyViewModel,
 ) {
-    val session by callLobbyViewModel.call.state.session.collectAsState()
-    val participantsSize = session?.participants?.size ?: 0
+    val participantCounts by callLobbyViewModel.call.state.participantCounts.collectAsState()
 
-    LobbyDescriptionContent(participantsSize = participantsSize) {
+    LobbyDescriptionContent(participantCounts = participantCounts) {
         callLobbyViewModel.handleUiEvent(
             CallLobbyEvent.JoinCall,
         )
@@ -281,12 +281,16 @@ private fun LobbyDescription(
 }
 
 @Composable
-private fun LobbyDescriptionContent(participantsSize: Int, onClick: () -> Unit) {
-    val text = if (participantsSize > 0) {
+private fun LobbyDescriptionContent(participantCounts: ParticipantCount?, onClick: () -> Unit) {
+    val totalParticipants = participantCounts?.total ?: 0
+    val anonParticipants = participantCounts?.anonymous ?: 0
+
+    val text = if (totalParticipants != 0) {
         Pair(
             stringResource(
                 id = R.string.join_call_description,
-                participantsSize,
+                totalParticipants,
+                anonParticipants,
             ),
             stringResource(id = R.string.join_call),
         )
@@ -384,8 +388,7 @@ private fun CallLobbyBodyPreview() {
             onToggleMicrophone = {},
             onToggleCamera = {},
         ) {
-            LobbyDescriptionContent(participantsSize = 0) {
-            }
+            LobbyDescriptionContent(participantCounts = ParticipantCount(1, 1)) {}
         }
     }
 }

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -31,7 +31,7 @@
     <string name="join_description">Start a new call, join a meeting by \nentering the call ID or by scanning \na QR code.</string>
     <string name="join_call">Join Call</string>
     <string name="join_call_by_qr_code">Scan QR meeting code</string>
-    <string name="join_call_description">You are about to join a call. %d more people are in the call.</string>
+    <string name="join_call_description">You are about to join a call. %d more people are in the call (%d anonymous).</string>
     <string name="join_call_no_id_hint">Don\'t have a Call ID?</string>
     <string name="join_call_call_id_hint">Call ID</string>
     <string name="start_a_new_call">Start a New Call</string>

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -7197,6 +7197,30 @@ public final class org/openapitools/client/models/CallSessionEndedEvent : org/op
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class org/openapitools/client/models/CallSessionParticipantCountsUpdatedEvent : org/openapitools/client/models/VideoEvent, org/openapitools/client/models/WSCallEvent {
+	public fun <init> (ILjava/lang/String;Lorg/threeten/bp/OffsetDateTime;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/lang/String;Lorg/threeten/bp/OffsetDateTime;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lorg/threeten/bp/OffsetDateTime;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Lorg/threeten/bp/OffsetDateTime;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)Lorg/openapitools/client/models/CallSessionParticipantCountsUpdatedEvent;
+	public static synthetic fun copy$default (Lorg/openapitools/client/models/CallSessionParticipantCountsUpdatedEvent;ILjava/lang/String;Lorg/threeten/bp/OffsetDateTime;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lorg/openapitools/client/models/CallSessionParticipantCountsUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnonymousParticipantCount ()I
+	public fun getCallCID ()Ljava/lang/String;
+	public final fun getCallCid ()Ljava/lang/String;
+	public final fun getCreatedAt ()Lorg/threeten/bp/OffsetDateTime;
+	public fun getEventType ()Ljava/lang/String;
+	public final fun getParticipantsCountByRole ()Ljava/util/Map;
+	public final fun getSessionId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class org/openapitools/client/models/CallSessionParticipantJoinedEvent : org/openapitools/client/models/VideoEvent, org/openapitools/client/models/WSCallEvent {
 	public fun <init> (Ljava/lang/String;Lorg/threeten/bp/OffsetDateTime;Lorg/openapitools/client/models/CallParticipantResponse;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Lorg/threeten/bp/OffsetDateTime;Lorg/openapitools/client/models/CallParticipantResponse;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -7242,23 +7266,25 @@ public final class org/openapitools/client/models/CallSessionParticipantLeftEven
 }
 
 public final class org/openapitools/client/models/CallSessionResponse {
-	public fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;)V
-	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/Map;ILjava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;)V
+	public synthetic fun <init> (Ljava/util/Map;ILjava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/Map;
 	public final fun component10 ()Lorg/threeten/bp/OffsetDateTime;
 	public final fun component11 ()Lorg/threeten/bp/OffsetDateTime;
-	public final fun component2 ()Ljava/lang/String;
-	public final fun component3 ()Ljava/util/Map;
-	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Ljava/util/Map;
+	public final fun component12 ()Lorg/threeten/bp/OffsetDateTime;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/List;
 	public final fun component6 ()Ljava/util/Map;
-	public final fun component7 ()Lorg/threeten/bp/OffsetDateTime;
+	public final fun component7 ()Ljava/util/Map;
 	public final fun component8 ()Lorg/threeten/bp/OffsetDateTime;
 	public final fun component9 ()Lorg/threeten/bp/OffsetDateTime;
-	public final fun copy (Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;)Lorg/openapitools/client/models/CallSessionResponse;
-	public static synthetic fun copy$default (Lorg/openapitools/client/models/CallSessionResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;ILjava/lang/Object;)Lorg/openapitools/client/models/CallSessionResponse;
+	public final fun copy (Ljava/util/Map;ILjava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;)Lorg/openapitools/client/models/CallSessionResponse;
+	public static synthetic fun copy$default (Lorg/openapitools/client/models/CallSessionResponse;Ljava/util/Map;ILjava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;Lorg/threeten/bp/OffsetDateTime;ILjava/lang/Object;)Lorg/openapitools/client/models/CallSessionResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAcceptedBy ()Ljava/util/Map;
+	public final fun getAnonymousParticipantCount ()I
 	public final fun getEndedAt ()Lorg/threeten/bp/OffsetDateTime;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getLiveEndedAt ()Lorg/threeten/bp/OffsetDateTime;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -773,7 +773,7 @@ public class CallState(
             }
 
             is SFUHealthCheckEvent -> {
-                call.state._participantCounts.value = event.participantCount
+                updateParticipantCounts(sfuHealthCheckEvent = event)
             }
 
             is ICETrickleEvent -> {
@@ -877,23 +877,26 @@ public class CallState(
                     )
                 }
 
-                // When in JOINED state, we should use the participant from SFU health check event, as it's more accurate.
-                if (connection.value !is RealtimeConnection.Joined) {
-                    _participantCounts.value = ParticipantCount(
-                        total = event.anonymousParticipantCount + event.participantsCountByRole.values.sum(),
-                        anonymous = event.anonymousParticipantCount,
-                    )
-                }
+                updateParticipantCounts(session = session.value)
             }
 
             is CallSessionParticipantLeftEvent -> {
                 _session.value?.let { callSessionResponse ->
                     val newList = callSessionResponse.participants.toMutableList()
                     newList.removeIf { it.userSessionId == event.participant.userSessionId }
+
+                    val newMap = callSessionResponse.participantsCountByRole.toMutableMap()
+                    newMap
+                        .computeIfPresent(event.participant.role) { _, v -> maxOf(v - 1, 0) }
+                        .also { if (it == 0) newMap.remove(event.participant.role) }
+
                     _session.value = callSessionResponse.copy(
-                        participants = newList.toList(),
+                        participants = newList,
+                        participantsCountByRole = newMap,
                     )
                 }
+
+                updateParticipantCounts(session = session.value)
             }
 
             is CallSessionParticipantJoinedEvent -> {
@@ -902,26 +905,37 @@ public class CallState(
                     val participant = CallParticipantResponse(
                         user = event.participant.user,
                         joinedAt = event.createdAt,
-                        role = "user",
+                        role = event.participant.user.role,
                         userSessionId = event.participant.userSessionId,
                     )
+                    val newMap = callSessionResponse.participantsCountByRole.toMutableMap()
+                    newMap.merge(event.participant.role, 1, Int::plus)
+
+                    // It could happen that the backend delivers the same participant more than once.
+                    // Once with the call.session_started event and once again with the
+                    // call.session_participant_joined event. In this case,
+                    // we should update the existing participant and prevent duplicating it.
                     val index = newList.indexOfFirst { user.id == event.participant.user.id }
                     if (index == -1) {
                         newList.add(participant)
                     } else {
                         newList[index] = participant
                     }
+
                     _session.value = callSessionResponse.copy(
-                        participants = newList.toList(),
+                        participants = newList,
+                        participantsCountByRole = newMap,
                     )
                 }
+
+                updateParticipantCounts(session = session.value)
                 updateRingingState()
             }
         }
     }
 
     private fun updateServerSidePins(pins: List<PinUpdate>) {
-        // Update particioants that are still in the call
+        // Update participants that are still in the call
         val pinnedInCall = pins.filter {
             _participants.value.containsKey(it.sessionId)
         }
@@ -1043,6 +1057,19 @@ public class CallState(
             getOrCreateParticipant(it)
         }
         upsertParticipants(participantStates)
+    }
+
+    private fun updateParticipantCounts(session: CallSessionResponse? = null, sfuHealthCheckEvent: SFUHealthCheckEvent? = null) {
+        // When in JOINED state, we should use the participant from SFU health check event, as it's more accurate.
+
+        if (sfuHealthCheckEvent != null) {
+            _participantCounts.value = sfuHealthCheckEvent.participantCount
+        } else if (session != null && connection.value !is RealtimeConnection.Joined) {
+            _participantCounts.value = ParticipantCount(
+                total = session.anonymousParticipantCount + session.participantsCountByRole.values.sum(),
+                anonymous = session.anonymousParticipantCount,
+            )
+        }
     }
 
     fun markSpeakingAsMuted() {

--- a/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/CallSessionParticipantCountsUpdatedEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/CallSessionParticipantCountsUpdatedEvent.kt
@@ -23,7 +23,6 @@
 
 package org.openapitools.client.models
 
-import org.openapitools.client.models.CallParticipantResponse
 
 
 
@@ -37,59 +36,46 @@ import com.squareup.moshi.ToJson
 import org.openapitools.client.infrastructure.Serializer
 
 /**
+ * This event is sent when the participant counts in a call session are updated
  *
- *
- * @param acceptedBy
  * @param anonymousParticipantCount
- * @param id
- * @param missedBy
- * @param participants
+ * @param callCid
+ * @param createdAt
  * @param participantsCountByRole
- * @param rejectedBy
- * @param endedAt
- * @param liveEndedAt
- * @param liveStartedAt
- * @param startedAt
- * @param timerEndsAt
+ * @param sessionId Call session ID
+ * @param type The type of event: \"call.session_participant_count_updated\" in this case
  */
 
 
-data class CallSessionResponse (
-
-    @Json(name = "accepted_by")
-    val acceptedBy: kotlin.collections.Map<kotlin.String, org.threeten.bp.OffsetDateTime>,
+data class CallSessionParticipantCountsUpdatedEvent (
 
     @Json(name = "anonymous_participant_count")
     val anonymousParticipantCount: kotlin.Int,
 
-    @Json(name = "id")
-    val id: kotlin.String,
+    @Json(name = "call_cid")
+    val callCid: kotlin.String,
 
-    @Json(name = "missed_by")
-    val missedBy: kotlin.collections.Map<kotlin.String, org.threeten.bp.OffsetDateTime>,
-
-    @Json(name = "participants")
-    val participants: kotlin.collections.List<CallParticipantResponse>,
+    @Json(name = "created_at")
+    val createdAt: org.threeten.bp.OffsetDateTime,
 
     @Json(name = "participants_count_by_role")
     val participantsCountByRole: kotlin.collections.Map<kotlin.String, kotlin.Int>,
 
-    @Json(name = "rejected_by")
-    val rejectedBy: kotlin.collections.Map<kotlin.String, org.threeten.bp.OffsetDateTime>,
+    /* Call session ID */
+    @Json(name = "session_id")
+    val sessionId: kotlin.String,
 
-    @Json(name = "ended_at")
-    val endedAt: org.threeten.bp.OffsetDateTime? = null,
+    /* The type of event: \"call.session_participant_count_updated\" in this case */
+    @Json(name = "type")
+    val type: kotlin.String = "call.session_participant_count_updated"
 
-    @Json(name = "live_ended_at")
-    val liveEndedAt: org.threeten.bp.OffsetDateTime? = null,
+) : VideoEvent(), WSCallEvent {
 
-    @Json(name = "live_started_at")
-    val liveStartedAt: org.threeten.bp.OffsetDateTime? = null,
+    override fun getCallCID(): String {
+        return callCid
+    }
 
-    @Json(name = "started_at")
-    val startedAt: org.threeten.bp.OffsetDateTime? = null,
-
-    @Json(name = "timer_ends_at")
-    val timerEndsAt: org.threeten.bp.OffsetDateTime? = null
-
-)
+    override fun getEventType(): String {
+        return type
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/org/openapitools/client/models/VideoEvent.kt
@@ -141,6 +141,7 @@ class VideoEventAdapter : JsonAdapter<VideoEvent>() {
             "call.rejected" -> CallRejectedEvent::class.java
             "call.ring" -> CallRingEvent::class.java
             "call.session_ended" -> CallSessionEndedEvent::class.java
+            "call.session_participant_count_updated" -> CallSessionParticipantCountsUpdatedEvent::class.java
             "call.session_participant_joined" -> CallSessionParticipantJoinedEvent::class.java
             "call.session_participant_left" -> CallSessionParticipantLeftEvent::class.java
             "call.session_started" -> CallSessionStartedEvent::class.java


### PR DESCRIPTION
### 🎯 Goal

We need to handle the new `call.session_participant_count_updated` event & overall improve the participant count logic.

### 🛠 Implementation details

- Handling new `CallSessionParticipantCountsUpdatedEvent` event
- Improved existing participant events to update the `byRole` map in the call session
- Updating `call.state.participantCounts` from new event in lobby state and from SFU Health Check after join.