### PR TITLE
Fix camera disable method

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -586,13 +586,12 @@ public class CameraManager(
     }
 
     fun disable(fromUser: Boolean = true) {
+        if (fromUser) _status.value = DeviceStatus.Disabled
+
         if (isCapturingVideo) {
             // 1. update our local state
             // 2. update the track enabled status
             // 3. Rtc listens and sends the update mute state request
-            if (fromUser) {
-                _status.value = DeviceStatus.Disabled
-            }
             mediaManager.videoTrack.trySetEnabled(false)
             videoCapturer.stopCapture()
             isCapturingVideo = false

--- a/tutorials/tutorial-livestream/src/main/kotlin/io/getstream/video/android/tutorial/livestream/LiveGuest.kt
+++ b/tutorials/tutorial-livestream/src/main/kotlin/io/getstream/video/android/tutorial/livestream/LiveGuest.kt
@@ -16,18 +16,16 @@
 
 package io.getstream.video.android.tutorial.livestream
 
-import android.widget.Toast
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import io.getstream.log.Priority
-import io.getstream.video.android.compose.permission.LaunchCallPermissions
 import io.getstream.video.android.compose.ui.components.call.CallAppBar
 import io.getstream.video.android.compose.ui.components.livestream.LivestreamPlayer
 import io.getstream.video.android.core.GEO
@@ -67,11 +65,11 @@ fun LiveAudience(
 
     // step3 - join a call, which type is `default` and id is `123`.
     val call = client.call("livestream", callId)
-    LaunchCallPermissions(call = call) {
-        val result = call.join()
-        result.onError {
-            Toast.makeText(context, "uh oh $it", Toast.LENGTH_SHORT).show()
-        }
+
+    LaunchedEffect(call) {
+        call.microphone.setEnabled(false, fromUser = true)
+        call.camera.setEnabled(false, fromUser = true)
+        call.join()
     }
 
     Box {

--- a/tutorials/tutorial-livestream/src/main/kotlin/io/getstream/video/android/tutorial/livestream/LiveHost.kt
+++ b/tutorials/tutorial-livestream/src/main/kotlin/io/getstream/video/android/tutorial/livestream/LiveHost.kt
@@ -44,7 +44,9 @@ import androidx.navigation.NavController
 import io.getstream.log.Priority
 import io.getstream.video.android.compose.permission.LaunchCallPermissions
 import io.getstream.video.android.compose.theme.VideoTheme
+import io.getstream.video.android.compose.ui.components.call.controls.actions.FlipCameraAction
 import io.getstream.video.android.compose.ui.components.call.controls.actions.LeaveCallAction
+import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleCameraAction
 import io.getstream.video.android.compose.ui.components.video.VideoRenderer
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.GEO
@@ -158,6 +160,8 @@ private fun LiveHostContent(
             }
         },
         bottomBar = {
+            val isCameraEnabled by call.camera.isEnabled.collectAsState()
+
             Row {
                 Button(
                     colors = ButtonDefaults.buttonColors(
@@ -174,6 +178,14 @@ private fun LiveHostContent(
                         text = if (backstage) "Start Broadcast" else "Stop Broadcast",
                         color = Color.White,
                     )
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                ToggleCameraAction(isCameraEnabled = isCameraEnabled) {
+                    call.camera.setEnabled(it.isEnabled)
+                }
+                Spacer(modifier = Modifier.width(16.dp))
+                FlipCameraAction {
+                    call.camera.flip()
                 }
                 Spacer(modifier = Modifier.width(16.dp))
                 LeaveCallAction {


### PR DESCRIPTION
### 🎯 Goal

Trying to disable camera before joining didn't work.

### 🛠 Implementation details

The cause was that the camera status was not updated, causing it to be always overridden by the dashboard settings.