### PR TITLE
Update StreamPush dependency to 1.3.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,7 @@ streamNoiseCancellation = "1.0.2"
 streamResult = "1.3.0"
 streamChat = "6.10.0"
 streamLog = "1.3.2"
-streamPush = "1.3.0"
+streamPush = "1.3.1"
 
 androidxTest = "1.5.2"
 androidxTestCore = "1.5.0"


### PR DESCRIPTION
### 🎯 Goal
Upgrade StreamPush dependency to 1.3.1 that includes changes on the proguard rules to avoid error
Related PR: https://github.com/GetStream/stream-android-push/pull/28
Release Changelog: https://github.com/GetStream/stream-android-push/releases/tag/1.3.1

### 🎉 GIF
![](https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExNGh6bGJqcHl0aTgybHlnenppcnc1OWhtNWg1M3hlMDBoOTB0bmU1diZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/VJnwwe4Qp7fZSOJVt7/giphy.gif)