### PR TITLE
[AND-164] Fix exception when entering PiP mode

### DIFF
--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -69,6 +69,8 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun onResume (Lio/getstream/video/android/core/Call;)V
 	public final fun onStop ()V
 	public fun onStop (Lio/getstream/video/android/core/Call;)V
+	public final fun onUserLeaveHint ()V
+	public fun onUserLeaveHint (Lio/getstream/video/android/core/Call;)V
 	public fun reject (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/model/RejectReason;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun reject$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/model/RejectReason;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 }

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -20,6 +20,7 @@ import android.app.PictureInPictureParams
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.os.PersistableBundle
@@ -231,6 +232,13 @@ public abstract class StreamCallActivity : ComponentActivity() {
         }
     }
 
+    public final override fun onUserLeaveHint() {
+        withCachedCall {
+            onUserLeaveHint(it)
+            super.onUserLeaveHint()
+        }
+    }
+
     public final override fun onPause() {
         withCachedCall {
             onPause(it)
@@ -352,20 +360,36 @@ public abstract class StreamCallActivity : ComponentActivity() {
     }
 
     /**
+     * Called when the activity is about to go into the background as the result of user choice. Makes sure the call object is available.
+     *
+     * @param call the call
+     */
+    public open fun onUserLeaveHint(call: Call) {
+        window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        // Default PiP behavior
+        if (packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) &&
+            isConnected(call) &&
+            !isChangingConfigurations &&
+            isVideoCall(call) &&
+            !isInPictureInPictureMode
+        ) {
+            try {
+                enterPictureInPicture()
+            } catch (e: Exception) {
+                logger.e(e) { "[onUserLeaveHint] Something went wrong when entering PiP." }
+            }
+        }
+
+        logger.d { "DefaultCallActivity - Leave Hinted (call -> $call)" }
+    }
+
+    /**
      * Called when the activity is paused. Makes sure the call object is available.
      *
      * @param call the call
      */
     public open fun onPause(call: Call) {
         window.clearFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-        // Default PiP behavior
-        if (isConnected(call) &&
-            !isChangingConfigurations &&
-            isVideoCall(call) &&
-            !isInPictureInPictureMode
-        ) {
-            enterPictureInPicture()
-        }
         logger.d { "DefaultCallActivity - Paused (call -> $call)" }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fix exception that happens when using `StreamCallActivity`:
> java.lang.RuntimeException: Unable to pause activity {com.alfamart.alfagift/com.alfamart.alfagift.screen.inappchat.call.CustomCallActivity}: java.lang.IllegalStateException: enterPictureInPictureMode: Current activity is not visible (state=STOPPING)

Cannot reproduce it, but might be caused by the activity going through `RESUMED` -> `PAUSED` -> `STOPPING` -> `STOPPED` before it gets the chance to enter PiP mode, as `enterPictureInPicture` is called in `onPause`.

### 🛠 Implementation details

- Moved `enterPictureInPicture` call to `onUserLeaveHint` in `StreamCallActivity` to lower the chance of the activity not being visible.
- Added exception handling.