### PR TITLE
Fix not getting call end updates

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -49,7 +49,6 @@ import io.getstream.video.android.core.call.utils.TrackOverridesHandler
 import io.getstream.video.android.core.call.utils.stringify
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.errors.RtcException
-import io.getstream.video.android.core.events.CallEndedSfuEvent
 import io.getstream.video.android.core.events.ChangePublishOptionsEvent
 import io.getstream.video.android.core.events.ChangePublishQualityEvent
 import io.getstream.video.android.core.events.ICERestartEvent
@@ -439,10 +438,6 @@ public class RtcSession internal constructor(
         // listen to socket events and errors
         eventJob = coroutineScope.launch {
             sfuConnectionModule.socketConnection.events().collect {
-                if (it is CallEndedSfuEvent) {
-                    logger.d { "#rtcsession #events #sfu, event: $it" }
-                    call.leave()
-                }
                 clientImpl.fireEvent(it, call.cid)
             }
         }


### PR DESCRIPTION
### 🎯 Goal

Fix issues:
- `endedAt` flow not emitting
- `CallEndedEvent` not received (e.g. in `call.subscribeFor`)

### 🛠 Implementation details

- Caused by leaving the call too early and removing it from the internal `calls` map.
- Do not handle `CallEndedSfuEvent` in `RtcSession` and do not leave call there.
- Kept only `CallEndedEvent` handling, as having both, even in `CallState`, would bring us in the same situation.

> [!NOTE]  
> Potential future improvements:
> - Don't rely on the `calls` map to forward coordinator events, instead use `client.subscribe` in the call object.
> - Use the `calls` map only as a cache to return the same call from `client.call()`.
> - Don't remove the event listener from the subscriptions when `leave`ing the call. Asses memory leaks in this situation.
> - Migrate the subscriptions from listener classes to flows.
> - Then we can listen to `CallEndedSfuEvent` in the `RtcSession` and leave the call.
> - Similar to what iOS does.

### 🧪 Testing

When a call is ended, Android device got:
- Before: not enough, these methods don't update the `endedAt` flow and don't propagate the event subscriptions.
```
CoordinatorSocket.onEvent; call.ended
ClientState.handleEvent; call.ended
StreamVideoClient.fireEvent; call.ended
```
- After: `subscribeFor` and `endedAt` are updated.
```
CoordinatorSocket.onEvent; call.ended
ClientState.handleEvent; call.ended
CallService.observeCallEvents; call.ended
StreamVideoClient.fireEvent; call.ended
LiveGuest subscribeFor; call.ended
LiveGuest; endedAt emitted 2025-03-19T12:13:39.168Z
```


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs