### PR TITLE
[AND-511] Highlight participant only if dominant speaker is actively speaking

### DIFF
--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LandscapeVideoRenderer.kt
@@ -31,6 +31,8 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -87,6 +89,11 @@ internal fun BoxScope.LandscapeVideoRenderer(
     },
     floatingVideoRenderer: @Composable (BoxScope.(call: Call, IntSize) -> Unit)? = null,
 ) {
+    val isDomSpeakerSpeaking by dominantSpeaker
+        ?.speaking
+        ?.collectAsStateWithLifecycle(initialValue = false)
+        ?: remember { mutableStateOf(false) }
+
     val remoteParticipants by call.state.remoteParticipants.collectAsStateWithLifecycle()
     val paddedModifier = modifier.padding(VideoTheme.dimens.spacingXXs)
     when (callParticipants.size) {
@@ -102,7 +109,7 @@ internal fun BoxScope.LandscapeVideoRenderer(
                 call,
                 participant,
                 style.copy(
-                    isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                    isFocused = isDomSpeakerSpeaking && dominantSpeaker?.sessionId == participant.sessionId,
                 ),
             )
         }
@@ -118,7 +125,7 @@ internal fun BoxScope.LandscapeVideoRenderer(
                         call,
                         participant,
                         style.copy(
-                            isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                            isFocused = isDomSpeakerSpeaking && dominantSpeaker?.sessionId == participant.sessionId,
                         ),
                     )
                 }
@@ -176,7 +183,7 @@ internal fun BoxScope.LandscapeVideoRenderer(
                                 call,
                                 participant,
                                 style.copy(
-                                    isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                                    isFocused = isDomSpeakerSpeaking && dominantSpeaker?.sessionId == participant.sessionId,
                                 ),
                             )
                         }
