### PR TITLE
Fix UI on API 35 devices

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
@@ -20,6 +20,9 @@ import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.ui.Modifier
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
@@ -70,6 +73,9 @@ class MainActivity : ComponentActivity() {
             setContent {
                 VideoTheme {
                     AppNavHost(
+                        modifier = Modifier
+                            .background(VideoTheme.colors.baseSheetPrimary)
+                            .systemBarsPadding(),
                         startDestination = if (!isLoggedIn) {
                             AppScreens.Login.routeWithArg(true) // Pass true for autoLogIn
                         } else {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -97,124 +98,130 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
     override fun setContent(activity: StreamCallActivity, call: Call) {
         logger.d { "[setContent(activity, call)] invoked from compose delegate." }
         activity.setContent {
-            logger.d { "[setContent] with RootContent" }
-            activity.RootContent(call = call)
+            VideoTheme {
+                Box(
+                    modifier = Modifier
+                        .background(VideoTheme.colors.baseSheetPrimary)
+                        .systemBarsPadding(),
+                ) {
+                    logger.d { "[setContent] with RootContent" }
+                    activity.RootContent(call = call)
+                }
+            }
         }
     }
 
     @StreamCallActivityDelicateApi
     @Composable
     override fun StreamCallActivity.RootContent(call: Call) {
-        VideoTheme {
-            var callAction: CallAction by remember {
-                mutableStateOf(CustomAction(tag = "initial"))
+        var callAction: CallAction by remember {
+            mutableStateOf(CustomAction(tag = "initial"))
+        }
+
+        when (callAction) {
+            is LeaveCall, is DeclineCall, is CancelCall -> {
+                CallDisconnectedContent(call)
             }
 
-            when (callAction) {
-                is LeaveCall, is DeclineCall, is CancelCall -> {
-                    CallDisconnectedContent(call)
-                }
-
-                else -> {
-                    LaunchPermissionRequest(listOf(Manifest.permission.RECORD_AUDIO)) {
-                        AllPermissionsGranted {
-                            // All permissions granted
-                            RingingCallContent(
-                                isVideoType = isVideoCall(call),
-                                call = call,
-                                modifier = Modifier.background(
-                                    color = VideoTheme.colors.baseSheetPrimary,
-                                ),
-                                onBackPressed = {
-                                    onBackPressed(call)
-                                },
-                                onOutgoingContent = {
-                                        modifier: Modifier,
-                                        call: Call,
-                                        isVideoType: Boolean,
-                                        isShowingHeader: Boolean,
-                                        headerContent: @Composable (ColumnScope.() -> Unit)?,
-                                        detailsContent: @Composable (
-                                            ColumnScope.(
-                                                participants: List<MemberState>,
-                                                topPadding: Dp,
-                                            ) -> Unit
-                                        )?,
-                                        controlsContent: @Composable (BoxScope.() -> Unit)?,
-                                        onBackPressed: () -> Unit,
-                                        onCallAction: (CallAction) -> Unit,
-                                    ->
-                                    OutgoingCallContent(
-                                        call = call,
-                                        isVideoType = isVideoType,
-                                        modifier = modifier,
-                                        isShowingHeader = isShowingHeader,
-                                        headerContent = headerContent,
-                                        detailsContent = detailsContent,
-                                        controlsContent = controlsContent,
-                                        onBackPressed = onBackPressed,
-                                        onCallAction = onCallAction,
-                                    )
-                                },
-                                onIncomingContent = {
-                                        modifier: Modifier,
-                                        call: Call,
-                                        isVideoType: Boolean, isShowingHeader: Boolean,
-                                        headerContent: @Composable (ColumnScope.() -> Unit)?,
-                                        detailsContent: @Composable (
-                                            ColumnScope.(
-                                                participants: List<MemberState>,
-                                                topPadding: Dp,
-                                            ) -> Unit
-                                        )?,
-                                        controlsContent: @Composable (BoxScope.() -> Unit)?,
-                                        onBackPressed: () -> Unit,
-                                        onCallAction: (CallAction) -> Unit,
-                                    ->
-                                    IncomingCallContent(
-                                        call = call,
-                                        isVideoType = isVideoType,
-                                        modifier = modifier,
-                                        isShowingHeader = isShowingHeader,
-                                        headerContent = headerContent,
-                                        detailsContent = detailsContent,
-                                        controlsContent = controlsContent,
-                                        onBackPressed = onBackPressed,
-                                        onCallAction = onCallAction,
-                                    )
-                                },
-                                onAcceptedContent = {
-                                    ConnectionAvailable(call = call) { theCall ->
-                                        if (isVideoCall(theCall)) {
-                                            VideoCallContent(call = theCall)
-                                        } else {
-                                            AudioCallContent(call = theCall)
-                                        }
+            else -> {
+                LaunchPermissionRequest(listOf(Manifest.permission.RECORD_AUDIO)) {
+                    AllPermissionsGranted {
+                        // All permissions granted
+                        RingingCallContent(
+                            isVideoType = isVideoCall(call),
+                            call = call,
+                            modifier = Modifier.background(
+                                color = VideoTheme.colors.baseSheetPrimary,
+                            ),
+                            onBackPressed = {
+                                onBackPressed(call)
+                            },
+                            onOutgoingContent = {
+                                    modifier: Modifier,
+                                    call: Call,
+                                    isVideoType: Boolean,
+                                    isShowingHeader: Boolean,
+                                    headerContent: @Composable (ColumnScope.() -> Unit)?,
+                                    detailsContent: @Composable (
+                                        ColumnScope.(
+                                            participants: List<MemberState>,
+                                            topPadding: Dp,
+                                        ) -> Unit
+                                    )?,
+                                    controlsContent: @Composable (BoxScope.() -> Unit)?,
+                                    onBackPressed: () -> Unit,
+                                    onCallAction: (CallAction) -> Unit,
+                                ->
+                                OutgoingCallContent(
+                                    call = call,
+                                    isVideoType = isVideoType,
+                                    modifier = modifier,
+                                    isShowingHeader = isShowingHeader,
+                                    headerContent = headerContent,
+                                    detailsContent = detailsContent,
+                                    controlsContent = controlsContent,
+                                    onBackPressed = onBackPressed,
+                                    onCallAction = onCallAction,
+                                )
+                            },
+                            onIncomingContent = {
+                                    modifier: Modifier,
+                                    call: Call,
+                                    isVideoType: Boolean, isShowingHeader: Boolean,
+                                    headerContent: @Composable (ColumnScope.() -> Unit)?,
+                                    detailsContent: @Composable (
+                                        ColumnScope.(
+                                            participants: List<MemberState>,
+                                            topPadding: Dp,
+                                        ) -> Unit
+                                    )?,
+                                    controlsContent: @Composable (BoxScope.() -> Unit)?,
+                                    onBackPressed: () -> Unit,
+                                    onCallAction: (CallAction) -> Unit,
+                                ->
+                                IncomingCallContent(
+                                    call = call,
+                                    isVideoType = isVideoType,
+                                    modifier = modifier,
+                                    isShowingHeader = isShowingHeader,
+                                    headerContent = headerContent,
+                                    detailsContent = detailsContent,
+                                    controlsContent = controlsContent,
+                                    onBackPressed = onBackPressed,
+                                    onCallAction = onCallAction,
+                                )
+                            },
+                            onAcceptedContent = {
+                                ConnectionAvailable(call = call) { theCall ->
+                                    if (isVideoCall(theCall)) {
+                                        VideoCallContent(call = theCall)
+                                    } else {
+                                        AudioCallContent(call = theCall)
                                     }
-                                },
-                                onNoAnswerContent = {
-                                    NoAnswerContent(call)
-                                },
-                                onRejectedContent = {
-                                    RejectedContent(call)
-                                },
-                                onCallAction = {
-                                    onCallAction(call, it)
-                                    callAction = it
-                                },
-                                onIdle = {
-                                    LoadingContent(call)
-                                },
-                            )
-                        }
+                                }
+                            },
+                            onNoAnswerContent = {
+                                NoAnswerContent(call)
+                            },
+                            onRejectedContent = {
+                                RejectedContent(call)
+                            },
+                            onCallAction = {
+                                onCallAction(call, it)
+                                callAction = it
+                            },
+                            onIdle = {
+                                LoadingContent(call)
+                            },
+                        )
+                    }
 
-                        SomeGranted { granted, notGranted, showRationale ->
-                            InternalPermissionContent(showRationale, call, granted, notGranted)
-                        }
+                    SomeGranted { granted, notGranted, showRationale ->
+                        InternalPermissionContent(showRationale, call, granted, notGranted)
+                    }
 
-                        NoneGranted {
-                            InternalPermissionContent(it, call, emptyList(), emptyList())
-                        }
+                    NoneGranted {
+                        InternalPermissionContent(it, call, emptyList(), emptyList())
                     }
                 }
             }


### PR DESCRIPTION
### 🎯 Goal

From API 35 onwards, the app is displayed edge-to-edge. The window spans the entire width and height of the display by drawing behind the system bars. System bars include the status bar, caption bar, and navigation bar.

To prevent content from being rendered behind those bars, some paddings need to be applied.

### 🎨 UI Changes

#### API 35

| Before | After |
| --- | --- |
| ![api35_mainscreen](https://github.com/user-attachments/assets/55927ec6-46fd-4858-808a-c1247b3689e0) | ![fix_api35_mainscreen](https://github.com/user-attachments/assets/3029a33d-24e6-46da-856d-260d4ee52738) |
| ![api35_joinscreen](https://github.com/user-attachments/assets/06944cec-7b77-4b36-af77-bcfa3dbf6d4a) | ![fix_api35_joinscreen](https://github.com/user-attachments/assets/003ba798-02ff-48bb-945f-29a385824295) |
| ![api35_callscreen](https://github.com/user-attachments/assets/9299cc95-217d-4b12-9fad-2febf082cbf6) | ![fix_api35_callscreen](https://github.com/user-attachments/assets/2b70969e-cffc-4852-8086-cf82fed58fea) |

#### API 30 (no side-effects should be introduced to the previous API)

| Before | After |
| --- | --- |
| ![api30_mainscreen](https://github.com/user-attachments/assets/14a05b78-c11b-463f-9c9a-3f0679f16ee3) | ![fix_api30_mainscreen](https://github.com/user-attachments/assets/930f4902-6e47-493b-a969-a658a0ea001e) |
| ![api30_joinscreen](https://github.com/user-attachments/assets/f2c3171d-0720-483f-a75b-39dc04a32d30) | ![fix_api30_joinscreen](https://github.com/user-attachments/assets/917b6933-ae81-4c2e-b196-4ddb69c910c4) |
| ![api30_callscreen](https://github.com/user-attachments/assets/2ecd430b-60b9-409b-b31a-1d9d82f110f9) | ![fix_api30_callscreen](https://github.com/user-attachments/assets/5b551f83-4c1b-4f59-bc5f-dbb9c18a2d70) |
