### PR TITLE
[AND-500] Do not crash the Publisher if its transceiver is already disposed whe…

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
@@ -111,8 +111,17 @@ internal class Publisher(
 
     private fun dispose() {
         transceiverCache.items().forEach {
-            it.transceiver.stop()
-            it.transceiver.dispose()
+            try {
+                it.transceiver.stop()
+            } catch (e: Exception) {
+                logger.w { "Transceiver already stopped." }
+            }
+
+            try {
+                it.transceiver.dispose()
+            } catch (e: Exception) {
+                logger.w { "Transceiver already disposed." }
+            }
         }
     }
 
@@ -287,8 +296,10 @@ internal class Publisher(
             val (option, transceiver) = item
             val hasPublishOption = transceiverCache.has(option)
             if (!hasPublishOption) continue
-            transceiver.stop()
-            transceiver.dispose()
+            safeCall {
+                transceiver.stop()
+                transceiver.dispose()
+            }
             transceiverCache.remove(option)
         }
     }


### PR DESCRIPTION
### 🎯 Goal
Do not crush the publisher when `dispose()` is closed.

## Implementation

If there are consecutive calls on `session.cleanup()` such as in reconnect the `dispose()` of the `Publisher` CAN in certain cases be called twice. Which will result in a crash as the transceiver is already disposed. The solution is to catch this crash and just log a warning. because the transiver is already disposed at this point and we don't have anything to do.