### PR TITLE
Refactor capabilities check when sending video & audio tracks

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -27,6 +27,7 @@ import android.os.PowerManager.THERMAL_STATUS_SEVERE
 import android.os.PowerManager.THERMAL_STATUS_SHUTDOWN
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
+import io.getstream.android.video.generated.models.OwnCapability
 import io.getstream.android.video.generated.models.VideoEvent
 import io.getstream.log.taggedLogger
 import io.getstream.result.Result
@@ -562,26 +563,33 @@ public class RtcSession internal constructor(
         listenToSfuSocket()
     }
 
-    private suspend fun listenToMediaChanges() {
+    private fun listenToMediaChanges() {
         coroutineScope.launch {
             // update the tracks when the camera or microphone status changes
             call.mediaManager.camera.status.collectLatest {
-                // set the mute /unumute status
-                setMuteState(isEnabled = it == DeviceStatus.Enabled, TrackType.TRACK_TYPE_VIDEO)
+                val canUserSendVideo = call.state.ownCapabilities.value.contains(
+                    OwnCapability.SendVideo,
+                )
 
                 if (it == DeviceStatus.Enabled) {
-                    val track = publisher?.publishStream(
-                        TrackType.TRACK_TYPE_VIDEO,
-                        call.mediaManager.camera.resolution.value,
-                    )
-                    setLocalTrack(
-                        TrackType.TRACK_TYPE_VIDEO,
-                        VideoTrack(
-                            streamId = buildTrackId(TrackType.TRACK_TYPE_VIDEO),
-                            video = track as org.webrtc.VideoTrack,
-                        ),
-                    )
+                    if (canUserSendVideo) {
+                        setMuteState(isEnabled = true, TrackType.TRACK_TYPE_VIDEO)
+
+                        val track = publisher?.publishStream(
+                            TrackType.TRACK_TYPE_VIDEO,
+                            call.mediaManager.camera.resolution.value,
+                        )
+
+                        setLocalTrack(
+                            TrackType.TRACK_TYPE_VIDEO,
+                            VideoTrack(
+                                streamId = buildTrackId(TrackType.TRACK_TYPE_VIDEO),
+                                video = track as org.webrtc.VideoTrack,
+                            ),
+                        )
+                    }
                 } else {
+                    setMuteState(isEnabled = false, TrackType.TRACK_TYPE_VIDEO)
                     publisher?.unpublishStream(TrackType.TRACK_TYPE_VIDEO)
                 }
             }
@@ -589,21 +597,28 @@ public class RtcSession internal constructor(
 
         coroutineScope.launch {
             call.mediaManager.microphone.status.collectLatest {
-                // set the mute /unumute status
-                setMuteState(isEnabled = it == DeviceStatus.Enabled, TrackType.TRACK_TYPE_AUDIO)
+                val canUserSendAudio = call.state.ownCapabilities.value.contains(
+                    OwnCapability.SendAudio,
+                )
 
                 if (it == DeviceStatus.Enabled) {
-                    val track = publisher?.publishStream(
-                        TrackType.TRACK_TYPE_AUDIO,
-                    )
-                    setLocalTrack(
-                        TrackType.TRACK_TYPE_AUDIO,
-                        AudioTrack(
-                            streamId = buildTrackId(TrackType.TRACK_TYPE_AUDIO),
-                            audio = track as org.webrtc.AudioTrack,
-                        ),
-                    )
+                    if (canUserSendAudio) {
+                        setMuteState(isEnabled = true, TrackType.TRACK_TYPE_AUDIO)
+
+                        val track = publisher?.publishStream(
+                            TrackType.TRACK_TYPE_AUDIO,
+                        )
+
+                        setLocalTrack(
+                            TrackType.TRACK_TYPE_AUDIO,
+                            AudioTrack(
+                                streamId = buildTrackId(TrackType.TRACK_TYPE_AUDIO),
+                                audio = track as org.webrtc.AudioTrack,
+                            ),
+                        )
+                    }
                 } else {
+                    setMuteState(isEnabled = false, TrackType.TRACK_TYPE_AUDIO)
                     publisher?.unpublishStream(TrackType.TRACK_TYPE_AUDIO)
                 }
             }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -626,23 +626,28 @@ public class RtcSession internal constructor(
 
         coroutineScope.launch {
             call.mediaManager.screenShare.status.collectLatest {
-                // set the mute /unumute status
-                setMuteState(
-                    isEnabled = it == DeviceStatus.Enabled,
-                    TrackType.TRACK_TYPE_SCREEN_SHARE,
+                val canUserShareScreen = call.state.ownCapabilities.value.contains(
+                    OwnCapability.Screenshare,
                 )
+
                 if (it == DeviceStatus.Enabled) {
-                    val track = publisher?.publishStream(
-                        TrackType.TRACK_TYPE_SCREEN_SHARE,
-                    )
-                    setLocalTrack(
-                        TrackType.TRACK_TYPE_SCREEN_SHARE,
-                        VideoTrack(
-                            streamId = buildTrackId(TrackType.TRACK_TYPE_SCREEN_SHARE),
-                            video = track as org.webrtc.VideoTrack,
-                        ),
-                    )
+                    if (canUserShareScreen) {
+                        setMuteState(true, TrackType.TRACK_TYPE_SCREEN_SHARE)
+
+                        val track = publisher?.publishStream(
+                            TrackType.TRACK_TYPE_SCREEN_SHARE,
+                        )
+
+                        setLocalTrack(
+                            TrackType.TRACK_TYPE_SCREEN_SHARE,
+                            VideoTrack(
+                                streamId = buildTrackId(TrackType.TRACK_TYPE_SCREEN_SHARE),
+                                video = track as org.webrtc.VideoTrack,
+                            ),
+                        )
+                    }
                 } else {
+                    setMuteState(false, TrackType.TRACK_TYPE_SCREEN_SHARE)
                     publisher?.unpublishStream(TrackType.TRACK_TYPE_SCREEN_SHARE)
                 }
             }


### PR DESCRIPTION
### 🎯 Goal

Refactor capabilities check when sending video & audio tracks and allow camera preview when call is not created on the backend side.

### 🛠 Implementation details

- Moved cam & mic capabilities check to `RtcSession.listenToMediaChanges`.

### 🧪 Testing

- Use `CallLobby` with a call that is only created locally - preview should be visible.
- Join a livestream as a `user` with camera and microphone `on` - no rejoins should happen.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_