### PR TITLE
[AND-518] Support configurable notification UI with sound per callType and call state

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
@@ -82,6 +82,7 @@ class ClientState(private val client: StreamVideo) {
     public val activeCall: StateFlow<Call?> = _activeCall
 
     public val callConfigRegistry = (client as StreamVideoClient).callServiceConfigRegistry
+    public val notificationConfigRegistry = (client as StreamVideoClient).notificationConfigRegistry
 
     /**
      * Returns true if there is an active or ringing call

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -28,6 +28,7 @@ import io.getstream.video.android.core.internal.InternalStreamVideoApi
 import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
 import io.getstream.video.android.core.logging.LoggingLevel
 import io.getstream.video.android.core.notifications.NotificationConfig
+import io.getstream.video.android.core.notifications.NotificationConfigRegistry
 import io.getstream.video.android.core.notifications.internal.StreamNotificationManager
 import io.getstream.video.android.core.notifications.internal.service.CallServiceConfig
 import io.getstream.video.android.core.notifications.internal.service.CallServiceConfigRegistry
@@ -136,6 +137,8 @@ public class StreamVideoBuilder @JvmOverloads constructor(
     private val audioProcessing: ManagedAudioProcessingFactory? = null,
     private val leaveAfterDisconnectSeconds: Long = 30,
     private val callUpdatesAfterLeave: Boolean = false,
+    private var notificationConfigRegistry: NotificationConfigRegistry =
+        NotificationConfigRegistry(),
 ) {
     private val context: Context = context.applicationContext
     private val scope = UserScope(ClientScope())
@@ -260,6 +263,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             audioProcessing = audioProcessing,
             leaveAfterDisconnectSeconds = leaveAfterDisconnectSeconds,
             enableCallUpdatesAfterLeave = callUpdatesAfterLeave,
+            notificationConfigRegistry = notificationConfigRegistry,
         )
 
         if (user.type == UserType.Guest) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -92,6 +92,7 @@ import io.getstream.video.android.core.model.RejectReason
 import io.getstream.video.android.core.model.SortField
 import io.getstream.video.android.core.model.UpdateUserPermissionsData
 import io.getstream.video.android.core.model.toRequest
+import io.getstream.video.android.core.notifications.NotificationConfigRegistry
 import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.core.notifications.internal.StreamNotificationManager
 import io.getstream.video.android.core.notifications.internal.service.ANY_MARKER
@@ -165,6 +166,7 @@ internal class StreamVideoClient internal constructor(
     internal val leaveAfterDisconnectSeconds: Long = 30,
     internal val appVersion: String? = null,
     internal val enableCallUpdatesAfterLeave: Boolean = false,
+    internal val notificationConfigRegistry: NotificationConfigRegistry,
 ) : StreamVideo, NotificationHandler by streamNotificationManager {
 
     private var locationJob: Deferred<Result<String>>? = null

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/CallNotificationConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/CallNotificationConfig.kt
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications
+
+import android.content.Context
+import io.getstream.video.android.core.call.CallType
+import io.getstream.video.android.core.sounds.MutedRingingConfig
+import io.getstream.video.android.core.sounds.RingingConfig
+import io.getstream.video.android.core.sounds.defaultMutedRingingConfig
+import io.getstream.video.android.core.sounds.defaultResourcesRingingConfig
+
+enum class CallNotificationState {
+    INCOMING,
+    OUTGOING,
+    ONGOING,
+    MISSED,
+    DECLINED,
+    ENDED,
+}
+
+data class CallNotificationConfig(
+    val states: Map<CallNotificationState, NotificationStateConfig> = emptyMap(),
+)
+
+data class NotificationStateConfig(
+    val contentText: String? = null,
+    val ringingConfigBuilder: ((Context) -> RingingConfig)? = null,
+    val mutedRingingConfig: MutedRingingConfig? = null,
+    val actionButtons: NotificationActionButtons? = null,
+) {
+    fun getRingingConfig(context: Context): RingingConfig? = ringingConfigBuilder?.invoke(context)
+}
+
+data class NotificationActionButtons(
+    val primary: String? = null,
+    val secondary: String? = null,
+    val extra: String? = null,
+)
+
+object DefaultCallNotificationConfigs {
+
+    val audioCall: CallNotificationConfig = CallNotificationConfig(
+        states = mapOf(
+            CallNotificationState.INCOMING to NotificationStateConfig(
+                contentText = "Incoming Audio Call",
+                ringingConfigBuilder = { context ->
+                    defaultResourcesRingingConfig(context)
+                },
+                mutedRingingConfig = defaultMutedRingingConfig(),
+                actionButtons = NotificationActionButtons(
+                    primary = "Accept",
+                    secondary = "Decline",
+                ),
+            ),
+            CallNotificationState.OUTGOING to NotificationStateConfig(
+                contentText = "Calling...",
+                ringingConfigBuilder = { context ->
+                    defaultResourcesRingingConfig(context)
+                },
+                actionButtons = NotificationActionButtons(
+                    secondary = "Cancel",
+                ),
+            ),
+            CallNotificationState.ONGOING to NotificationStateConfig(
+                contentText = "On Audio Call",
+                actionButtons = NotificationActionButtons(
+                    primary = "Mute",
+                    secondary = "End",
+                ),
+            ),
+        ),
+    )
+
+    val livestream: CallNotificationConfig = CallNotificationConfig(
+        states = mapOf(
+            CallNotificationState.INCOMING to NotificationStateConfig(
+                contentText = "Live Event Starting",
+                actionButtons = NotificationActionButtons(
+                    primary = "Join",
+                    secondary = "Dismiss",
+                ),
+            ),
+            CallNotificationState.ONGOING to NotificationStateConfig(
+                contentText = "Watching Livestream",
+            ),
+        ),
+    )
+
+    val default: CallNotificationConfig = CallNotificationConfig(
+        states = mapOf(
+            CallNotificationState.INCOMING to NotificationStateConfig(
+                contentText = "Incoming Video Call",
+                ringingConfigBuilder = { context ->
+                    defaultResourcesRingingConfig(context)
+                },
+                actionButtons = NotificationActionButtons(
+                    primary = "Answer",
+                    secondary = "Dismiss",
+                ),
+            ),
+        ),
+    )
+
+    val all: Map<String, CallNotificationConfig> = mapOf(
+        CallType.AudioCall.name to audioCall,
+        CallType.Livestream.name to livestream,
+        CallType.Default.name to default,
+        CallType.AnyMarker.name to default,
+    )
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationConfigRegistry.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationConfigRegistry.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications
+
+import io.getstream.video.android.core.call.CallType
+
+class NotificationConfigRegistry {
+
+    private val configs: MutableMap<String, CallNotificationConfig> =
+        HashMap(DefaultCallNotificationConfigs.all)
+
+    fun register(callType: String, config: CallNotificationConfig) {
+        configs[callType] = config
+    }
+
+    fun register(callType: String, configBuilder: () -> CallNotificationConfig) {
+        configs[callType] = configBuilder()
+    }
+
+    fun registerAll(map: Map<String, CallNotificationConfig>) {
+        map.forEach { (type, config) ->
+            configs[type] = config
+        }
+    }
+
+    fun get(callType: String): CallNotificationConfig {
+        return configs[callType]
+            ?: configs[CallType.AnyMarker.name]
+            ?: CallNotificationConfig() // fully empty fallback
+    }
+
+    fun update(callType: String, updater: CallNotificationConfig.() -> CallNotificationConfig) {
+        val current = configs[callType] ?: CallNotificationConfig()
+        configs[callType] = current.updater()
+    }
+
+    fun createConfigRegistry(block: NotificationConfigRegistry.() -> Unit) {
+        apply(block)
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NotificationsMigrationHelper.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NotificationsMigrationHelper.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications.internal
+
+import android.app.PendingIntent
+import io.getstream.video.android.model.StreamCallId
+
+/**
+ * The sole purpose of this class is to assist in making changes in a non-breaking way until we make
+ * next major release in later 2025
+ */
+internal object NotificationsMigrationHelper {
+
+    val incomingCallMap = object : LinkedHashMap<PendingIntent, StreamCallId>(10, 0.75f, false) {
+        override fun removeEldestEntry(
+            eldest: MutableMap.MutableEntry<PendingIntent, StreamCallId>,
+        ): Boolean {
+            return size > 10
+        }
+    }
+}


### PR DESCRIPTION
## 🎯 Goal
The goal of this PR is to provide a flexible and extensible way for clients to customize call notifications based on both callType (e.g., audio_call, livestream, or custom types) and call state (INCOMING, OUTGOING, ONGOING, etc.).

This enables clients to:
- Customize titles, sounds, and buttons for different call experiences
- Support unique branding or workflows per call type
- Integrate with internal notification policies or user flows

## 🧠 Core Concept
We introduce a new model: CallNotificationConfig, which maps each CallNotificationState (e.g., INCOMING, ONGOING) to a NotificationStateConfig. Each state's config contains:

- `title`: The display title for the notification
- `ringingConfigBuilder`: A lazy function to resolve sound URIs with Context
- `mutedRingingConfig`: Behavior when device is muted
- `actionButtons`: Primary, secondary, and optional extra button labels

Only `INCOMING` and `OUTGOING` states are expected to play sounds. Other states like ONGOING omit sound-related properties.

## 🛠 API Design
We introduce a central `NotificationConfigRegistry` that handles registration and retrieval of configs:

SDK provides default configs for `audio_call`, `livestream`, and `default`.

Clients can override configs via:
```kotlin
register(CallType, config: CallNotificationConfig)

register(CallType, configBuilder: () -> CallNotificationConfig)

registerAll(map: Map<CallType, CallNotificationConfig>)
```
At runtime, the SDK fetches the appropriate configuration using `registry.get(callType)` and applies the relevant state-specific values.

## 👨‍💻 Client Usage

### Register a custom config
```kotlin
val registry = NotificationConfigRegistry().apply {
    register(CallType.AudioCall, customAudioCallConfig)

    register(CallType.CustomCallType("team_huddle")) {
        CallNotificationConfig(
            states = mapOf(
                CallNotificationState.INCOMING to NotificationStateConfig(
                    title = "Join the Huddle",
                    ringingConfigBuilder = { context -> defaultResourcesRingingConfig(context) },
                    actionButtons = NotificationActionButtons(
                        primary = "Join",
                        secondary = "Dismiss"
                    )
                )
            )
        )
    }
}
```


## 🛠 Implementation details


* Introduced a new `CallNotificationConfig` data class to hold state-wise configurations for a given `CallType`. Each state (`INCOMING`, `OUTGOING`, `ONGOING`, etc.) maps to a `NotificationStateConfig`.

* `NotificationStateConfig` includes:

  * `title`: the display text for the notification
  * `ringingConfigBuilder`: a lazily invoked lambda that uses `Context` to return a `RingingConfig`, avoiding the need to pass `Context` at configuration time
  * `mutedRingingConfig`: optional control over playback when the device is muted
  * `actionButtons`: labels for primary, secondary, and extra actions

* Created a `NotificationConfigRegistry` class that:

  * Stores all configs in a single `Map<String, CallNotificationConfig>`
  * Initializes with SDK defaults for `audio_call`, `livestream`, and `default`
  * Supports client overrides through multiple `register(...)` methods
  * Provides a safe `get(callType)` lookup method that falls back to the default (`ANY_MARKER`) if needed

* Integrated this registry into the SDK (via `StreamVideoBuilder`) so that:

  * Clients can override defaults by passing a custom registry or config map
  * Runtime logic can easily resolve notification details based on both `callType` and `call state`

* Avoided sealed classes for `NotificationStateConfig` to keep map-based lookups simple and type-safe without casting. Nullable fields are used with clear state boundaries (e.g., only `INCOMING`/`OUTGOING` should define ringing config).

* Default configurations are defined in `DefaultCallNotificationConfigs` and are designed to be context-free at definition time using `ringingConfigBuilder`.

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |