### PR TITLE
[AND-503] Fix fullscreen notification under lock screen issue

### DIFF
--- a/stream-video-android-core/src/main/AndroidManifest.xml
+++ b/stream-video-android-core/src/main/AndroidManifest.xml
@@ -77,7 +77,11 @@
                 <action android:name="io.getstream.video.android.action.LEAVE_CALL" />
             </intent-filter>
         </receiver>
-        <activity android:name=".notifications.internal.DismissNotificationActivity" />
+        <activity
+            android:name=".notifications.internal.DismissNotificationActivity"
+            android:showOnLockScreen="true"
+            android:showWhenLocked="true"
+            android:turnScreenOn="true" />
 
         <receiver android:name=".notifications.internal.receivers.StopScreenshareBroadcastReceiver"
             android:exported="false">


### PR DESCRIPTION
### 🎯 Goal

On some devices (mainly Pixel with Android 13), the incoming call full-screen notification appears under the lock-screen.

### 🛠 Implementation details

- Added relevant lock-screen flags to `DismissNotificationActivity`, which is used in `DefaultStreamIntentResolver#getActivityForIntent` when calling `PendingIntent.getActivities`.

### 🧪 Testing

Tested on Android 10, 13 (emulator) and 14.