### PR TITLE
[AND-162] Fix bug in video StreamCallActivity#initializeCallOrFail

### DIFF
--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -779,11 +779,13 @@ public abstract class StreamCallActivity : ComponentActivity() {
 
         if (cid == null) {
             val e = IllegalArgumentException("CallActivity started without call ID.")
-            logger.e(
-                e,
-            ) { "Failed to initialize call because call ID is not found in the intent. $intent" }
-            onError?.let {
-            } ?: throw e
+
+            logger.e(e) {
+                "Failed to initialize call because call ID is not found in the intent. $intent"
+            }
+
+            onError?.invoke(e) ?: throw e
+
             // Finish
             return
         }


### PR DESCRIPTION
### 🎯 Goal

Fix: initializeCallOrFail doesn't invoke onError lambda when it's not null.

### 🛠 Implementation details

- Invoke onError when it's not `null`.