### PR TITLE
[AND-544] Improve AudioSwitch activation

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioHandler.kt
@@ -70,7 +70,6 @@ public class AudioSwitchHandler(
                     )
                     audioSwitch = switch
                     switch.start(audioDeviceChangeListener)
-                    switch.activate()
                 }
             }
         }


### PR DESCRIPTION
### 🎯 Goal

Currently, we are calling `activate` when `start`ing AudioSwitch. This causes audio-focus to be acquired and ringtone volume to be lowered. The calls to `start` and `activate` should be separated.

### 🛠 Implementation details

- Removed `activate` from `AudioHandler.start`. This method now only starts AudioSwitch, without activating it.
- `activate` is now called only in `AudioSwitchHandler.selectDevice()`.

### 🧪 Testing

#### Android Team

- Make sure that all code paths end up calling `activate` when joining a call. My testing shows they do because:
  - `activate` is eventually called from `Call.join`, like below:
    - `join` -> `updateMediaManagerFromSettings` -> `setSpeakerPhone` -> `select` -> `selectDevice` -> `activate`
      - `setSpeakerPhone` is called in `updateMediaManagerFromSettings` when `speaker.status.value is DeviceStatus.NotSelected`. If this condition is false, it means `setSpeakerPhone` or `select` were called at some previous point by the integrating app (only these two methods can change the speaker status), which also means that `activate` was called.
  - `[selectDevice]` should be visible in the logs when joining the call - that means `activate` was called
  - ❓ We can add a call to `activate` in `updateMediaManagerFromSettings` just for safety.

#### QA & Android Team

- Toggle microphone in a call - check if sound output still has correct volume
- Select another audio device in a call (`Choose audio device` menu item in demo-app)  - check if device was selected correctly
- Check that earpiece was selected at join for audio call and speakerphone for video call
- Start a group call and toggle microphone in the lobby - state should be reflected in the call
- Toggle microphone and camera in ringing calls on incoming and outgoing screens - their state should be reflected in the call, after joining
- For all these cases, `[selectDevice]` should be visible in the logs when joining the call - that means `activate` was called and the correct device was selected
- Create a ringing call (aka direct call) and toggle the microphone by clicking on the button in the outgoing and incoming call screens - the ringtone volume shouldn't change
- Check the phone's volume after a call is ended (with music or other content)