### PR TITLE
[AND-484] Add the possibility to play incoming/outgoing call sounds when device is on silent

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -10823,32 +10823,37 @@ public final class io/getstream/video/android/core/sounds/CallSoundPlayer {
 	public final fun stopCallSound ()V
 }
 
-public abstract interface class io/getstream/video/android/core/sounds/RingingConfig {
-	public abstract fun getIncomingCallSoundUri ()Landroid/net/Uri;
-	public abstract fun getOutgoingCallSoundUri ()Landroid/net/Uri;
+public abstract interface class io/getstream/video/android/core/sounds/MutedRingingConfig {
 	public abstract fun getPlayIncomingSoundIfMuted ()Z
 	public abstract fun getPlayOutgoingSoundIfMuted ()Z
 }
 
+public abstract interface class io/getstream/video/android/core/sounds/RingingConfig {
+	public abstract fun getIncomingCallSoundUri ()Landroid/net/Uri;
+	public abstract fun getOutgoingCallSoundUri ()Landroid/net/Uri;
+}
+
 public final class io/getstream/video/android/core/sounds/RingingConfigKt {
-	public static final fun defaultResourcesRingingConfig (Landroid/content/Context;ZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static synthetic fun defaultResourcesRingingConfig$default (Landroid/content/Context;ZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static final fun deviceRingtoneRingingConfig (Landroid/content/Context;ZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static synthetic fun deviceRingtoneRingingConfig$default (Landroid/content/Context;ZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun defaultMutedRingingConfig (ZZ)Lio/getstream/video/android/core/sounds/MutedRingingConfig;
+	public static synthetic fun defaultMutedRingingConfig$default (ZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/MutedRingingConfig;
+	public static final fun defaultResourcesRingingConfig (Landroid/content/Context;)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun deviceRingtoneRingingConfig (Landroid/content/Context;)Lio/getstream/video/android/core/sounds/RingingConfig;
 	public static final fun emptyRingingConfig ()Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static final fun resRingingConfig (Landroid/content/Context;IIZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static synthetic fun resRingingConfig$default (Landroid/content/Context;IIZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun resRingingConfig (Landroid/content/Context;II)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun ringingConfig (Lio/getstream/video/android/core/sounds/RingingConfig;Lio/getstream/video/android/core/sounds/MutedRingingConfig;)Lio/getstream/video/android/core/sounds/Sounds;
 	public static final fun toSounds (Lio/getstream/video/android/core/sounds/RingingConfig;)Lio/getstream/video/android/core/sounds/Sounds;
-	public static final fun uriRingingConfig (Landroid/net/Uri;Landroid/net/Uri;ZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static synthetic fun uriRingingConfig$default (Landroid/net/Uri;Landroid/net/Uri;ZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun uriRingingConfig (Landroid/net/Uri;Landroid/net/Uri;)Lio/getstream/video/android/core/sounds/RingingConfig;
 }
 
 public final class io/getstream/video/android/core/sounds/Sounds {
-	public fun <init> (Lio/getstream/video/android/core/sounds/RingingConfig;)V
+	public fun <init> (Lio/getstream/video/android/core/sounds/RingingConfig;Lio/getstream/video/android/core/sounds/MutedRingingConfig;)V
+	public synthetic fun <init> (Lio/getstream/video/android/core/sounds/RingingConfig;Lio/getstream/video/android/core/sounds/MutedRingingConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/video/android/core/sounds/RingingConfig;
-	public final fun copy (Lio/getstream/video/android/core/sounds/RingingConfig;)Lio/getstream/video/android/core/sounds/Sounds;
-	public static synthetic fun copy$default (Lio/getstream/video/android/core/sounds/Sounds;Lio/getstream/video/android/core/sounds/RingingConfig;ILjava/lang/Object;)Lio/getstream/video/android/core/sounds/Sounds;
+	public final fun component2 ()Lio/getstream/video/android/core/sounds/MutedRingingConfig;
+	public final fun copy (Lio/getstream/video/android/core/sounds/RingingConfig;Lio/getstream/video/android/core/sounds/MutedRingingConfig;)Lio/getstream/video/android/core/sounds/Sounds;
+	public static synthetic fun copy$default (Lio/getstream/video/android/core/sounds/Sounds;Lio/getstream/video/android/core/sounds/RingingConfig;Lio/getstream/video/android/core/sounds/MutedRingingConfig;ILjava/lang/Object;)Lio/getstream/video/android/core/sounds/Sounds;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMutedRingingConfig ()Lio/getstream/video/android/core/sounds/MutedRingingConfig;
 	public final fun getRingingConfig ()Lio/getstream/video/android/core/sounds/RingingConfig;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -10815,18 +10815,32 @@ public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketSta
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/video/android/core/sounds/CallSoundPlayer {
+	public fun <init> (Landroid/content/Context;)V
+	public final fun cleanUpAudioResources ()V
+	public final fun playCallSound (Landroid/net/Uri;Z)V
+	public static synthetic fun playCallSound$default (Lio/getstream/video/android/core/sounds/CallSoundPlayer;Landroid/net/Uri;ZILjava/lang/Object;)V
+	public final fun stopCallSound ()V
+}
+
 public abstract interface class io/getstream/video/android/core/sounds/RingingConfig {
 	public abstract fun getIncomingCallSoundUri ()Landroid/net/Uri;
 	public abstract fun getOutgoingCallSoundUri ()Landroid/net/Uri;
+	public abstract fun getPlayIncomingSoundIfMuted ()Z
+	public abstract fun getPlayOutgoingSoundIfMuted ()Z
 }
 
 public final class io/getstream/video/android/core/sounds/RingingConfigKt {
-	public static final fun defaultResourcesRingingConfig (Landroid/content/Context;)Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static final fun deviceRingtoneRingingConfig (Landroid/content/Context;)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun defaultResourcesRingingConfig (Landroid/content/Context;ZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static synthetic fun defaultResourcesRingingConfig$default (Landroid/content/Context;ZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun deviceRingtoneRingingConfig (Landroid/content/Context;ZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static synthetic fun deviceRingtoneRingingConfig$default (Landroid/content/Context;ZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
 	public static final fun emptyRingingConfig ()Lio/getstream/video/android/core/sounds/RingingConfig;
-	public static final fun resRingingConfig (Landroid/content/Context;II)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun resRingingConfig (Landroid/content/Context;IIZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static synthetic fun resRingingConfig$default (Landroid/content/Context;IIZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
 	public static final fun toSounds (Lio/getstream/video/android/core/sounds/RingingConfig;)Lio/getstream/video/android/core/sounds/Sounds;
-	public static final fun uriRingingConfig (Landroid/net/Uri;Landroid/net/Uri;)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static final fun uriRingingConfig (Landroid/net/Uri;Landroid/net/Uri;ZZ)Lio/getstream/video/android/core/sounds/RingingConfig;
+	public static synthetic fun uriRingingConfig$default (Landroid/net/Uri;Landroid/net/Uri;ZZILjava/lang/Object;)Lio/getstream/video/android/core/sounds/RingingConfig;
 }
 
 public final class io/getstream/video/android/core/sounds/Sounds {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -479,6 +479,7 @@ internal open class CallService : Service() {
                         if (!it.acceptedByMe) {
                             callSoundPlayer?.playCallSound(
                                 streamVideo.sounds.ringingConfig.incomingCallSoundUri,
+                                streamVideo.sounds.ringingConfig.playIncomingSoundIfMuted,
                             )
                         } else {
                             callSoundPlayer?.stopCallSound() // Stops sound sooner than Active. More responsive.
@@ -489,6 +490,7 @@ internal open class CallService : Service() {
                         if (!it.acceptedByCallee) {
                             callSoundPlayer?.playCallSound(
                                 streamVideo.sounds.ringingConfig.outgoingCallSoundUri,
+                                streamVideo.sounds.ringingConfig.playOutgoingSoundIfMuted,
                             )
                         } else {
                             callSoundPlayer?.stopCallSound() // Stops sound sooner than Active. More responsive.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -479,7 +479,7 @@ internal open class CallService : Service() {
                         if (!it.acceptedByMe) {
                             callSoundPlayer?.playCallSound(
                                 streamVideo.sounds.ringingConfig.incomingCallSoundUri,
-                                streamVideo.sounds.ringingConfig.playIncomingSoundIfMuted,
+                                streamVideo.sounds.mutedRingingConfig?.playIncomingSoundIfMuted ?: false,
                             )
                         } else {
                             callSoundPlayer?.stopCallSound() // Stops sound sooner than Active. More responsive.
@@ -490,7 +490,7 @@ internal open class CallService : Service() {
                         if (!it.acceptedByCallee) {
                             callSoundPlayer?.playCallSound(
                                 streamVideo.sounds.ringingConfig.outgoingCallSoundUri,
-                                streamVideo.sounds.ringingConfig.playOutgoingSoundIfMuted,
+                                streamVideo.sounds.mutedRingingConfig?.playOutgoingSoundIfMuted ?: false,
                             )
                         } else {
                             callSoundPlayer?.stopCallSound() // Stops sound sooner than Active. More responsive.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -27,16 +27,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.pm.ServiceInfo
-import android.media.AudioAttributes
-import android.media.AudioFocusRequest
-import android.media.AudioManager
-import android.media.MediaPlayer
-import android.media.Ringtone
-import android.media.RingtoneManager
-import android.net.Uri
-import android.os.Build
 import android.os.IBinder
-import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.app.NotificationManagerCompat
 import androidx.core.content.ContextCompat
@@ -53,6 +44,7 @@ import io.getstream.video.android.core.notifications.NotificationHandler.Compani
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.INTENT_EXTRA_CALL_CID
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.INTENT_EXTRA_CALL_DISPLAY_NAME
 import io.getstream.video.android.core.notifications.internal.receivers.ToggleCameraBroadcastReceiver
+import io.getstream.video.android.core.sounds.CallSoundPlayer
 import io.getstream.video.android.core.utils.safeCallWithDefault
 import io.getstream.video.android.core.utils.safeCallWithResult
 import io.getstream.video.android.core.utils.startForegroundWithServiceType
@@ -88,10 +80,7 @@ internal open class CallService : Service() {
     private var isToggleCameraBroadcastReceiverRegistered = false
 
     // Call sounds
-    private var mediaPlayer: MediaPlayer? = null
-    private var audioManager: AudioManager? = null
-    private var audioFocusRequest: AudioFocusRequest? = null
-    private var ringtone: Ringtone? = null
+    private var callSoundPlayer: CallSoundPlayer? = null
 
     internal companion object {
         private const val TAG = "CallServiceCompanion"
@@ -369,9 +358,9 @@ internal open class CallService : Service() {
 
             if (trigger == TRIGGER_INCOMING_CALL) {
                 updateRingingCall(streamVideo, intentCallId, RingingState.Incoming())
-                instantiateMediaPlayer()
+                callSoundPlayer = CallSoundPlayer(applicationContext)
             } else if (trigger == TRIGGER_OUTGOING_CALL) {
-                instantiateMediaPlayer()
+                callSoundPlayer = CallSoundPlayer(applicationContext)
             }
             observeCall(intentCallId, streamVideo)
             registerToggleCameraBroadcastReceiver()
@@ -473,12 +462,6 @@ internal open class CallService : Service() {
         }
     }
 
-    private fun instantiateMediaPlayer() {
-        synchronized(this) {
-            if (mediaPlayer == null) mediaPlayer = MediaPlayer()
-        }
-    }
-
     private fun observeCall(callId: StreamCallId, streamVideo: StreamVideoClient) {
         observeRingingState(callId, streamVideo)
         observeCallEvents(callId, streamVideo)
@@ -494,35 +477,35 @@ internal open class CallService : Service() {
                 when (it) {
                     is RingingState.Incoming -> {
                         if (!it.acceptedByMe) {
-                            playCallSound(
+                            callSoundPlayer?.playCallSound(
                                 streamVideo.sounds.ringingConfig.incomingCallSoundUri,
                             )
                         } else {
-                            stopCallSound() // Stops sound sooner than Active. More responsive.
+                            callSoundPlayer?.stopCallSound() // Stops sound sooner than Active. More responsive.
                         }
                     }
 
                     is RingingState.Outgoing -> {
                         if (!it.acceptedByCallee) {
-                            playCallSound(
+                            callSoundPlayer?.playCallSound(
                                 streamVideo.sounds.ringingConfig.outgoingCallSoundUri,
                             )
                         } else {
-                            stopCallSound() // Stops sound sooner than Active. More responsive.
+                            callSoundPlayer?.stopCallSound() // Stops sound sooner than Active. More responsive.
                         }
                     }
 
                     is RingingState.Active -> { // Handle Active to make it more reliable
-                        stopCallSound()
+                        callSoundPlayer?.stopCallSound()
                     }
 
                     is RingingState.RejectedByAll -> {
-                        stopCallSound()
+                        callSoundPlayer?.stopCallSound()
                         stopService()
                     }
 
                     is RingingState.TimeoutNoAnswer -> {
-                        stopCallSound()
+                        callSoundPlayer?.stopCallSound()
                     }
 
                     else -> {
@@ -530,121 +513,6 @@ internal open class CallService : Service() {
                     }
                 }
             }
-        }
-    }
-
-    private fun playCallSound(soundUri: Uri?) {
-        try {
-            synchronized(this) {
-                requestAudioFocus(
-                    context = applicationContext,
-                    onGranted = {
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                            playWithRingtone(soundUri)
-                        } else {
-                            playWithMediaPlayer(soundUri)
-                        }
-                    },
-                )
-            }
-        } catch (e: Exception) {
-            logger.d { "[Sounds] Error playing call sound: ${e.message}" }
-        }
-    }
-
-    private fun requestAudioFocus(context: Context, onGranted: () -> Unit) {
-        if (audioManager == null) {
-            audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
-        }
-
-        val isGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            if (audioFocusRequest == null) {
-                audioFocusRequest = AudioFocusRequest
-                    .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
-                    .setAudioAttributes(
-                        AudioAttributes.Builder()
-                            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
-                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
-                            .build(),
-                    )
-                    .setAcceptsDelayedFocusGain(false)
-                    .build()
-            }
-
-            audioFocusRequest?.let {
-                audioManager?.requestAudioFocus(it) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
-            } ?: false
-        } else {
-            audioManager?.requestAudioFocus(
-                null,
-                AudioManager.STREAM_RING,
-                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
-            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
-        }
-
-        logger.d { "[Sounds] Audio focus " + if (isGranted) "granted" else "not granted" }
-        if (isGranted) onGranted()
-    }
-
-    @RequiresApi(Build.VERSION_CODES.P)
-    private fun playWithRingtone(soundUri: Uri?) {
-        soundUri?.let {
-            if (ringtone?.isPlaying == true) ringtone?.stop()
-            ringtone = RingtoneManager.getRingtone(applicationContext, soundUri)
-            if (ringtone?.isPlaying == false) {
-                ringtone?.isLooping = true
-                ringtone?.play()
-
-                logger.d { "[Sounds] Sound playing with Ringtone" }
-            }
-        }
-    }
-
-    private fun playWithMediaPlayer(soundUri: Uri?) {
-        soundUri?.let {
-            mediaPlayer?.let { mediaPlayer ->
-                if (!mediaPlayer.isPlaying) {
-                    setMediaPlayerDataSource(mediaPlayer, soundUri)
-                    mediaPlayer.start()
-
-                    logger.d { "[Sounds] Sound playing with MediaPlayer" }
-                }
-            }
-        }
-    }
-
-    private fun setMediaPlayerDataSource(mediaPlayer: MediaPlayer, uri: Uri) {
-        mediaPlayer.reset()
-        mediaPlayer.setDataSource(applicationContext, uri)
-        mediaPlayer.isLooping = true
-        mediaPlayer.prepare()
-    }
-
-    private fun stopCallSound() {
-        synchronized(this) {
-            try {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    logger.d { "[Sounds] Stopping Ringtone sound" }
-                    if (ringtone?.isPlaying == true) ringtone?.stop()
-                } else {
-                    logger.d { "[Sounds] Stopping MediaPlayer sound" }
-                    if (mediaPlayer?.isPlaying == true) mediaPlayer?.stop()
-                }
-            } catch (e: Exception) {
-                logger.d { "[Sounds] Error stopping call sound: ${e.message}" }
-            } finally {
-                abandonAudioFocus()
-            }
-        }
-    }
-
-    private fun abandonAudioFocus() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            audioFocusRequest?.let {
-                audioManager?.abandonAudioFocusRequest(it)
-            }
-        } else {
-            audioManager?.abandonAudioFocus(null)
         }
     }
 
@@ -823,7 +691,7 @@ internal open class CallService : Service() {
         unregisterToggleCameraBroadcastReceiver()
 
         // Call sounds
-        cleanAudioResources()
+        callSoundPlayer?.cleanUpAudioResources()
 
         // Stop any jobs
         serviceScope.cancel()
@@ -840,21 +708,6 @@ internal open class CallService : Service() {
             } catch (e: Exception) {
                 logger.d { "Unable to unregister ToggleCameraBroadcastReceiver." }
             }
-        }
-    }
-
-    private fun cleanAudioResources() {
-        synchronized(this) {
-            logger.d { "[Sounds] Cleaning audio resources" }
-
-            if (ringtone?.isPlaying == true) ringtone?.stop()
-            ringtone = null
-
-            mediaPlayer?.release()
-            mediaPlayer = null
-
-            audioManager = null
-            audioFocusRequest = null
         }
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/CallSoundPlayer.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/CallSoundPlayer.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.sounds
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioManager
+import android.media.MediaPlayer
+import android.media.Ringtone
+import android.media.RingtoneManager
+import android.net.Uri
+import android.os.Build
+import androidx.annotation.RequiresApi
+import io.getstream.log.taggedLogger
+
+class CallSoundPlayer(private val context: Context) {
+    private val logger by taggedLogger("CallSoundPlayer")
+    private val mediaPlayer: MediaPlayer by lazy { MediaPlayer() }
+    private var audioManager: AudioManager? = null
+    private var audioFocusRequest: AudioFocusRequest? = null
+    private var ringtone: Ringtone? = null
+
+    fun playCallSound(soundUri: Uri?) {
+        try {
+            synchronized(this) {
+                requestAudioFocus {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        playWithRingtoneManager(soundUri)
+                    } else {
+                        playWithMediaPlayer(soundUri)
+                    }
+                }
+            }
+        } catch (e: Exception) {
+            logger.d { "[playCallSound] Error playing call sound: ${e.message}" }
+        }
+    }
+
+    private fun requestAudioFocus(onGranted: () -> Unit) {
+        if (audioManager == null) {
+            (context.getSystemService(Context.AUDIO_SERVICE) as? AudioManager)?.let {
+                audioManager = it
+            } ?: run {
+                logger.d { "[requestAudioFocus] Error getting AudioManager system service" }
+                return
+            }
+        }
+
+        val isGranted = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            if (audioFocusRequest == null) {
+                audioFocusRequest = AudioFocusRequest
+                    .Builder(AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE)
+                    .setAudioAttributes(
+                        AudioAttributes.Builder()
+                            .setUsage(AudioAttributes.USAGE_NOTIFICATION_RINGTONE)
+                            .setContentType(AudioAttributes.CONTENT_TYPE_SONIFICATION)
+                            .build(),
+                    )
+                    .setAcceptsDelayedFocusGain(false)
+                    .build()
+            }
+
+            audioFocusRequest?.let {
+                audioManager?.requestAudioFocus(it) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+            } ?: false
+        } else {
+            audioManager?.requestAudioFocus(
+                null,
+                AudioManager.STREAM_RING,
+                AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE,
+            ) == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        }
+
+        logger.d { "[requestAudioFocus] Audio focus " + if (isGranted) "granted" else "not granted" }
+        if (isGranted) onGranted()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    private fun playWithRingtoneManager(soundUri: Uri?) {
+        soundUri?.let {
+            if (ringtone?.isPlaying == true) ringtone?.stop()
+            ringtone = RingtoneManager.getRingtone(context, soundUri)
+            if (ringtone?.isPlaying == false) {
+                ringtone?.isLooping = true
+                ringtone?.play()
+
+                logger.d { "[playWithRingtoneManager] Sound playing" }
+            }
+        }
+    }
+
+    private fun playWithMediaPlayer(soundUri: Uri?) {
+        soundUri?.let {
+            mediaPlayer.let { mediaPlayer ->
+                if (!mediaPlayer.isPlaying) {
+                    setMediaPlayerDataSource(mediaPlayer, soundUri)
+                    mediaPlayer.start()
+
+                    logger.d { "[playWithMediaPlayer] Sound playing" }
+                }
+            }
+        }
+    }
+
+    private fun setMediaPlayerDataSource(mediaPlayer: MediaPlayer, uri: Uri) {
+        mediaPlayer.reset()
+        mediaPlayer.setDataSource(context, uri)
+        mediaPlayer.isLooping = true
+        mediaPlayer.prepare()
+    }
+
+    fun stopCallSound() {
+        synchronized(this) {
+            try {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    logger.d { "[stopCallSound] Stopping RingtoneManager sound" }
+                    if (ringtone?.isPlaying == true) ringtone?.stop()
+                } else {
+                    logger.d { "[stopCallSound] Stopping MediaPlayer sound" }
+                    if (mediaPlayer.isPlaying == true) mediaPlayer.stop()
+                }
+            } catch (e: Exception) {
+                logger.d { "[stopCallSound] Error stopping call sound: ${e.message}" }
+            } finally {
+                abandonAudioFocus()
+            }
+        }
+    }
+
+    private fun abandonAudioFocus() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let { audioManager?.abandonAudioFocusRequest(it) }
+        } else {
+            audioManager?.abandonAudioFocus(null)
+        }
+    }
+
+    fun cleanUpAudioResources() {
+        synchronized(this) {
+            logger.d { "[cleanAudioResources] Cleaning audio resources" }
+
+            if (ringtone?.isPlaying == true) ringtone?.stop()
+            ringtone = null
+
+            mediaPlayer.release()
+
+            audioManager = null
+            audioFocusRequest = null
+        }
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
@@ -37,6 +37,8 @@ import io.getstream.video.android.core.utils.safeCallWithDefault
 public interface RingingConfig {
     val incomingCallSoundUri: Uri?
     val outgoingCallSoundUri: Uri?
+    val playIncomingSoundIfMuted: Boolean
+    val playOutgoingSoundIfMuted: Boolean
 }
 
 /**
@@ -54,19 +56,38 @@ public data class Sounds(val ringingConfig: RingingConfig)
  * Returns a ringing config that uses the SDK default sounds for incoming and outgoing calls.
  *
  * @param context Context used for retrieving the sounds.
+ * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
+ * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
-public fun defaultResourcesRingingConfig(context: Context): RingingConfig = object : RingingConfig {
+public fun defaultResourcesRingingConfig(
+    context: Context,
+    playIncomingSoundIfMuted: Boolean = false,
+    playOutgoingSoundIfMuted: Boolean = false,
+): RingingConfig = object : RingingConfig {
     override val incomingCallSoundUri: Uri? = R.raw.call_incoming_sound.toUriOrNUll(context)
     override val outgoingCallSoundUri: Uri? = R.raw.call_outgoing_sound.toUriOrNUll(context)
+
+    override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
+    override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
 
 /**
  * Returns a ringing config that uses the device ringtone for incoming calls and the SDK default ringing tone for outgoing calls.
  *
  * @param context Context used for retrieving the sounds.
+ * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
+ * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
-public fun deviceRingtoneRingingConfig(context: Context): RingingConfig = object : RingingConfig {
-    private val streamResSoundConfig = defaultResourcesRingingConfig(context)
+public fun deviceRingtoneRingingConfig(
+    context: Context,
+    playIncomingSoundIfMuted: Boolean = false,
+    playOutgoingSoundIfMuted: Boolean = false,
+): RingingConfig = object : RingingConfig {
+    private val streamResSoundConfig = defaultResourcesRingingConfig(
+        context,
+        playIncomingSoundIfMuted,
+        playOutgoingSoundIfMuted,
+    )
     override val incomingCallSoundUri: Uri?
         get() = safeCallWithDefault(default = null) {
             RingtoneManager.getActualDefaultRingtoneUri(
@@ -75,6 +96,9 @@ public fun deviceRingtoneRingingConfig(context: Context): RingingConfig = object
             )
         } ?: streamResSoundConfig.incomingCallSoundUri
     override val outgoingCallSoundUri: Uri? = streamResSoundConfig.outgoingCallSoundUri
+
+    override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
+    override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
 
 /**
@@ -83,14 +107,21 @@ public fun deviceRingtoneRingingConfig(context: Context): RingingConfig = object
  * @param context Context used for retrieving the sounds.
  * @param incomingCallSoundResId The resource ID for the incoming call sound.
  * @param outgoingCallSoundResId The resource ID for the outgoing call sound.
+ * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
+ * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
 public fun resRingingConfig(
     context: Context,
     @RawRes incomingCallSoundResId: Int,
     @RawRes outgoingCallSoundResId: Int,
+    playIncomingSoundIfMuted: Boolean = false,
+    playOutgoingSoundIfMuted: Boolean = false,
 ) = object : RingingConfig {
     override val incomingCallSoundUri: Uri? = incomingCallSoundResId.toUriOrNUll(context)
     override val outgoingCallSoundUri: Uri? = outgoingCallSoundResId.toUriOrNUll(context)
+
+    override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
+    override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
 
 /**
@@ -98,13 +129,20 @@ public fun resRingingConfig(
  *
  * @param incomingCallSoundUri The URI for the incoming call sound.
  * @param outgoingCallSoundUri The URI for the outgoing call sound.
+ * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
+ * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
 public fun uriRingingConfig(
     incomingCallSoundUri: Uri,
     outgoingCallSoundUri: Uri,
+    playIncomingSoundIfMuted: Boolean = false,
+    playOutgoingSoundIfMuted: Boolean = false,
 ) = object : RingingConfig {
     override val incomingCallSoundUri: Uri = incomingCallSoundUri
     override val outgoingCallSoundUri: Uri = outgoingCallSoundUri
+
+    override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
+    override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
 
 /**
@@ -113,6 +151,9 @@ public fun uriRingingConfig(
 public fun emptyRingingConfig(): RingingConfig = object : RingingConfig {
     override val incomingCallSoundUri: Uri? = null
     override val outgoingCallSoundUri: Uri? = null
+
+    override val playIncomingSoundIfMuted: Boolean = false
+    override val playOutgoingSoundIfMuted: Boolean = false
 }
 
 /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
@@ -58,6 +58,13 @@ public data class Sounds(
 )
 
 // Factories
+/**
+ * Creates a [Sounds] object using the provided [RingingConfig] and [MutedRingingConfig].
+ *
+ * @param ringingConfig The configuration for incoming and outgoing call sounds.
+ * @param mutedRingingConfig The configuration for handling incoming and outgoing call sounds if device is muted. Can be null.
+ * @return A [Sounds] object containing the specified configurations.
+ */
 public fun ringingConfig(
     ringingConfig: RingingConfig,
     mutedRingingConfig: MutedRingingConfig?,
@@ -69,8 +76,6 @@ public fun ringingConfig(
  * Returns a ringing config that uses the SDK default sounds for incoming and outgoing calls.
  *
  * @param context Context used for retrieving the sounds.
- * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
- * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
 public fun defaultResourcesRingingConfig(
     context: Context,
@@ -91,8 +96,6 @@ public fun defaultMutedRingingConfig(
  * Returns a ringing config that uses the device ringtone for incoming calls and the SDK default ringing tone for outgoing calls.
  *
  * @param context Context used for retrieving the sounds.
- * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
- * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
 public fun deviceRingtoneRingingConfig(
     context: Context,
@@ -114,8 +117,6 @@ public fun deviceRingtoneRingingConfig(
  * @param context Context used for retrieving the sounds.
  * @param incomingCallSoundResId The resource ID for the incoming call sound.
  * @param outgoingCallSoundResId The resource ID for the outgoing call sound.
- * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
- * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
 public fun resRingingConfig(
     context: Context,
@@ -131,8 +132,6 @@ public fun resRingingConfig(
  *
  * @param incomingCallSoundUri The URI for the incoming call sound.
  * @param outgoingCallSoundUri The URI for the outgoing call sound.
- * @param playIncomingSoundIfMuted Whether to play the incoming sound even if the device is muted.
- * @param playOutgoingSoundIfMuted Whether to play the outgoing sound even if the device is muted.
  */
 public fun uriRingingConfig(
     incomingCallSoundUri: Uri,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
@@ -37,6 +37,9 @@ import io.getstream.video.android.core.utils.safeCallWithDefault
 public interface RingingConfig {
     val incomingCallSoundUri: Uri?
     val outgoingCallSoundUri: Uri?
+}
+
+public interface MutedRingingConfig {
     val playIncomingSoundIfMuted: Boolean
     val playOutgoingSoundIfMuted: Boolean
 }
@@ -46,12 +49,22 @@ public interface RingingConfig {
  */
 @Deprecated(
     message = "Sounds will be deprecated in the future and replaced with RingingConfig. It is recommended to use one of the factory methods along with toSounds() to create the Sounds object.",
-    replaceWith = ReplaceWith("SoundConfig"),
+    replaceWith = ReplaceWith("RingingConfig"),
     level = DeprecationLevel.WARNING,
 )
-public data class Sounds(val ringingConfig: RingingConfig)
+public data class Sounds(
+    val ringingConfig: RingingConfig,
+    val mutedRingingConfig: MutedRingingConfig? = null,
+)
 
 // Factories
+public fun ringingConfig(
+    ringingConfig: RingingConfig,
+    mutedRingingConfig: MutedRingingConfig?,
+): Sounds {
+    return Sounds(ringingConfig, mutedRingingConfig)
+}
+
 /**
  * Returns a ringing config that uses the SDK default sounds for incoming and outgoing calls.
  *
@@ -61,12 +74,15 @@ public data class Sounds(val ringingConfig: RingingConfig)
  */
 public fun defaultResourcesRingingConfig(
     context: Context,
-    playIncomingSoundIfMuted: Boolean = false,
-    playOutgoingSoundIfMuted: Boolean = false,
 ): RingingConfig = object : RingingConfig {
     override val incomingCallSoundUri: Uri? = R.raw.call_incoming_sound.toUriOrNull(context)
     override val outgoingCallSoundUri: Uri? = R.raw.call_outgoing_sound.toUriOrNull(context)
+}
 
+public fun defaultMutedRingingConfig(
+    playIncomingSoundIfMuted: Boolean = false,
+    playOutgoingSoundIfMuted: Boolean = false,
+): MutedRingingConfig = object : MutedRingingConfig {
     override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
     override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
@@ -80,14 +96,8 @@ public fun defaultResourcesRingingConfig(
  */
 public fun deviceRingtoneRingingConfig(
     context: Context,
-    playIncomingSoundIfMuted: Boolean = false,
-    playOutgoingSoundIfMuted: Boolean = false,
 ): RingingConfig = object : RingingConfig {
-    private val streamResSoundConfig = defaultResourcesRingingConfig(
-        context,
-        playIncomingSoundIfMuted,
-        playOutgoingSoundIfMuted,
-    )
+    private val streamResSoundConfig = defaultResourcesRingingConfig(context)
     override val incomingCallSoundUri: Uri?
         get() = safeCallWithDefault(default = null) {
             RingtoneManager.getActualDefaultRingtoneUri(
@@ -96,9 +106,6 @@ public fun deviceRingtoneRingingConfig(
             )
         } ?: streamResSoundConfig.incomingCallSoundUri
     override val outgoingCallSoundUri: Uri? = streamResSoundConfig.outgoingCallSoundUri
-
-    override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
-    override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
 
 /**
@@ -114,14 +121,9 @@ public fun resRingingConfig(
     context: Context,
     @RawRes incomingCallSoundResId: Int,
     @RawRes outgoingCallSoundResId: Int,
-    playIncomingSoundIfMuted: Boolean = false,
-    playOutgoingSoundIfMuted: Boolean = false,
 ) = object : RingingConfig {
     override val incomingCallSoundUri: Uri? = incomingCallSoundResId.toUriOrNull(context)
     override val outgoingCallSoundUri: Uri? = outgoingCallSoundResId.toUriOrNull(context)
-
-    override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
-    override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
 
 /**
@@ -135,14 +137,9 @@ public fun resRingingConfig(
 public fun uriRingingConfig(
     incomingCallSoundUri: Uri,
     outgoingCallSoundUri: Uri,
-    playIncomingSoundIfMuted: Boolean = false,
-    playOutgoingSoundIfMuted: Boolean = false,
 ) = object : RingingConfig {
     override val incomingCallSoundUri: Uri = incomingCallSoundUri
     override val outgoingCallSoundUri: Uri = outgoingCallSoundUri
-
-    override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
-    override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
 }
 
 /**
@@ -151,9 +148,6 @@ public fun uriRingingConfig(
 public fun emptyRingingConfig(): RingingConfig = object : RingingConfig {
     override val incomingCallSoundUri: Uri? = null
     override val outgoingCallSoundUri: Uri? = null
-
-    override val playIncomingSoundIfMuted: Boolean = false
-    override val playOutgoingSoundIfMuted: Boolean = false
 }
 
 /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/RingingConfig.kt
@@ -64,8 +64,8 @@ public fun defaultResourcesRingingConfig(
     playIncomingSoundIfMuted: Boolean = false,
     playOutgoingSoundIfMuted: Boolean = false,
 ): RingingConfig = object : RingingConfig {
-    override val incomingCallSoundUri: Uri? = R.raw.call_incoming_sound.toUriOrNUll(context)
-    override val outgoingCallSoundUri: Uri? = R.raw.call_outgoing_sound.toUriOrNUll(context)
+    override val incomingCallSoundUri: Uri? = R.raw.call_incoming_sound.toUriOrNull(context)
+    override val outgoingCallSoundUri: Uri? = R.raw.call_outgoing_sound.toUriOrNull(context)
 
     override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
     override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
@@ -117,8 +117,8 @@ public fun resRingingConfig(
     playIncomingSoundIfMuted: Boolean = false,
     playOutgoingSoundIfMuted: Boolean = false,
 ) = object : RingingConfig {
-    override val incomingCallSoundUri: Uri? = incomingCallSoundResId.toUriOrNUll(context)
-    override val outgoingCallSoundUri: Uri? = outgoingCallSoundResId.toUriOrNUll(context)
+    override val incomingCallSoundUri: Uri? = incomingCallSoundResId.toUriOrNull(context)
+    override val outgoingCallSoundUri: Uri? = outgoingCallSoundResId.toUriOrNull(context)
 
     override val playIncomingSoundIfMuted: Boolean = playIncomingSoundIfMuted
     override val playOutgoingSoundIfMuted: Boolean = playOutgoingSoundIfMuted
@@ -162,7 +162,7 @@ public fun emptyRingingConfig(): RingingConfig = object : RingingConfig {
 public fun RingingConfig.toSounds() = Sounds(this)
 
 // Internal utilities
-private fun Int?.toUriOrNUll(context: Context): Uri? =
+private fun Int?.toUriOrNull(context: Context): Uri? =
     safeCallWithDefault(default = null) {
         if (this != null) {
             Uri.parse("android.resource://${context.packageName}/$this")


### PR DESCRIPTION
### 🎯 Goal

Currently, incoming and outgoing call sounds are not played if the device is on silent/muted. The goal is to make it possible via configuration.

### 🛠 Implementation details

- Encapsulated call sounds in `CallSoundPlayer`
- Use specific audio attributes depending if should play sound when muted or not
- Add flags in `RingingConfig` to be used in `StreamVideoBuilder(sounds)`

### 🧪 Testing

- Tested on Samsung phone and Pixel emulator
- Tested the flags for each type of sound
- Tested in all states of phone (silent, vibrate, sound)