### PR TITLE
Fix nested MicrophoneManager.setup calls 

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -520,7 +520,7 @@ class MicrophoneManager(
 
                         pendingSetupCallbacks.forEach { it.invoke() }
                         pendingSetupCallbacks.clear()
-                    }
+                    },
                 )
                 audioHandler.start()
             } else {


### PR DESCRIPTION
### 🎯 Goal

This PR resolves an issue where nested calls to `MicrophoneManager.setup` or `enforceSetup` would not execute their callbacks if the `audioHandler` lateinit var was already initialized but `setupCompleted` was still `false`. In this scenario nested setup calls would be ignored. 

This causes, for example, an issue when trying to apply the dashboard mic on/off settings in the incoming call screen (by overriding `IncomingCallContent`), because `setEnabled` and `enable` are called, which means nested `enforceSetup` calls.

The fix ensures that pending callbacks are properly handled and executed in this edge case, making nested setup/enforceSetup calls reliable regardless of the internal initialization state.

### 🛠 Implementation details

The issue by maintaining a `pendingSetupCallbacks` list and invoking all callbacks once the async setup completes, regardless of the internal state. This guarantees that nested setup callbacks are not lost and always run as expected.

> [!NOTE] 
> Another approach that I tried was to use `suspendCoroutine` to wait for the device callback from AudioSwitch to execute. In order to not make the setup method `suspend`, I'd have to use `runBlocking`, but this would cause a deadlock: runBlocking blocks the main thread, but AudioSwitchHandler posts its initialization work to the same main thread using Handler.post. Since the main thread is blocked, the posted work never runs, so the coroutine inside runBlocking never resumes.

### 🎨 UI Changes

Dashboard settings: camera `off` by default, microphone `on` by default

| Before: mic is off, despite dashboard settings | After: mic is on as per dashboard settings |
| --- | --- |
| ![Screen_recording_20250506_174227](https://github.com/user-attachments/assets/aacabd65-1856-4675-97b6-33e4976ddca0) | ![Screen_recording_20250506_172853](https://github.com/user-attachments/assets/8cc06c89-ee5b-4b90-9a87-931ce66b3559) |