### PR TITLE
[AND-481] Device selection issues

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -1070,7 +1070,8 @@ public class Call(
                     // be a new audio.defaultDevice setting returned from backend
                     true
                 } else {
-                    callSettings.audio.defaultDevice == AudioSettingsResponse.DefaultDevice.Speaker
+                    callSettings.audio.defaultDevice == AudioSettingsResponse.DefaultDevice.Speaker ||
+                        callSettings.audio.speakerDefaultOn
                 }
 
             speaker.setEnabled(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -1070,8 +1070,7 @@ public class Call(
                     // be a new audio.defaultDevice setting returned from backend
                     true
                 } else {
-                    callSettings.audio.defaultDevice == AudioSettingsResponse.DefaultDevice.Speaker ||
-                        callSettings.audio.speakerDefaultOn
+                    callSettings.audio.defaultDevice == AudioSettingsResponse.DefaultDevice.Speaker
                 }
 
             speaker.setEnabled(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -420,11 +420,9 @@ class MicrophoneManager(
      * Select a specific device
      */
     fun select(device: StreamAudioDevice?) {
-        enforceSetup {
-            logger.i { "selecting device $device" }
-            ifAudioHandlerInitialized { it.selectDevice(device?.toAudioDevice()) }
-            _selectedDevice.value = device
-        }
+        logger.i { "#deviceDebug; selecting device $device" }
+        ifAudioHandlerInitialized { it.selectDevice(device?.toAudioDevice()) }
+        _selectedDevice.value = device
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -420,7 +420,7 @@ class MicrophoneManager(
      * Select a specific device
      */
     fun select(device: StreamAudioDevice?) {
-        logger.i { "#deviceDebug; selecting device $device" }
+        logger.i { "selecting device $device" }
         ifAudioHandlerInitialized { it.selectDevice(device?.toAudioDevice()) }
         _selectedDevice.value = device
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -711,10 +711,6 @@ public class RtcSession internal constructor(
         logger.d { "[connectRtc] #sfu; #track; no args" }
         val settings = call.state.settings.value
 
-        // turn of the speaker if needed
-        if (settings?.audio?.speakerDefaultOn == false) {
-            call.speaker.setVolume(0)
-        }
         // update the peer state
         coroutineScope.launch {
             // call update participant subscriptions debounced


### PR DESCRIPTION
### 🎯 Goal

Select speaker for video calls and earpiece for audio calls (but based on dashboard settings).

### 🛠 Implementation details

- Removed `enforceSetup` for the `select` method, as this method receives a `device` to select, so it means `setup` was already done.
- This solves the issue where there were nested `enforceSetup` calls with passed-in callbacks and the first lambda was replaced by the second and didn't run until the end, causing the device not being selected in some cases.