### PR TITLE
Change deprecation status for Sounds

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -5078,8 +5078,6 @@ public final class io/getstream/video/android/core/sounds/RingingConfigKt {
 }
 
 public final class io/getstream/video/android/core/sounds/Sounds {
-	public synthetic fun <init> (II)V
-	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lio/getstream/video/android/core/sounds/RingingConfig;)V
 	public final fun component1 ()Lio/getstream/video/android/core/sounds/RingingConfig;
 	public final fun copy (Lio/getstream/video/android/core/sounds/RingingConfig;)Lio/getstream/video/android/core/sounds/Sounds;

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -5078,7 +5078,7 @@ public final class io/getstream/video/android/core/sounds/RingingConfigKt {
 }
 
 public final class io/getstream/video/android/core/sounds/Sounds {
-	public fun <init> (II)V
+	public synthetic fun <init> (II)V
 	public synthetic fun <init> (IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lio/getstream/video/android/core/sounds/RingingConfig;)V
 	public final fun component1 ()Lio/getstream/video/android/core/sounds/RingingConfig;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
@@ -23,7 +23,6 @@ import androidx.annotation.RawRes
 import io.getstream.log.StreamLog
 import io.getstream.video.android.core.R
 import io.getstream.video.android.core.utils.safeCallWithDefault
-import org.jetbrains.annotations.ApiStatus
 
 // Interface & API
 /**
@@ -49,11 +48,10 @@ public interface RingingConfig {
     level = DeprecationLevel.WARNING,
 )
 public data class Sounds(val ringingConfig: RingingConfig) {
-    @ApiStatus.ScheduledForRemoval(inVersion = "1.0.18")
     @Deprecated(
         message = "Deprecated. This Constructor will now return a sound configuration with no sounds. Use constructor with SoundConfig parameter instead.",
         replaceWith = ReplaceWith("defaultResourcesRingingConfig(context).toSounds()"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.HIDDEN,
     )
     constructor(
         @RawRes incomingCallSound: Int = R.raw.call_incoming_sound,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
@@ -47,17 +47,7 @@ public interface RingingConfig {
     replaceWith = ReplaceWith("SoundConfig"),
     level = DeprecationLevel.WARNING,
 )
-public data class Sounds(val ringingConfig: RingingConfig) {
-    @Deprecated(
-        message = "Deprecated. This Constructor will now return a sound configuration with no sounds. Use constructor with SoundConfig parameter instead.",
-        replaceWith = ReplaceWith("defaultResourcesRingingConfig(context).toSounds()"),
-        level = DeprecationLevel.HIDDEN,
-    )
-    constructor(
-        @RawRes incomingCallSound: Int = R.raw.call_incoming_sound,
-        @RawRes outgoingCallSound: Int = R.raw.call_outgoing_sound,
-    ) : this(emptyRingingConfig())
-}
+public data class Sounds(val ringingConfig: RingingConfig)
 
 // Factories
 /**


### PR DESCRIPTION
### 🎯 Goal

Change deprecation info for Sounds

### 🛠 Implementation details

- ~~Made ctor that accepted resources `hidden`~~
- ~~Removed `ScheduledForRemoval`~~
- Actually removed the deprecated constructor after a second analysis.