### PR TITLE
Improve speaker toggling

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -83,7 +83,7 @@ class SpeakerManager(
     val volume: StateFlow<Int?> = _volume
 
     /** The status of the audio */
-    private val _status = MutableStateFlow<DeviceStatus>(DeviceStatus.NotSelected)
+    internal val _status = MutableStateFlow<DeviceStatus>(DeviceStatus.NotSelected)
     val status: StateFlow<DeviceStatus> = _status
 
     /** Represents whether the speakerphone is enabled */
@@ -436,6 +436,14 @@ class MicrophoneManager(
         logger.i { "selecting device $device" }
         ifAudioHandlerInitialized { it.selectDevice(device?.toAudioDevice()) }
         _selectedDevice.value = device
+
+        if (device !is StreamAudioDevice.Speakerphone && mediaManager.speaker.isEnabled.value) {
+            mediaManager.speaker._status.value = DeviceStatus.Disabled
+        }
+
+        if (device is StreamAudioDevice.Speakerphone) {
+            mediaManager.speaker._status.value = DeviceStatus.Enabled
+        }
 
         if (device !is StreamAudioDevice.BluetoothHeadset && device !is StreamAudioDevice.WiredHeadset) {
             selectedDeviceBeforeHeadset = device


### PR DESCRIPTION
### 🎯 Goal

Now, if we have the speaker selected at join, the previous device will be set as speaker, which leads to selecting only speaker when using the ToggleSpeakerphone toggle and setSpeakerPhone method.

Also, the state of the speaker toggle is not aligned with the selected device: if you have the toggle on the UI and also a Select Device menu, when you select Earpiece, the speaker toggle is still `on`

Also, it should respond to BT and wired headsets.

### 🛠 Implementation details

- Changed the logic of how `selectedBeforeSpeaker` is set and read in `setSpeakerPhone`
- Changed the logic of `select` to disable speaker if needed.