### PR TITLE
[AND-356] Update call configuration defaults

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/DefaultCallConfigurations.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/DefaultCallConfigurations.kt
@@ -95,13 +95,7 @@ object DefaultCallConfigurations {
         return mapOf(
             Pair(CallType.AnyMarker, default),
             Pair(CallType.AudioCall, audioCall),
-            Pair(
-                CallType.Livestream,
-                livestream.copy(
-                    runCallServiceInForeground = true,
-                    audioUsage = AudioAttributes.USAGE_MEDIA,
-                ),
-            ),
+            Pair(CallType.Livestream, livestreamGuestCall),
         )
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Update call configuration defaults, especially for `livestream`.

### 🛠 Implementation details

Change `DefaultCallConfigurations.get*Config` methods.