### PR TITLE
[AND-198] Improve behaviour when receiving incoming call during active call

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -31,6 +31,7 @@ import io.getstream.video.android.compose.ui.ComposeStreamCallActivity
 import io.getstream.video.android.compose.ui.StreamCallActivityComposeDelegate
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.StreamVideo
+import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.ui.call.CallScreen
 import io.getstream.video.android.ui.common.StreamActivityUiDelegate
@@ -47,6 +48,19 @@ class CallActivity : ComposeStreamCallActivity() {
     override val uiDelegate: StreamActivityUiDelegate<StreamCallActivity> = StreamDemoUiDelegate()
     override val configuration: StreamCallActivityConfiguration =
         StreamCallActivityConfiguration(closeScreenOnCallEnded = false)
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+
+        if (intent.action == NotificationHandler.ACTION_ACCEPT_CALL) {
+            val activeCall = StreamVideo.instance().state.activeCall.value
+            if (activeCall != null) {
+                leave(activeCall)
+                finish()
+                startActivity(intent)
+            }
+        }
+    }
 
     @StreamCallActivityDelicateApi
     override fun onPreCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -411,7 +411,9 @@ internal open class CallService : Service() {
 
     @SuppressLint("MissingPermission")
     private fun showIncomingCall(notificationId: Int, notification: Notification) {
-        if (callId == null) { // If there isn't another call in progress (callId is set in onStartCommand())
+        val hasActiveCall = StreamVideo.instanceOrNull()?.state?.activeCall?.value != null
+
+        if (!hasActiveCall) { // If there isn't another call in progress
             // The service was started with startForegroundService() (from companion object), so we need to call startForeground().
             startForegroundWithServiceType(
                 notificationId,


### PR DESCRIPTION
### 🎯 Goal

Current active call should be left and new incoming call should be accepted & joined.

### 🛠 Implementation details

- Changed how we check for an active call in `CallService`
- Added code to handle new incoming call in example `CallActivity`
- 👉 There is still a case when the new incoming call notification is not dismissed, depending on the call service config, but it is rare as almost always incoming calls will start the fg service, so leaving that for later. Probably it will be touched by the `Telecom` implementation.