### PR TITLE
Fix issue when caller cancels a group call

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1040,7 +1040,9 @@ public class CallState(
         val state: RingingState = if (hasActiveCall) {
             cancelTimeout()
             RingingState.Active
-        } else if (rejectedBy.isNotEmpty() && rejectedBy.size >= outgoingMembersCount) {
+        } else if (rejectedBy.isNotEmpty() && rejectedBy.size >= outgoingMembersCount ||
+            (rejectReason?.alias == RejectReason.Cancel.alias || rejectedBy.contains(createdBy?.id))
+        ) {
             call.leave()
             cancelTimeout()
 


### PR DESCRIPTION
### 🎯 Goal

Fix reported issue: if the caller hangs up the call before anyone answers. Other Android users are stuck in the call indefinitely.

### 🛠 Implementation details

Added check for creator reject or cancel reason.