### PR TITLE
[AND-512] Retry camera resolution selection

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -558,7 +558,12 @@ public class RtcSession internal constructor(
                 )
 
                 if (it == DeviceStatus.Enabled) {
-                    logger.d { "Camera resolution: ${call.mediaManager.camera.resolution.value}" }
+                    val resolution = call.mediaManager.camera.resolution.value
+                    if (resolution == null) {
+                        logger.d { "Camera resolution is null. This will result in an empty video track." }
+                    } else {
+                        logger.d { "Camera resolution: $resolution" }
+                    }
                     if (canUserSendVideo) {
                         setMuteState(isEnabled = true, TrackType.TRACK_TYPE_VIDEO)
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -551,11 +551,6 @@ public class RtcSession internal constructor(
     private fun listenToMediaChanges() {
         logger.d { "[trackPublishing] listenToMediaChanges" }
         coroutineScope.launch {
-            // We don't want to publish video track if there is no camera resolution
-            if (call.camera.resolution.value == null) {
-                return@launch
-            }
-
             // update the tracks when the camera or microphone status changes
             call.mediaManager.camera.status.collectLatest {
                 val canUserSendVideo = call.state.ownCapabilities.value.contains(
@@ -563,6 +558,7 @@ public class RtcSession internal constructor(
                 )
 
                 if (it == DeviceStatus.Enabled) {
+                    logger.d { "Camera resolution: ${call.mediaManager.camera.resolution.value}" }
                     if (canUserSendVideo) {
                         setMuteState(isEnabled = true, TrackType.TRACK_TYPE_VIDEO)
 
@@ -578,6 +574,8 @@ public class RtcSession internal constructor(
                                 video = track as org.webrtc.VideoTrack,
                             ),
                         )
+                    } else {
+                        logger.d { "[listenToMediaChanges#enableCamera] No capability to send video." }
                     }
                 } else {
                     setMuteState(isEnabled = false, TrackType.TRACK_TYPE_VIDEO)


### PR DESCRIPTION
### 🎯 Goal

Retry camera resolution selection if failed for the first

_Describe why we are making this change_

### 🛠 Implementation details

If the camera's supported formats are unavailable during setup,
the app now retries resolution selection with a backoff strategy.
This ensures the video track can eventually start even after an
initial failure in getting camera resolution.

Uses mediaManager.scope to ensure lifecycle-aware retries.

### 🎨 UI Changes


### Before

| Lobby | Home |
|-------|------|
| <img src="https://github.com/user-attachments/assets/dfed8392-3159-40a5-84a1-4ccb1d9d5f2d" width="300"/> | <img src="https://github.com/user-attachments/assets/7fe417de-9c8d-4d6e-bbe1-0bdbb444cec6" width="300"/> |


### After
## Home
https://github.com/user-attachments/assets/1b7c7158-c4bb-40ae-aad8-b34937dc3bc9

