### PR TITLE
Call end/reject improvements

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -10815,14 +10815,6 @@ public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketSta
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/video/android/core/sounds/CallSoundPlayer {
-	public fun <init> (Landroid/content/Context;)V
-	public final fun cleanUpAudioResources ()V
-	public final fun playCallSound (Landroid/net/Uri;Z)V
-	public static synthetic fun playCallSound$default (Lio/getstream/video/android/core/sounds/CallSoundPlayer;Landroid/net/Uri;ZILjava/lang/Object;)V
-	public final fun stopCallSound ()V
-}
-
 public abstract interface class io/getstream/video/android/core/sounds/MutedRingingConfig {
 	public abstract fun getPlayIncomingSoundIfMuted ()Z
 	public abstract fun getPlayOutgoingSoundIfMuted ()Z

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1147,6 +1147,7 @@ public class CallState(
                 // double check that we are still in Outgoing call state and call is not active
                 if (_ringingState.value is RingingState.Outgoing || _ringingState.value is RingingState.Incoming && client.state.activeCall.value == null) {
                     call.reject(reason = RejectReason.Custom(alias = REJECT_REASON_TIMEOUT))
+                    call.leave()
                 }
             } else {
                 logger.w { "[startRingingTimer] No autoCancelTimeoutMs set - call ring with no timeout" }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1041,7 +1041,7 @@ public class CallState(
             cancelTimeout()
             RingingState.Active
         } else if ((rejectedBy.isNotEmpty() && rejectedBy.size >= outgoingMembersCount) ||
-            rejectedBy.contains(createdBy?.id)
+            (rejectedBy.contains(createdBy?.id) && hasRingingCall)
         ) {
             call.leave()
             cancelTimeout()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/CallSoundPlayer.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/sounds/CallSoundPlayer.kt
@@ -28,7 +28,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import io.getstream.log.taggedLogger
 
-class CallSoundPlayer(private val context: Context) {
+internal class CallSoundPlayer(private val context: Context) {
     private val logger by taggedLogger("CallSoundPlayer")
     private val mediaPlayer: MediaPlayer by lazy { MediaPlayer() }
     private var audioManager: AudioManager? = null


### PR DESCRIPTION
### 🎯 Goal

See implementation details.

### 🛠 Implementation details

- Added `leave` at timeout to leave call even if part of receivers accepted.
- Added ringing call check at reject to avoid leaving call UI when initiator leaves call