### PR TITLE
[AND-373] Filter-out unneeded notification updates and add flag to enable/disable

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9932,18 +9932,20 @@ public final class io/getstream/video/android/core/notifications/DefaultStreamIn
 
 public final class io/getstream/video/android/core/notifications/NotificationConfig {
 	public fun <init> ()V
-	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;Z)V
-	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;ZZ)V
+	public synthetic fun <init> (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component2 ()Lkotlin/jvm/functions/Function0;
 	public final fun component3 ()Lio/getstream/video/android/core/notifications/NotificationHandler;
 	public final fun component4 ()Z
 	public final fun component5 ()Lkotlin/jvm/functions/Function0;
 	public final fun component6 ()Z
-	public final fun copy (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;Z)Lio/getstream/video/android/core/notifications/NotificationConfig;
-	public static synthetic fun copy$default (Lio/getstream/video/android/core/notifications/NotificationConfig;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;ZILjava/lang/Object;)Lio/getstream/video/android/core/notifications/NotificationConfig;
+	public final fun component7 ()Z
+	public final fun copy (Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;ZZ)Lio/getstream/video/android/core/notifications/NotificationConfig;
+	public static synthetic fun copy$default (Lio/getstream/video/android/core/notifications/NotificationConfig;Ljava/util/List;Lkotlin/jvm/functions/Function0;Lio/getstream/video/android/core/notifications/NotificationHandler;ZLkotlin/jvm/functions/Function0;ZZILjava/lang/Object;)Lio/getstream/video/android/core/notifications/NotificationConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAutoRegisterPushDevice ()Z
+	public final fun getEnableCallNotificationUpdates ()Z
 	public final fun getHideRingingNotificationInForeground ()Z
 	public final fun getNotificationHandler ()Lio/getstream/video/android/core/notifications/NotificationHandler;
 	public final fun getPushDeviceGenerators ()Ljava/util/List;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -239,6 +239,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             lifecycle = lifecycle,
             coordinatorConnectionModule = coordinatorConnectionModule,
             streamNotificationManager = streamNotificationManager,
+            enableCallNotificationUpdates = notificationConfig.enableCallNotificationUpdates,
             callServiceConfigRegistry = callConfigRegistry,
             testSfuAddress = localSfuAddress,
             sounds = sounds,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -152,6 +152,7 @@ internal class StreamVideoClient internal constructor(
     internal val coordinatorConnectionModule: CoordinatorConnectionModule,
     internal val tokenProvider: TokenProvider = ConstantTokenProvider(token),
     internal val streamNotificationManager: StreamNotificationManager,
+    internal val enableCallNotificationUpdates: Boolean,
     internal val callServiceConfigRegistry: CallServiceConfigRegistry = CallServiceConfigRegistry(),
     internal val testSfuAddress: String? = null,
     internal val sounds: Sounds,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -434,34 +434,38 @@ public open class DefaultNotificationHandler(
                             onUpdate(it)
                         }
                     } else if (ringingState is RingingState.Active) {
+                        val currentRemoteParticipantCount = remoteParticipants.size
                         // If number of remote participants increased or decreased
-                        if (remoteParticipants.size != latestRemoteParticipantCount) {
-                            latestRemoteParticipantCount = remoteParticipants.size
+                        if (currentRemoteParticipantCount != latestRemoteParticipantCount) {
+                            val isSameCase = currentRemoteParticipantCount > 1 && latestRemoteParticipantCount > 1
+                            latestRemoteParticipantCount = currentRemoteParticipantCount
 
-                            val callDisplayName = if (remoteParticipants.isEmpty()) {
-                                // If no remote participants, get simple call notification title
-                                application.getString(
-                                    R.string.stream_video_ongoing_call_notification_title,
-                                )
-                            } else {
-                                if (remoteParticipants.size > 1) {
-                                    // If more than 1 remote participant, get group call notification title
+                            if (!isSameCase) {
+                                val callDisplayName = if (remoteParticipants.isEmpty()) {
+                                    // If no remote participants, get simple call notification title
                                     application.getString(
-                                        R.string.stream_video_ongoing_group_call_notification_title,
+                                        R.string.stream_video_ongoing_call_notification_title,
                                     )
                                 } else {
-                                    // If 1 remote participant, get the name of the remote participant
-                                    remoteParticipants.firstOrNull()?.name?.value ?: "Unknown"
+                                    if (currentRemoteParticipantCount > 1) {
+                                        // If more than 1 remote participant, get group call notification title
+                                        application.getString(
+                                            R.string.stream_video_ongoing_group_call_notification_title,
+                                        )
+                                    } else {
+                                        // If 1 remote participant, get the name of the remote participant
+                                        remoteParticipants.firstOrNull()?.name?.value ?: "Unknown"
+                                    }
                                 }
-                            }
 
-                            // Use latest call display name in notification
-                            getOngoingCallNotification(
-                                callId = StreamCallId.fromCallCid(call.cid),
-                                callDisplayName = callDisplayName,
-                                remoteParticipantCount = remoteParticipants.size,
-                            )?.let {
-                                onUpdate(it)
+                                // Use latest call display name in notification
+                                getOngoingCallNotification(
+                                    callId = StreamCallId.fromCallCid(call.cid),
+                                    callDisplayName = callDisplayName,
+                                    remoteParticipantCount = currentRemoteParticipantCount,
+                                )?.let {
+                                    onUpdate(it)
+                                }
                             }
                         }
                     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -40,6 +40,7 @@ import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.R
 import io.getstream.video.android.core.RingingState
 import io.getstream.video.android.core.StreamVideo
+import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_LIVE_CALL
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_MISSED_CALL
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_NOTIFICATION
@@ -394,6 +395,10 @@ public open class DefaultNotificationHandler(
         localUser: User,
         onUpdate: (Notification) -> Unit,
     ) {
+        val streamVideoClient = StreamVideo.instanceOrNull() as? StreamVideoClient
+
+        if (streamVideoClient?.enableCallNotificationUpdates != true) return
+
         coroutineScope.launch {
             var latestRemoteParticipantCount = -1
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationConfig.kt
@@ -33,4 +33,8 @@ public data class NotificationConfig(
      * NOTE: This setting has only an effect if you don't set a custom [NotificationHandler]!
      */
     val hideRingingNotificationInForeground: Boolean = false,
+    /**
+     * If `true`, call notifications will receive subsequent updates, based on the number of participants and other data.
+     */
+    val enableCallNotificationUpdates: Boolean = true,
 )


### PR DESCRIPTION
### 🎯 Goal

Ongoing call notifications are updated when the number of participants changes. We have three cases: no remote participant (shows generic info and icon), 1:1 call (shows the name of the other participant and avatar) and multiple participants (shows `Group call` text and icon). More info in [this](https://github.com/GetStream/stream-video-android/pull/1183) PR.

### 🛠 Implementation details

- Debounced notification updates caused by participants joining/leaving, when the count falls in the same `multiple participants` case. Useful for calls with a large number of join/leave events, e.g. livestreams.
- Checking if the participant count change is still in the `> 1` case. If yes, don't update the notification.
- Update the notification only when the participant count changes from `multiple` to `one` or `none` and vice-versa.
- Added `notificationConfig.enableCallNotificationUpdates` flag to disable notification updates in `StreamVideoBuilder`.