### PR TITLE
AND-27 Improve behaviour when receiving incoming call when device is locked

### DIFF
--- a/demo-app/src/main/AndroidManifest.xml
+++ b/demo-app/src/main/AndroidManifest.xml
@@ -75,8 +75,8 @@
         <activity
             android:name=".CallActivity"
             android:supportsPictureInPicture="true"
-            android:showOnLockScreen="true"
             android:showWhenLocked="true"
+            android:turnScreenOn="true"
             android:launchMode="singleTop"
             android:exported="false">
             <intent-filter android:priority="1">

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -375,6 +375,7 @@ public class io/getstream/video/android/compose/ui/ComposeStreamCallActivity : i
 	public static final field $stable I
 	public fun <init> ()V
 	public fun getUiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
+	public fun onPreCreate (Landroid/os/Bundle;Landroid/os/PersistableBundle;)V
 }
 
 public class io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate : io/getstream/video/android/compose/ui/StreamCallActivityComposeUi {

--- a/stream-video-android-ui-compose/src/main/AndroidManifest.xml
+++ b/stream-video-android-ui-compose/src/main/AndroidManifest.xml
@@ -24,8 +24,8 @@
         <activity
         android:name=".ui.ComposeStreamCallActivity"
         android:supportsPictureInPicture="true"
-        android:showOnLockScreen="true"
         android:showWhenLocked="true"
+        android:turnScreenOn="true"
         android:launchMode="singleTop"
         android:exported="false">
         <intent-filter android:priority="1">

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/ComposeStreamCallActivity.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/ComposeStreamCallActivity.kt
@@ -16,8 +16,14 @@
 
 package io.getstream.video.android.compose.ui
 
+import android.app.KeyguardManager
+import android.os.Build
+import android.os.Bundle
+import android.os.PersistableBundle
+import android.view.WindowManager
 import io.getstream.video.android.ui.common.StreamActivityUiDelegate
 import io.getstream.video.android.ui.common.StreamCallActivity
+import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
 
 /**
  * Default [StreamCallActivity] for use with compose.
@@ -27,4 +33,24 @@ public open class ComposeStreamCallActivity : StreamCallActivity() {
 
     override val uiDelegate: StreamActivityUiDelegate<StreamCallActivity> =
         StreamCallActivityComposeDelegate()
+
+    @StreamCallActivityDelicateApi
+    override fun onPreCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
+        enableDisplayOnLockScreen()
+        super.onPreCreate(savedInstanceState, persistentState)
+    }
+
+    private fun enableDisplayOnLockScreen() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1) {
+            val keyguardManager = getSystemService(KEYGUARD_SERVICE) as? KeyguardManager
+            keyguardManager?.requestDismissKeyguard(this, null)
+        } else {
+            @Suppress("DEPRECATION")
+            window.addFlags(
+                WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
+                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+            )
+        }
+    }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/ComposeStreamCallActivity.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/ComposeStreamCallActivity.kt
@@ -48,8 +48,8 @@ public open class ComposeStreamCallActivity : StreamCallActivity() {
             @Suppress("DEPRECATION")
             window.addFlags(
                 WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD or
-                        WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
-                        WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON,
             )
         }
     }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -235,7 +235,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         granted: List<String>,
         notGranted: List<String>,
     ) {
-        if (!showRationale && configuration.canSkiPermissionRationale) {
+        if (!showRationale && configuration.canSkipPermissionRationale) {
             logger.w { "Permissions were not granted, but rationale is required to be skipped." }
             finish()
         } else {

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -93,7 +93,7 @@ public final class io/getstream/video/android/ui/common/StreamCallActivityConfig
 	public static synthetic fun copy$default (Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;ZZZZLandroid/os/Bundle;ILjava/lang/Object;)Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanKeepScreenOn ()Z
-	public final fun getCanSkiPermissionRationale ()Z
+	public final fun getCanSkipPermissionRationale ()Z
 	public final fun getCloseScreenOnCallEnded ()Z
 	public final fun getCloseScreenOnError ()Z
 	public final fun getCustom ()Landroid/os/Bundle;

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivityConfiguration.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivityConfiguration.kt
@@ -36,7 +36,7 @@ public data class StreamCallActivityConfiguration(
     /** When the call has ended for any reason, close the screen */
     val closeScreenOnCallEnded: Boolean = true,
     /** When set to false, the activity will simply ignore the `showRationale` from the system and show the rationale screen anyway. */
-    val canSkiPermissionRationale: Boolean = true,
+    val canSkipPermissionRationale: Boolean = true,
     /** When set to true, the activity will keep the screen on. */
     val canKeepScreenOn: Boolean = true,
     /**
@@ -62,7 +62,7 @@ public fun Bundle.extractStreamActivityConfig(): StreamCallActivityConfiguration
         closeScreenOnError = closeScreenOnError,
         closeScreenOnCallEnded = closeScreenOnCallEnded,
         canKeepScreenOn = canKeepScreenOn,
-        canSkiPermissionRationale = canSkipPermissionRationale,
+        canSkipPermissionRationale = canSkipPermissionRationale,
         custom = custom,
     )
 }
@@ -76,7 +76,7 @@ public fun StreamCallActivityConfiguration.toBundle(): Bundle {
     bundle.putBoolean(StreamCallActivityConfigStrings.EXTRA_CLOSE_ON_ENDED, closeScreenOnCallEnded)
     bundle.putBoolean(
         StreamCallActivityConfigStrings.EXTRA_CAN_SKIP_RATIONALE,
-        canSkiPermissionRationale,
+        canSkipPermissionRationale,
     )
     bundle.putBoolean(StreamCallActivityConfigStrings.EXTRA_KEEP_SCREEN_ON, canKeepScreenOn)
     bundle.putBundle(StreamCallActivityConfigStrings.EXTRA_CUSTOM, custom)


### PR DESCRIPTION
### 🎯 Goal

Handle incoming call when device is locked.

GH issue [here](https://github.com/GetStream/stream-video-android/issues/1215) and Zendesk ticket [here](https://getstream.zendesk.com/tickets/58153).

### 🛠 Implementation details

- For default `ComposeStreamCallActivity` activity now we have
  - In `Manifest`: `showWhenLocked` and `turnScreenOn`. Removed `showOnLockScreen`, as it's deprecated.
  - In `onPreCreate`: code that handles `requestDismissKeyguard` and above flags, depending on Android version.
- For `demo-app` example `CallActivity`
  - In `Manifest`: `showWhenLocked` and `turnScreenOn`. Removed `showOnLockScreen`, as it's deprecated.

👉 `showWhenLocked` and `turnScreenOn` are recommended to be set in the `Manifest`, not in code with, therefore to disable showing on lock screen, users will need to set these flags to `false` in the `Manifest` for the activity that handles the `INCOMING_CALL` action and inherits `ComposeStreamCallActivity`.


### 🎨 UI Changes

The activity is now shown when receiving an incoming call while the screen is locked and the keyguard is dismissed. Accepting/rejecting the call works.

![Screen Recording 2025-01-07 at 13 20 12](https://github.com/user-attachments/assets/c7f2f3d0-725c-4e80-a739-ebc72f391a9f)