### PR TITLE
[AND-479] Allow to pass a `VideoRendererConfig` to the `LivestreamPlayer` and move away from the deprecated `livestream` flow

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
@@ -140,7 +140,7 @@ class DeeplinkingActivity : ComponentActivity() {
         requestMultiplePermissionsLauncher.launch(permissions)
     }
 
-    private fun extractCallType(data: Uri?) : String {
+    private fun extractCallType(data: Uri?): String {
         return data?.getQueryParameter("type") ?: "default"
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfigRegistry.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceConfigRegistry.kt
@@ -64,6 +64,7 @@ class CallServiceConfigRegistry {
 
     init {
         configs[ANY_MARKER] = DefaultCallConfigurations.default
+        configs[CallType.Livestream.name] = DefaultCallConfigurations.livestream
     }
 
     /**

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/MicrophoneManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/MicrophoneManagerTest.kt
@@ -66,7 +66,7 @@ class MicrophoneManagerTest {
         microphoneManager.setEnabled(false) // 9, 10, calls disable internally
 
         // Then
-        verify(exactly = 10) {
+        verify(exactly = 9) {
             // Setup will be called exactly 10 times
             microphoneManager.setup(any())
         }

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -366,9 +366,13 @@ public final class io/getstream/video/android/compose/theme/VideoThemeKt {
 
 public final class io/getstream/video/android/compose/ui/ComposableSingletons$StreamCallActivityComposeDelegateKt {
 	public static final field INSTANCE Lio/getstream/video/android/compose/ui/ComposableSingletons$StreamCallActivityComposeDelegateKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-3$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public class io/getstream/video/android/compose/ui/ComposeStreamCallActivity : io/getstream/video/android/ui/common/StreamCallActivity {

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -1809,7 +1809,7 @@ public final class io/getstream/video/android/compose/ui/components/livestream/C
 }
 
 public final class io/getstream/video/android/compose/ui/components/livestream/LivestreamPlayerKt {
-	public static final fun LivestreamPlayer (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
+	public static final fun LivestreamPlayer (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;Lio/getstream/video/android/compose/ui/components/video/config/VideoRendererConfig;Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/livestream/LivestreamPlayerOverlayKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.material.Text
@@ -35,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
@@ -49,15 +51,20 @@ import io.getstream.log.taggedLogger
 import io.getstream.video.android.compose.R
 import io.getstream.video.android.compose.permission.LaunchPermissionRequest
 import io.getstream.video.android.compose.theme.VideoTheme
+import io.getstream.video.android.compose.ui.components.avatar.UserAvatarBackground
 import io.getstream.video.android.compose.ui.components.base.StreamDialogPositiveNegative
 import io.getstream.video.android.compose.ui.components.base.styling.ButtonStyles
 import io.getstream.video.android.compose.ui.components.base.styling.StreamDialogStyles
 import io.getstream.video.android.compose.ui.components.base.styling.StyleSize
+import io.getstream.video.android.compose.ui.components.call.CallAppBar
 import io.getstream.video.android.compose.ui.components.call.activecall.CallContent
 import io.getstream.video.android.compose.ui.components.call.ringing.RingingCallContent
+import io.getstream.video.android.compose.ui.components.livestream.LivestreamPlayer
+import io.getstream.video.android.compose.ui.components.video.config.videoRenderConfig
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.MemberState
 import io.getstream.video.android.core.RealtimeConnection
+import io.getstream.video.android.core.call.CallType
 import io.getstream.video.android.core.call.state.CallAction
 import io.getstream.video.android.core.call.state.CancelCall
 import io.getstream.video.android.core.call.state.CustomAction
@@ -115,114 +122,141 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
     @StreamCallActivityDelicateApi
     @Composable
     override fun StreamCallActivity.RootContent(call: Call) {
-        var callAction: CallAction by remember {
-            mutableStateOf(CustomAction(tag = "initial"))
-        }
-
-        when (callAction) {
-            is LeaveCall, is DeclineCall, is CancelCall -> {
-                CallDisconnectedContent(call)
+        if (call.type == CallType.Livestream.name) {
+            Box {
+                LivestreamPlayer(
+                    call = call, videoRendererConfig =
+                        videoRenderConfig {
+                            this.fallbackContent = {
+                                val userName = it.user.userNameOrId
+                                val userImage = it.user.image
+                                Box {
+                                    UserAvatarBackground(userImage = userImage, userName = userName)
+                                }
+                            }
+                        })
+                CallAppBar(
+                    modifier = Modifier
+                        .align(Alignment.TopCenter)
+                        .padding(end = 16.dp, top = 16.dp),
+                    call = call,
+                    centerContent = { },
+                    onCallAction = {
+                        call.leave()
+                        finish()
+                    },
+                )
+            }
+        } else {
+            var callAction: CallAction by remember {
+                mutableStateOf(CustomAction(tag = "initial"))
             }
 
-            else -> {
-                LaunchPermissionRequest(getRequiredPermissions(call)) {
-                    AllPermissionsGranted {
-                        // All permissions granted
-                        RingingCallContent(
-                            isVideoType = isVideoCall(call),
-                            call = call,
-                            modifier = Modifier.background(
-                                color = VideoTheme.colors.baseSheetPrimary,
-                            ),
-                            onBackPressed = {
-                                onBackPressed(call)
-                            },
-                            onOutgoingContent = {
-                                    modifier: Modifier,
-                                    call: Call,
-                                    isVideoType: Boolean,
-                                    isShowingHeader: Boolean,
-                                    headerContent: @Composable (ColumnScope.() -> Unit)?,
-                                    detailsContent: @Composable (
+            when (callAction) {
+                is LeaveCall, is DeclineCall, is CancelCall -> {
+                    CallDisconnectedContent(call)
+                }
+
+                else -> {
+                    LaunchPermissionRequest(getRequiredPermissions(call)) {
+                        AllPermissionsGranted {
+                            // All permissions granted
+                            RingingCallContent(
+                                isVideoType = isVideoCall(call),
+                                call = call,
+                                modifier = Modifier.background(
+                                    color = VideoTheme.colors.baseSheetPrimary,
+                                ),
+                                onBackPressed = {
+                                    onBackPressed(call)
+                                },
+                                onOutgoingContent = {
+                                        modifier: Modifier,
+                                        call: Call,
+                                        isVideoType: Boolean,
+                                        isShowingHeader: Boolean,
+                                        headerContent: @Composable (ColumnScope.() -> Unit)?,
+                                        detailsContent: @Composable (
                                         ColumnScope.(
                                             participants: List<MemberState>,
                                             topPadding: Dp,
                                         ) -> Unit
-                                    )?,
-                                    controlsContent: @Composable (BoxScope.() -> Unit)?,
-                                    onBackPressed: () -> Unit,
-                                    onCallAction: (CallAction) -> Unit,
-                                ->
-                                OutgoingCallContent(
-                                    call = call,
-                                    isVideoType = isVideoType,
-                                    modifier = modifier,
-                                    isShowingHeader = isShowingHeader,
-                                    headerContent = headerContent,
-                                    detailsContent = detailsContent,
-                                    controlsContent = controlsContent,
-                                    onBackPressed = onBackPressed,
-                                    onCallAction = onCallAction,
-                                )
-                            },
-                            onIncomingContent = {
-                                    modifier: Modifier,
-                                    call: Call,
-                                    isVideoType: Boolean, isShowingHeader: Boolean,
-                                    headerContent: @Composable (ColumnScope.() -> Unit)?,
-                                    detailsContent: @Composable (
+                                        )?,
+                                        controlsContent: @Composable (BoxScope.() -> Unit)?,
+                                        onBackPressed: () -> Unit,
+                                        onCallAction: (CallAction) -> Unit,
+                                    ->
+                                    OutgoingCallContent(
+                                        call = call,
+                                        isVideoType = isVideoType,
+                                        modifier = modifier,
+                                        isShowingHeader = isShowingHeader,
+                                        headerContent = headerContent,
+                                        detailsContent = detailsContent,
+                                        controlsContent = controlsContent,
+                                        onBackPressed = onBackPressed,
+                                        onCallAction = onCallAction,
+                                    )
+                                },
+                                onIncomingContent = {
+                                        modifier: Modifier,
+                                        call: Call,
+                                        isVideoType: Boolean, isShowingHeader: Boolean,
+                                        headerContent: @Composable (ColumnScope.() -> Unit)?,
+                                        detailsContent: @Composable (
                                         ColumnScope.(
                                             participants: List<MemberState>,
                                             topPadding: Dp,
                                         ) -> Unit
-                                    )?,
-                                    controlsContent: @Composable (BoxScope.() -> Unit)?,
-                                    onBackPressed: () -> Unit,
-                                    onCallAction: (CallAction) -> Unit,
-                                ->
-                                IncomingCallContent(
-                                    call = call,
-                                    isVideoType = isVideoType,
-                                    modifier = modifier,
-                                    isShowingHeader = isShowingHeader,
-                                    headerContent = headerContent,
-                                    detailsContent = detailsContent,
-                                    controlsContent = controlsContent,
-                                    onBackPressed = onBackPressed,
-                                    onCallAction = onCallAction,
-                                )
-                            },
-                            onAcceptedContent = {
-                                ConnectionAvailable(call = call) { theCall ->
-                                    if (isVideoCall(theCall)) {
-                                        VideoCallContent(call = theCall)
-                                    } else {
-                                        AudioCallContent(call = theCall)
+                                        )?,
+                                        controlsContent: @Composable (BoxScope.() -> Unit)?,
+                                        onBackPressed: () -> Unit,
+                                        onCallAction: (CallAction) -> Unit,
+                                    ->
+                                    IncomingCallContent(
+                                        call = call,
+                                        isVideoType = isVideoType,
+                                        modifier = modifier,
+                                        isShowingHeader = isShowingHeader,
+                                        headerContent = headerContent,
+                                        detailsContent = detailsContent,
+                                        controlsContent = controlsContent,
+                                        onBackPressed = onBackPressed,
+                                        onCallAction = onCallAction,
+                                    )
+                                },
+                                onAcceptedContent = {
+                                    ConnectionAvailable(call = call) { theCall ->
+                                        if (isVideoCall(theCall)) {
+                                            VideoCallContent(call = theCall)
+                                        } else {
+                                            AudioCallContent(call = theCall)
+                                        }
                                     }
-                                }
-                            },
-                            onNoAnswerContent = {
-                                NoAnswerContent(call)
-                            },
-                            onRejectedContent = {
-                                RejectedContent(call)
-                            },
-                            onCallAction = {
-                                onCallAction(call, it)
-                                callAction = it
-                            },
-                            onIdle = {
-                                LoadingContent(call)
-                            },
-                        )
-                    }
+                                },
+                                onNoAnswerContent = {
+                                    NoAnswerContent(call)
+                                },
+                                onRejectedContent = {
+                                    RejectedContent(call)
+                                },
+                                onCallAction = {
+                                    onCallAction(call, it)
+                                    callAction = it
+                                },
+                                onIdle = {
+                                    LoadingContent(call)
+                                },
+                            )
+                        }
 
-                    SomeGranted { granted, notGranted, showRationale ->
-                        InternalPermissionContent(showRationale, call, granted, notGranted)
-                    }
+                        SomeGranted { granted, notGranted, showRationale ->
+                            InternalPermissionContent(showRationale, call, granted, notGranted)
+                        }
 
-                    NoneGranted {
-                        InternalPermissionContent(it, call, emptyList(), emptyList())
+                        NoneGranted {
+                            InternalPermissionContent(it, call, emptyList(), emptyList())
+                        }
                     }
                 }
             }
@@ -275,6 +309,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     finish()
                 }
             }
+
             is RealtimeConnection.Failed -> {
                 if (!configuration.closeScreenOnError) {
                     val err = Exception("${(connection as? RealtimeConnection.Failed)?.error}")
@@ -284,6 +319,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     finish()
                 }
             }
+
             else -> {
                 content.invoke(call)
             }
@@ -319,10 +355,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-            @Composable ColumnScope.(
-                participants: List<MemberState>,
-                topPadding: Dp,
-            ) -> Unit
+        @Composable ColumnScope.(
+            participants: List<MemberState>,
+            topPadding: Dp,
+        ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,
@@ -349,10 +385,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-            @Composable ColumnScope.(
-                participants: List<MemberState>,
-                topPadding: Dp,
-            ) -> Unit
+        @Composable ColumnScope.(
+            participants: List<MemberState>,
+            topPadding: Dp,
+        ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -123,29 +123,36 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
     @Composable
     override fun StreamCallActivity.RootContent(call: Call) {
         if (call.type == CallType.Livestream.name) {
-            Box {
-                LivestreamPlayer(
-                    call = call, videoRendererConfig =
-                        videoRenderConfig {
-                            this.fallbackContent = {
-                                val userName = it.user.userNameOrId
-                                val userImage = it.user.image
-                                Box {
-                                    UserAvatarBackground(userImage = userImage, userName = userName)
-                                }
-                            }
-                        })
-                CallAppBar(
-                    modifier = Modifier
-                        .align(Alignment.TopCenter)
-                        .padding(end = 16.dp, top = 16.dp),
-                    call = call,
-                    centerContent = { },
-                    onCallAction = {
-                        call.leave()
-                        finish()
-                    },
-                )
+            LaunchPermissionRequest(getRequiredPermissions(call)) {
+                AllPermissionsGranted {
+                    Box {
+                        LivestreamPlayer(
+                            call = call, videoRendererConfig =
+                                videoRenderConfig {
+                                    this.fallbackContent = {
+                                        val userName = it.user.userNameOrId
+                                        val userImage = it.user.image
+                                        Box {
+                                            UserAvatarBackground(
+                                                userImage = userImage,
+                                                userName = userName
+                                            )
+                                        }
+                                    }
+                                })
+                        CallAppBar(
+                            modifier = Modifier
+                                .align(Alignment.TopCenter)
+                                .padding(end = 16.dp, top = 16.dp),
+                            call = call,
+                            centerContent = { },
+                            onCallAction = {
+                                call.leave()
+                                finish()
+                            },
+                        )
+                    }
+                }
             }
         } else {
             var callAction: CallAction by remember {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -127,19 +127,21 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                 AllPermissionsGranted {
                     Box {
                         LivestreamPlayer(
-                            call = call, videoRendererConfig =
-                                videoRenderConfig {
-                                    this.fallbackContent = {
-                                        val userName = it.user.userNameOrId
-                                        val userImage = it.user.image
-                                        Box {
-                                            UserAvatarBackground(
-                                                userImage = userImage,
-                                                userName = userName
-                                            )
-                                        }
+                            call = call,
+                            videoRendererConfig =
+                            videoRenderConfig {
+                                this.fallbackContent = {
+                                    val userName = it.user.userNameOrId
+                                    val userImage = it.user.image
+                                    Box {
+                                        UserAvatarBackground(
+                                            userImage = userImage,
+                                            userName = userName,
+                                        )
                                     }
-                                })
+                                }
+                            },
+                        )
                         CallAppBar(
                             modifier = Modifier
                                 .align(Alignment.TopCenter)
@@ -184,10 +186,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                                         isShowingHeader: Boolean,
                                         headerContent: @Composable (ColumnScope.() -> Unit)?,
                                         detailsContent: @Composable (
-                                        ColumnScope.(
-                                            participants: List<MemberState>,
-                                            topPadding: Dp,
-                                        ) -> Unit
+                                            ColumnScope.(
+                                                participants: List<MemberState>,
+                                                topPadding: Dp,
+                                            ) -> Unit
                                         )?,
                                         controlsContent: @Composable (BoxScope.() -> Unit)?,
                                         onBackPressed: () -> Unit,
@@ -211,10 +213,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                                         isVideoType: Boolean, isShowingHeader: Boolean,
                                         headerContent: @Composable (ColumnScope.() -> Unit)?,
                                         detailsContent: @Composable (
-                                        ColumnScope.(
-                                            participants: List<MemberState>,
-                                            topPadding: Dp,
-                                        ) -> Unit
+                                            ColumnScope.(
+                                                participants: List<MemberState>,
+                                                topPadding: Dp,
+                                            ) -> Unit
                                         )?,
                                         controlsContent: @Composable (BoxScope.() -> Unit)?,
                                         onBackPressed: () -> Unit,
@@ -362,10 +364,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-        @Composable ColumnScope.(
-            participants: List<MemberState>,
-            topPadding: Dp,
-        ) -> Unit
+            @Composable ColumnScope.(
+                participants: List<MemberState>,
+                topPadding: Dp,
+            ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,
@@ -392,10 +394,10 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         isShowingHeader: Boolean,
         headerContent: (@Composable ColumnScope.() -> Unit)?,
         detailsContent: (
-        @Composable ColumnScope.(
-            participants: List<MemberState>,
-            topPadding: Dp,
-        ) -> Unit
+            @Composable ColumnScope.(
+                participants: List<MemberState>,
+                topPadding: Dp,
+            ) -> Unit
         )?,
         controlsContent: (@Composable BoxScope.() -> Unit)?,
         onBackPressed: () -> Unit,

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/livestream/LivestreamRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/livestream/LivestreamRenderer.kt
@@ -41,23 +41,30 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.video.VideoRenderer
+import io.getstream.video.android.compose.ui.components.video.config.VideoRendererConfig
+import io.getstream.video.android.compose.ui.components.video.config.videoRenderConfig
 import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewCall
 import io.getstream.webrtc.android.ui.VideoTextureViewRenderer
+import kotlinx.coroutines.flow.Flow
 
 @Composable
 internal fun LivestreamRenderer(
     call: Call,
+    configuration: VideoRendererConfig = videoRenderConfig(),
     enablePausing: Boolean,
     onPausedPlayer: ((isPaused: Boolean) -> Unit)? = {},
+    livestreamFlow: Flow<ParticipantState.Video?> = call.state.livestream,
 ) {
-    val livestream by call.state.livestream.collectAsStateWithLifecycle()
+    val livestream by livestreamFlow.collectAsStateWithLifecycle(null)
     var videoTextureView: VideoTextureViewRenderer? by remember { mutableStateOf(null) }
     var isPaused by rememberSaveable { mutableStateOf(false) }
 
     Box(modifier = Modifier.fillMaxSize()) {
         VideoRenderer(
+            videoRendererConfig = configuration,
             modifier = Modifier
                 .fillMaxSize()
                 .clickable(enabled = enablePausing) {


### PR DESCRIPTION
### 🎯 Goal

The goal of this PR is to improve the `LivestreamPlayer` and also include it in demo app.

### 🛠 Implementation details

1. Expose `videoRendererConfig` as a parameter to the `LivestreamPlayer`.
2. Expose `livestreamFlow` as a parameter to the `LivestreamPlayer` and default it to "first participant with video". This can be changed per integration requirements now.
3. Include the `LivestreamPlayer` in the `demo-app` In case the call type is `livestream` we show the `LivestreamPlayer` instead of the `CallSreen`.