### PR TITLE
Fix issue: ringtone continues ringing after accept/reject

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -516,7 +516,7 @@ internal open class CallService : Service() {
                     }
 
                     else -> {
-                        // Do nothing
+                        callSoundPlayer?.stopCallSound()
                     }
                 }
             }


### PR DESCRIPTION
### 🎯 Goal

In some cases, the ringtone continues to ring even after accepting or rejecting the call.

### 🛠 Implementation details

- Add `stopCallSound` to the `else` branch in `CallService.observeRingingState`.
- Solution based on issue https://github.com/GetStream/stream-video-android/issues/1347.