### PR TITLE
[AND-508] Prevent multiple calls to `leave()` and `cleanup()` which may cause a concurrency in WebRTC leading to native crashes

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -5451,7 +5451,6 @@ public final class io/getstream/video/android/core/Call {
 	public final fun getAudioFilter ()Lio/getstream/video/android/core/call/audio/InputAudioFilter;
 	public final fun getCamera ()Lio/getstream/video/android/core/CameraManager;
 	public final fun getCid ()Ljava/lang/String;
-	public final fun getEvents ()Lkotlinx/coroutines/flow/MutableSharedFlow;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getLocalMicrophoneAudioLevel ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getMicrophone ()Lio/getstream/video/android/core/MicrophoneManager;
@@ -5528,7 +5527,6 @@ public final class io/getstream/video/android/core/Call {
 	public final fun takeScreenshot (Lio/getstream/video/android/core/model/VideoTrack;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun toggleAudioProcessing ()Z
 	public final fun unpinForEveryone (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public final fun unsubscribe (Lio/getstream/video/android/core/EventSubscription;)Z
 	public final fun update (Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lio/getstream/video/android/core/Call;Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun updateClosedCaptionsSettings (Lio/getstream/video/android/core/closedcaptions/ClosedCaptionsSettings;)V

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -5451,6 +5451,7 @@ public final class io/getstream/video/android/core/Call {
 	public final fun getAudioFilter ()Lio/getstream/video/android/core/call/audio/InputAudioFilter;
 	public final fun getCamera ()Lio/getstream/video/android/core/CameraManager;
 	public final fun getCid ()Ljava/lang/String;
+	public final fun getEvents ()Lkotlinx/coroutines/flow/MutableSharedFlow;
 	public final fun getId ()Ljava/lang/String;
 	public final fun getLocalMicrophoneAudioLevel ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getMicrophone ()Lio/getstream/video/android/core/MicrophoneManager;
@@ -5527,6 +5528,7 @@ public final class io/getstream/video/android/core/Call {
 	public final fun takeScreenshot (Lio/getstream/video/android/core/model/VideoTrack;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun toggleAudioProcessing ()Z
 	public final fun unpinForEveryone (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unsubscribe (Lio/getstream/video/android/core/EventSubscription;)Z
 	public final fun update (Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun update$default (Lio/getstream/video/android/core/Call;Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun updateClosedCaptionsSettings (Lio/getstream/video/android/core/closedcaptions/ClosedCaptionsSettings;)V

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -137,7 +137,7 @@ public class Call(
     internal val clientImpl = client as StreamVideoClient
 
     // Atomic controls
-    private val atomicLeave = AtomicUnitCall()
+    private var atomicLeave = AtomicUnitCall()
 
     private val logger by taggedLogger("Call:$type:$id")
     private val supervisorJob = SupervisorJob()
@@ -398,6 +398,7 @@ public class Call(
 
         var result: Result<RtcSession>
 
+        atomicLeave = AtomicUnitCall()
         while (retryCount < 3) {
             result = _join(create, createOptions, ring, notify)
             if (result is Success) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -77,6 +77,7 @@ import io.getstream.video.android.core.model.SortField
 import io.getstream.video.android.core.model.UpdateUserPermissionsData
 import io.getstream.video.android.core.model.VideoTrack
 import io.getstream.video.android.core.model.toIceServer
+import io.getstream.video.android.core.utils.AtomicUnitCall
 import io.getstream.video.android.core.utils.RampValueUpAndDownHelper
 import io.getstream.video.android.core.utils.safeCall
 import io.getstream.video.android.core.utils.safeCallWithDefault

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -79,7 +79,6 @@ import io.getstream.video.android.core.model.VideoTrack
 import io.getstream.video.android.core.model.toIceServer
 import io.getstream.video.android.core.utils.AtomicUnitCall
 import io.getstream.video.android.core.utils.RampValueUpAndDownHelper
-import io.getstream.video.android.core.utils.safeCall
 import io.getstream.video.android.core.utils.safeCallWithDefault
 import io.getstream.video.android.core.utils.toQueriedMembers
 import io.getstream.video.android.model.User

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AtomicUnitCall.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AtomicUnitCall.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 /**
  * An atomic call that is executed only once, no matter how many consecutive calls are made.
  */
-class AtomicUnitCall {
+internal class AtomicUnitCall {
     private var called = AtomicBoolean(false)
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AtomicUnitCall.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/AtomicUnitCall.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.utils
+
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * An atomic call that is executed only once, no matter how many consecutive calls are made.
+ */
+class AtomicUnitCall {
+    private var called = AtomicBoolean(false)
+
+    /**
+     * Executes the given block of code only once, no matter how many consecutive calls are made.
+     */
+    operator fun invoke(block: () -> Unit) {
+        if (called.compareAndSet(false, true)) {
+            safeCall {
+                block()
+            }
+        }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/AtomicUnitCallTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/AtomicUnitCallTest.kt
@@ -27,7 +27,7 @@ class AtomicUnitCallTest {
         atomicUnitCall {
             executed = true
         }
-        assert(executed)
+        assertTrue(executed)
     }
 
     @Test

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/AtomicUnitCallTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/AtomicUnitCallTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.utils
+
+import org.junit.Test
+
+class AtomicUnitCallTest {
+
+    @Test
+    fun `invoke should execute the block`() {
+        val atomicUnitCall = AtomicUnitCall()
+        var executed = false
+        atomicUnitCall {
+            executed = true
+        }
+        assert(executed)
+    }
+
+    @Test
+    fun `invoke should execute the block only once`() {
+        val atomicUnitCall = AtomicUnitCall()
+        var executed = 0
+        atomicUnitCall {
+            executed++
+        }
+        atomicUnitCall {
+            executed++
+        }
+        assert(executed == 1)
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/AtomicUnitCallTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/AtomicUnitCallTest.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.utils
 
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class AtomicUnitCallTest {


### PR DESCRIPTION
### 🎯 Goal

The goal of this change is to prevent concurrent calls to `leave()` and `cleanup()` in the `Call` and `RtcSession`. Multiple `leave()` or `cleanup()` calls may cause an operation on already disposed media track in which case a native crash may occur.  

### 🛠 Implementation details

Create an `AtomicUnitCall` which supports the underlying function e.g. 
```kotlin
fun leave() = atomicLeave {
 // The leave code that will be called only once per the lifecycle of the `Call` object.
}
```