### PR TITLE
bundleRelease requires versionCode

### DIFF
--- a/metrics/stream-video-android-metrics/build.gradle.kts
+++ b/metrics/stream-video-android-metrics/build.gradle.kts
@@ -10,6 +10,7 @@ android {
 
     defaultConfig {
         minSdk = Configuration.minSdk
+        versionCode = 1
         ndk {
             abiFilters += "armeabi-v7a"
         }


### PR DESCRIPTION
The release pipeline calls `bundleRelease` that triggers bundling for all the application modules, including the metrics project.
`assembleRelease` doesn't require `versionCode` but `bundleRelease` requires it.

I ran `bundleRelease` locally, and it worked after setting a `versionCode` for the metrics project
