### PR TITLE
[AND-538] Revert code that affects ringtone volume

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -471,22 +471,22 @@ class MicrophoneManager(
 
     // Internal logic
     internal fun setup(preferSpeaker: Boolean = false, onAudioDevicesUpdate: (() -> Unit)? = null) {
-        synchronized(this) {
-            var capturedOnAudioDevicesUpdate = onAudioDevicesUpdate
+        var capturedOnAudioDevicesUpdate = onAudioDevicesUpdate
 
-            if (setupCompleted) {
-                capturedOnAudioDevicesUpdate?.invoke()
-                capturedOnAudioDevicesUpdate = null
+        if (setupCompleted) {
+            capturedOnAudioDevicesUpdate?.invoke()
+            capturedOnAudioDevicesUpdate = null
 
-                return
-            }
+            return
+        }
 
-            audioManager = mediaManager.context.getSystemService()
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                audioManager?.allowedCapturePolicy = AudioAttributes.ALLOW_CAPTURE_BY_ALL
-            }
+        audioManager = mediaManager.context.getSystemService()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            audioManager?.allowedCapturePolicy = AudioAttributes.ALLOW_CAPTURE_BY_ALL
+        }
 
-            if (canHandleDeviceSwitch() && !::audioHandler.isInitialized) {
+        if (canHandleDeviceSwitch()) {
+            if (!::audioHandler.isInitialized) { // This check is atomic
                 audioHandler = AudioSwitchHandler(
                     context = mediaManager.context,
                     preferredDeviceList = listOf(
@@ -509,18 +509,17 @@ class MicrophoneManager(
                         _devices.value = devices.map { it.fromAudio() }
                         _selectedDevice.value = selected?.fromAudio()
 
-                        setupCompleted = true
-
                         capturedOnAudioDevicesUpdate?.invoke()
                         capturedOnAudioDevicesUpdate = null
+                        setupCompleted = true
                     },
                 )
 
                 logger.d { "[setup] Calling start on instance $audioHandler" }
                 audioHandler.start()
-            } else {
-                logger.d { "[MediaManager#setup] Usage is MEDIA or audioHandle is already initialized" }
             }
+        } else {
+            logger.d { "[MediaManager#setup] usage is MEDIA, cannot handle device switch" }
         }
     }
 

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -1682,12 +1682,12 @@ public final class io/getstream/video/android/compose/ui/components/call/ringing
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallContentKt {
-	public static final fun IncomingCallContent (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZLjava/util/List;Ljava/lang/Boolean;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
+	public static final fun IncomingCallContent (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZLjava/util/List;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
 	public static final fun IncomingCallContent (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;ZZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function5;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallControlsKt {
-	public static final fun IncomingCallControls (Landroidx/compose/ui/Modifier;ZLjava/lang/Boolean;ZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun IncomingCallControls (Landroidx/compose/ui/Modifier;ZZLkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallDetailsKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallContent.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallContent.kt
@@ -82,12 +82,6 @@ public fun IncomingCallContent(
 ) {
     val members: List<MemberState> by call.state.members.collectAsStateWithLifecycle()
     val remoteMembers = members.filterNot { it.user.isLocalUser() }
-
-    val isMicrophoneEnabled by if (LocalInspectionMode.current) {
-        remember { mutableStateOf(true) }
-    } else {
-        call.microphone.isEnabled.collectAsStateWithLifecycle()
-    }
     val isCameraEnabled by if (LocalInspectionMode.current) {
         remember { mutableStateOf(true) }
     } else {
@@ -98,7 +92,6 @@ public fun IncomingCallContent(
         call = call,
         isVideoType = isVideoType,
         participants = remoteMembers,
-        isMicrophoneEnabled = isMicrophoneEnabled,
         isCameraEnabled = isCameraEnabled,
         isShowingHeader = isShowingHeader,
         modifier = modifier,
@@ -131,7 +124,6 @@ public fun IncomingCallContent(
     call: Call,
     isVideoType: Boolean = true,
     participants: List<MemberState>,
-    isMicrophoneEnabled: Boolean? = null,
     isCameraEnabled: Boolean,
     isShowingHeader: Boolean = true,
     backgroundContent: (@Composable BoxScope.() -> Unit)? = null,
@@ -174,7 +166,6 @@ public fun IncomingCallContent(
                 .align(Alignment.BottomCenter)
                 .padding(bottom = VideoTheme.dimens.genericXxl),
             isVideoCall = isVideoType,
-            isMicrophoneEnabled = isMicrophoneEnabled,
             isCameraEnabled = isCameraEnabled,
             onCallAction = onCallAction,
         )

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallControls.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/ringing/incomingcall/IncomingCallControls.kt
@@ -32,7 +32,6 @@ import io.getstream.video.android.compose.ui.components.base.styling.fillCircle
 import io.getstream.video.android.compose.ui.components.call.controls.actions.AcceptCallAction
 import io.getstream.video.android.compose.ui.components.call.controls.actions.DeclineCallAction
 import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleCameraAction
-import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleMicrophoneAction
 import io.getstream.video.android.core.call.state.CallAction
 
 /**
@@ -47,7 +46,6 @@ import io.getstream.video.android.core.call.state.CallAction
 public fun IncomingCallControls(
     modifier: Modifier = Modifier,
     isVideoCall: Boolean,
-    isMicrophoneEnabled: Boolean? = null,
     isCameraEnabled: Boolean,
     onCallAction: (CallAction) -> Unit,
 ) {
@@ -61,17 +59,6 @@ public fun IncomingCallControls(
             style = VideoTheme.styles.buttonStyles.primaryIconButtonStyle().fillCircle(1.5f),
 
         )
-
-        if (isMicrophoneEnabled != null) {
-            ToggleMicrophoneAction(
-                onStyle = VideoTheme.styles.buttonStyles.tertiaryIconButtonStyle().fillCircle(1.5f),
-                offStyle = VideoTheme.styles.buttonStyles.secondaryIconButtonStyle().fillCircle(
-                    1.5f,
-                ),
-                isMicrophoneEnabled = isMicrophoneEnabled,
-                onCallAction = onCallAction,
-            )
-        }
 
         if (isVideoCall) {
             ToggleCameraAction(
@@ -91,8 +78,7 @@ public fun IncomingCallControls(
     }
 }
 
-@Preview(name = "Small Phone - 320dp", widthDp = 320)
-@Preview(name = "Normal Phone - 411dp", widthDp = 411)
+@Preview
 @Composable
 private fun IncomingCallOptionsPreview() {
     VideoTheme {
@@ -106,13 +92,6 @@ private fun IncomingCallOptionsPreview() {
             IncomingCallControls(
                 isVideoCall = true,
                 isCameraEnabled = false,
-                onCallAction = { },
-            )
-            Spacer(modifier = Modifier.size(16.dp))
-            IncomingCallControls(
-                isVideoCall = true,
-                isMicrophoneEnabled = true,
-                isCameraEnabled = true,
                 onCallAction = { },
             )
         }

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -29,7 +29,6 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun <init> ()V
 	public fun accept (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun accept$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
-	public fun applyDashboardSettings (Lio/getstream/video/android/core/Call;)V
 	public fun call (Lio/getstream/video/android/model/StreamCallId;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun call$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/model/StreamCallId;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public fun cancel (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -40,7 +40,6 @@ import io.getstream.result.flatMap
 import io.getstream.result.onErrorSuspend
 import io.getstream.result.onSuccessSuspend
 import io.getstream.video.android.core.Call
-import io.getstream.video.android.core.DeviceStatus
 import io.getstream.video.android.core.RealtimeConnection
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.call.RtcSession
@@ -190,7 +189,6 @@ public abstract class StreamCallActivity : ComponentActivity() {
             onSuccess = { instanceState, persistentState, call, action ->
                 logger.d { "Calling [onCreate(Call)], because call is initialized $call" }
                 onIntentAction(call, action, onError = onErrorFinish) { successCall ->
-                    applyDashboardSettings(successCall)
                     onCreate(instanceState, persistentState, successCall)
                 }
             },
@@ -216,7 +214,6 @@ public abstract class StreamCallActivity : ComponentActivity() {
             onSuccess = { instanceState, persistedState, call, action ->
                 logger.d { "Calling [onCreate(Call)], because call is initialized $call" }
                 onIntentAction(call, action, onError = onErrorFinish) { successCall ->
-                    applyDashboardSettings(successCall)
                     onCreate(instanceState, persistedState, successCall)
                 }
             },
@@ -792,25 +789,6 @@ public abstract class StreamCallActivity : ComponentActivity() {
             else -> {
                 // No-op
             }
-        }
-    }
-
-    /**
-     * Used to apply dashboard settings to the call.
-     * By default, it enables or disables the microphone and camera based on the settings.
-     *
-     * @param call the call
-     */
-    public open fun applyDashboardSettings(call: Call) {
-        val callSettings = call.state.settings.value
-        val microphoneStatus = call.microphone.status.value
-        val cameraStatus = call.camera.status.value
-
-        if (microphoneStatus == DeviceStatus.NotSelected) {
-            call.microphone.setEnabled(callSettings?.audio?.micDefaultOn == true)
-        }
-        if (cameraStatus == DeviceStatus.NotSelected) {
-            call.camera.setEnabled(callSettings?.video?.cameraDefaultOn == true)
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Revert PRs that fix nested `MicrophoneManager.setup` and `Dashboard settings not applied` issues because of ringtone volume side-effect. This way we're avoiding a regression in `1.6.2`.