### PR TITLE
Add core desugar library for using Java 8

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ threetenAbp = "1.4.7"
 tink = "1.9.0"
 turbine = "0.13.0"
 itu = "1.7.3"
+desugar = "2.0.3"
 
 streamWebRTC = "1.3.6"
 streamNoiseCancellation = "1.0.2"
@@ -143,6 +144,7 @@ threentenabp2 = { group = "com.jakewharton.threetenabp", name = "threetenabp", v
 tink = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink" }
 turbine = { group = "app.cash.turbine", name = "turbine", version.ref = "turbine" }
 ituDate = { group = "com.ethlo.time", name = "itu", version.ref = "itu" }
+desugar = { group = "com.android.tools" , name = "desugar_jdk_libs", version.ref = "desugar" }
 
 stream-webrtc = { group = "io.getstream", name = "stream-webrtc-android", version.ref = "streamWebRTC" }
 stream-webrtc-ui = { group = "io.getstream", name = "stream-webrtc-android-ui", version.ref = "streamWebRTC" }

--- a/stream-video-android-core/build.gradle.kts
+++ b/stream-video-android-core/build.gradle.kts
@@ -66,6 +66,10 @@ android {
     namespace = "io.getstream.video.android.core"
     compileSdk = Configuration.compileSdk
 
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
+
     defaultConfig {
         minSdk = Configuration.minSdk
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -185,13 +189,15 @@ dependencies {
     implementation(libs.stream.push.delegate)
     api(libs.stream.push.permissions)
 
-
     // datastore
     api(libs.androidx.datastore)
     api(libs.androidx.datastore.core)
 
     // crypto
     implementation(libs.tink)
+
+    // desugar
+    coreLibraryDesugaring(libs.desugar)
 
     // unit tests
     testImplementation(libs.junit)


### PR DESCRIPTION
### 🎯 Goal

We still use Java 8 functions, such as `epochSecond` and `toEpochMilli`, which require a minimum SDK level of 26 for compilation. To ensure compatibility and proper functionality on devices running SDK levels below 26, we need to configure the desugar library in our project.

https://developer.android.com/studio/write/java8-support