@@ -218,6 +225,11 @@ private fun ParticipantRow(
     dominantSpeaker: ParticipantState?,
     expectedRowSize: Int = participants.size,
 ) {
+    val isDomSpeakerSpeaking by dominantSpeaker
+        ?.speaking
+        ?.collectAsStateWithLifecycle(initialValue = false)
+        ?: remember { mutableStateOf(false) }
+
     Row(modifier) {
         repeat(participants.size) {
             val participant = participants[it]
@@ -226,7 +238,7 @@ private fun ParticipantRow(
                 call,
                 participant,
                 style.copy(
-                    isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                    isFocused = isDomSpeakerSpeaking && dominantSpeaker?.sessionId == participant.sessionId,
                 ),
             )
         }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LazyColumnVideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LazyColumnVideoRenderer.kt
@@ -23,10 +23,14 @@ import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.call.renderer.ParticipantVideo
 import io.getstream.video.android.compose.ui.components.call.renderer.ScreenSharingVideoRendererStyle
@@ -129,12 +133,17 @@ private fun ListVideoRenderer(
         )
     },
 ) {
+    val isDomSpeakerSpeaking by dominantSpeaker
+        ?.speaking
+        ?.collectAsStateWithLifecycle(initialValue = false)
+        ?: remember { mutableStateOf(false) }
+
     videoRenderer.invoke(
         modifier,
         call,
         participant,
         style.copy(
-            isFocused = participant.sessionId == dominantSpeaker?.sessionId,
+            isFocused = isDomSpeakerSpeaking && participant.sessionId == dominantSpeaker?.sessionId,
         ),
     )
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LazyRowVideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/LazyRowVideoRenderer.kt
@@ -23,10 +23,14 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.call.renderer.ParticipantVideo
 import io.getstream.video.android.compose.ui.components.call.renderer.ScreenSharingVideoRendererStyle
@@ -126,12 +130,17 @@ private fun ListVideoRenderer(
         )
     },
 ) {
+    val isDomSpeakerSpeaking by dominantSpeaker
+        ?.speaking
+        ?.collectAsStateWithLifecycle(initialValue = false)
+        ?: remember { mutableStateOf(false) }
+
     videoRenderer.invoke(
         modifier,
         call,
         participant,
         style.copy(
-            isFocused = participant.sessionId == dominantSpeaker?.sessionId,
+            isFocused = isDomSpeakerSpeaking && participant.sessionId == dominantSpeaker?.sessionId,
         ),
     )
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitScreenSharingVideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitScreenSharingVideoRenderer.kt
@@ -32,6 +32,8 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -95,6 +97,11 @@ internal fun PortraitScreenSharingVideoRenderer(
     val sharingParticipant = session.participant
     val me by call.state.me.collectAsStateWithLifecycle()
 
+    val isDomSpeakerSpeaking by dominantSpeaker
+        ?.speaking
+        ?.collectAsStateWithLifecycle(initialValue = false)
+        ?: remember { mutableStateOf(false) }
+
     val paddedModifier = modifier.padding(VideoTheme.dimens.spacingXXs)
     BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
         LazyVerticalGrid(
@@ -125,7 +132,7 @@ internal fun PortraitScreenSharingVideoRenderer(
                         call,
                         participant,
                         style.copy(
-                            isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                            isFocused = isDomSpeakerSpeaking && dominantSpeaker?.sessionId == participant.sessionId,
                         ),
                     )
                 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
@@ -30,6 +30,8 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
@@ -93,6 +95,11 @@ internal fun BoxScope.PortraitVideoRenderer(
         return
     }
 
+    val isDomSpeakerSpeaking by dominantSpeaker
+        ?.speaking
+        ?.collectAsStateWithLifecycle(initialValue = false)
+        ?: remember { mutableStateOf(false) }
+
     val paddedModifier = modifier.padding(VideoTheme.dimens.spacingXXs)
     when (callParticipants.size) {
         1, 2 -> {
@@ -106,7 +113,7 @@ internal fun BoxScope.PortraitVideoRenderer(
                 call,
                 participant,
                 style.copy(
-                    isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                    isFocused = isDomSpeakerSpeaking && (dominantSpeaker?.sessionId == participant.sessionId),
                 ),
             )
         }
@@ -177,7 +184,7 @@ internal fun BoxScope.PortraitVideoRenderer(
                                 call,
                                 participant,
                                 style.copy(
-                                    isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                                    isFocused = isDomSpeakerSpeaking && (dominantSpeaker?.sessionId == participant.sessionId),
                                 ),
                             )
                         }
@@ -228,6 +235,11 @@ private fun ParticipantColumn(
     dominantSpeaker: ParticipantState?,
     expectedColumnSize: Int = remoteParticipants.size,
 ) {
+    val isDomSpeakerSpeaking by dominantSpeaker
+        ?.speaking
+        ?.collectAsStateWithLifecycle(initialValue = false)
+        ?: remember { mutableStateOf(false) }
+
     Column(modifier) {
         repeat(remoteParticipants.size) {
             val participant = remoteParticipants[it]
@@ -236,7 +248,7 @@ private fun ParticipantColumn(
                 call,
                 participant,
                 style.copy(
-                    isFocused = dominantSpeaker?.sessionId == participant.sessionId,
+                    isFocused = isDomSpeakerSpeaking && (dominantSpeaker?.sessionId == participant.sessionId),
                 ),
             )
         }


### PR DESCRIPTION
### 🎯 Goal

Highlight participant only if dominant speaker is actively speaking

_Describe why we are making this change_

Previously, the dominant speaker was always highlighted during a call, regardless of whether they were actively speaking or muted. This created confusion for users, as it visually suggested that the participant was speaking when they were not.

This update ensures that a participant is only highlighted if they are both the dominant speaker and actively speaking, resulting in a more accurate and intuitive call experience.

### 🛠 Implementation details

We changed the logic from
`isFocused = dominantSpeaker?.sessionId == participant.sessionId`
to
`isFocused = isDomSpeakerSpeaking && dominantSpeaker?.sessionId == participant.sessionId`

### 🎨 UI Changes

### Before

Even after the mic was muted, the last dominant speaker was still highlighted

![image](https://github.com/user-attachments/assets/af7f1d2b-afa2-4c9c-aeb2-2102a47690b2)

### After
https://github.com/user-attachments/assets/b6fab0fb-20df-45d8-b760-58211618b3b2