### PR TITLE
Fix App Distribute Workflow

### DIFF
--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -28,7 +28,7 @@ jobs:
           name: demo-app-release
           path: demo-app/build/outputs/apk/demo-app/release/
       - name: Upload artifact to Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1.5.0
+        uses: wzieba/Firebase-Distribution-Github-Action@v1.7.1
         with:
           appId: ${{secrets.FIREBASE_DOGFOODING_SAMPLE_APP_ID}}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img src=".readme-assets/Github-Graphic-Android.jpg" alt="Stream Video for Android Header image" style="box-shadow: 0 3px 10px rgb(0 0 0 / 0.2); border-radius: 1rem" />
 
 <p align="center">
-  <a href="https://github.com/GetStream/stream-video-android/actions"><img src="https://github.com/GetStream/stream-video-android/workflows/App%20Distribute%20CI/badge.svg" /></a>
+  <a href="https://github.com/GetStream/stream-video-android/actions/workflows/app-distribute.yml"><img src="https://github.com/GetStream/stream-video-android/workflows/App%20Distribute%20CI/badge.svg" /></a>
   <a href="https://android-arsenal.com/api?level=24"><img alt="API" src="https://img.shields.io/badge/API-24%2B-brightgreen.svg?style=flat"/></a>
   <a href="https://search.maven.org/search?q=stream-video-android"><img src="https://img.shields.io/maven-central/v/io.getstream/stream-video-android-core.svg?label=Maven%20Central" /></a>
 </p>


### PR DESCRIPTION
### 🎯 Goal
Last version of Firebase CLI required to use a newest node version.
This change has been already covered on last version of the [FirebaseDistribution Github Action](https://github.com/wzieba/Firebase-Distribution-Github-Action/releases/tag/v1.7.1), the one that we use to distribute apk on firebase.

At the same time I am changing the badge link to go directly to the workflow that this badge represents

Fix AND-476

### 🎉 GIF

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDJ5cjJuaW04MXdhcnZrcXM0ejRoNGI5MHc4OGtpMzkwbGR0ZWV2eiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/LnoY34a2mcGm3J5XEw/giphy.gif)