### PR TITLE
[AND-513] Stop retrying resolution selection once it becomes available

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -870,6 +870,9 @@ class CameraManager(
         mediaManager.scope.launch {
             repeat(retries) { attempt ->
                 delay((1000L * (attempt + 1)).coerceAtLeast(3000L))
+                if (_resolution.value != null) {
+                    return@launch
+                }
                 val selectedDevice = selectedDevice.value
                 if (selectedDevice != null) {
                     val desired = selectDesiredResolution(


### PR DESCRIPTION
### 🎯 Goal

Stop retrying resolution selection once it becomes available

### 🛠 Implementation details

Used

```kotlin
 if (_resolution.value != null) { return@launch }
```