### PR TITLE
[AND-336] Fix: BT headset stuck in call after leaving call

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
@@ -104,7 +104,10 @@ fun CallLobbyScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             CallLobbyHeader(
-                onBack = onBack,
+                onBack = {
+                    callLobbyViewModel.leaveCall()
+                    onBack()
+                },
                 callLobbyViewModel = callLobbyViewModel,
             )
 

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyViewModel.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyViewModel.kt
@@ -180,6 +180,10 @@ class CallLobbyViewModel @Inject constructor(
             StreamVideo.removeClient()
         }
     }
+
+    fun leaveCall() {
+        call.leave()
+    }
 }
 
 sealed interface CallLobbyUiState {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -459,18 +459,21 @@ class MicrophoneManager(
         }
 
         if (canHandleDeviceSwitch()) {
-            audioHandler = AudioSwitchHandler(mediaManager.context) { devices, selected ->
-                logger.i { "audio devices. selected $selected, available devices are $devices" }
+            if (!::audioHandler.isInitialized) { // This check is atomic
+                audioHandler = AudioSwitchHandler(mediaManager.context) { devices, selected ->
+                    logger.i { "audio devices. selected $selected, available devices are $devices" }
 
-                _devices.value = devices.map { it.fromAudio() }
-                _selectedDevice.value = selected?.fromAudio()
+                    _devices.value = devices.map { it.fromAudio() }
+                    _selectedDevice.value = selected?.fromAudio()
 
-                capturedOnAudioDevicesUpdate?.invoke()
-                capturedOnAudioDevicesUpdate = null
-                setupCompleted = true
+                    capturedOnAudioDevicesUpdate?.invoke()
+                    capturedOnAudioDevicesUpdate = null
+                    setupCompleted = true
+                }
+
+                logger.d { "[setup] Calling start on instance $audioHandler" }
+                audioHandler.start()
             }
-
-            audioHandler.start()
         } else {
             logger.d { "[MediaManager#setup] usage is MEDIA, cannot handle device switch" }
         }


### PR DESCRIPTION
### 🎯 Goal

Fix reported issue: BT headset still thinks it's in a call even after `leave`ing the call.

### 🛠 Implementation details

It turns out the issue was caused by instantiating `AudioSwitchHandler` two times in `MicrophoneManager.setup`, which caused `start`ing two instances of `AudioSwitch`. Then, calling `stop` once caused problems.

I was able to reproduce the problem in an isolated implementation, so I added checks to prevent two instances.

### 🎉 GIF

![gif](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExN215a3gzdmdqejAxbDZudHhmcTF3YWw5cWlrcGY1eXFvbGtjcmN0NyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l36kU80xPf0ojG0Erg/giphy.gif)