### PR TITLE
[AND-374] Update StreamLog dependency

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -50,7 +50,7 @@ streamWebRTC = "1.3.6"
 streamNoiseCancellation = "1.0.2"
 streamResult = "1.3.0"
 streamChat = "6.10.0"
-streamLog = "1.3.1"
+streamLog = "1.3.2"
 streamPush = "1.3.0"
 
 androidxTest = "1.5.2"


### PR DESCRIPTION
### 🎯 Goal
Upgrade StreamLog dependency to avoid a warning message while compilation time related with a duplicated namespace.

Related PR: https://github.com/GetStream/stream-log/pull/26

### 🎉 GIF

![ezgif-56933429f6494d](https://github.com/user-attachments/assets/e7adf69c-0a7f-4622-9c22-8db1e8935ac6)
