### PR TITLE
[AND-434]Improve resolution selection

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -772,7 +772,7 @@ public class CameraManager(
         val matchingTarget =
             supportedFormats?.toList()
                 ?.sortedBy { kotlin.math.abs(it.height - targetHeight) + kotlin.math.abs(it.width - targetWidth) }
-        val selectedFormat = matchingTarget?.first()
+        val selectedFormat = matchingTarget?.firstOrNull()
         logger.i { "selectDesiredResolution: $selectedFormat" }
         return selectedFormat
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -559,7 +559,13 @@ public class RtcSession internal constructor(
     }
 
     private fun listenToMediaChanges() {
+        logger.d { "[trackPublishing] listenToMediaChanges" }
         coroutineScope.launch {
+            // We don't want to publish video track if there is no camera resolution
+            if (call.camera.resolution.value == null) {
+                return@launch
+            }
+
             // update the tracks when the camera or microphone status changes
             call.mediaManager.camera.status.collectLatest {
                 val canUserSendVideo = call.state.ownCapabilities.value.contains(


### PR DESCRIPTION
### 🎯 Goal

Resolving the crash: [link](https://github.com/GetStream/stream-video-android/issues/1335)

### 🛠 Implementation details

1. Fix NPE in selecting resolution
2. Won't publish video track if there is no camera resolution

### 🎨 UI Changes


If we fail to select the resolution then this is how the UI will appear

| Lobby | Call Screen | Phone Home | Multiple Users | Phone Home (multiple user)
| --- | --- | --- | --- | --- |
| ![Lobby](https://github.com/user-attachments/assets/f10002ef-b817-44b0-8314-31c8c0f045be) | ![Call Screen](https://github.com/user-attachments/assets/a010cb1f-9606-403d-9267-d626009694fa) | ![Phone Home](https://github.com/user-attachments/assets/40c939f3-32a8-4e18-b7c7-d6a287514bce) | ![Multtiple user in call in home screen](https://github.com/user-attachments/assets/17771b98-aa09-4f1c-8afc-b26c831f03db) | ![Multtiple user in call](https://github.com/user-attachments/assets/12241ea9-8577-450b-8eeb-c213a15315a3) |