### PR TITLE
Add timestamp to all the snapshot versions

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
@@ -9,6 +9,7 @@ object Configuration {
     const val patchVersion = 0
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val versionCode = 56
+    const val snapshoBasetVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"
     const val streamVideoCallGooglePlayVersion = "1.6.0"

--- a/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
@@ -9,7 +9,7 @@ object Configuration {
     const val patchVersion = 0
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val versionCode = 56
-    const val snapshoBasetVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}"
+    const val snapshoBasedVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"
     const val streamVideoCallGooglePlayVersion = "1.6.0"

--- a/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
@@ -9,7 +9,7 @@ object Configuration {
     const val patchVersion = 0
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val versionCode = 56
-    const val snapshoBasedVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}"
+    const val snapshotBasedVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"
     const val streamVideoCallGooglePlayVersion = "1.6.0"

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -32,7 +32,7 @@ def timestamp = new SimpleDateFormat('yyyyMMddHHmm').with {
     format(new Date())
 }
 if (snapshot) {
-    ext['rootVersionName'] = "${Configuration.snapshoBasetVersionName}-" +
+    ext['rootVersionName'] = "${Configuration.snapshoBasedVersionName}-" +
             "${timestamp}-SNAPSHOT"
 } else {
     ext['rootVersionName'] = Configuration.versionName

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -1,4 +1,5 @@
 import io.getstream.video.android.Configuration
+import java.text.SimpleDateFormat
 
 // Create variables with empty default values
 ext["ossrhUsername"] = ''
@@ -26,6 +27,16 @@ if (secretPropsFile.exists()) {
   ext["snapshot"] = System.getenv('SNAPSHOT')
 }
 
+def timestamp = new SimpleDateFormat('yyyyMMddHHmm').with {
+    timeZone = TimeZone.getTimeZone('UTC')               // keep CI & local builds identical
+    format(new Date())
+}
+if (snapshot) {
+    ext['rootVersionName'] = "${Configuration.snapshoBasetVersionName}-" +
+            "${timestamp}-SNAPSHOT"
+} else {
+    ext['rootVersionName'] = Configuration.versionName
+}
 if (snapshot) {
   ext["rootVersionName"] = Configuration.snapshotVersionName
 } else {

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -32,7 +32,7 @@ def timestamp = new SimpleDateFormat('yyyyMMddHHmm').with {
     format(new Date())
 }
 if (snapshot) {
-    ext['rootVersionName'] = "${Configuration.snapshoBasedVersionName}-" +
+    ext['rootVersionName'] = "${Configuration.snapshotBasedVersionName}-" +
             "${timestamp}-SNAPSHOT"
 } else {
     ext['rootVersionName'] = Configuration.versionName


### PR DESCRIPTION
### 🎯 Goal

Introduce timestamp to the snapshot versions in order to not override them.