### PR TITLE
[AND-545] Return the original query calls response as part of the original

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9117,6 +9117,9 @@ public final class io/getstream/video/android/core/header/VersionPrefixHeader$Ui
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract interface annotation class io/getstream/video/android/core/internal/ExperimentalStreamVideoApi : java/lang/annotation/Annotation {
+}
+
 public abstract interface annotation class io/getstream/video/android/core/internal/InternalStreamVideoApi : java/lang/annotation/Annotation {
 }
 
@@ -9610,15 +9613,17 @@ public final class io/getstream/video/android/core/model/PreferredVideoSubscribe
 }
 
 public final class io/getstream/video/android/core/model/QueriedCalls {
-	public fun <init> (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/util/List;Lio/getstream/android/video/generated/models/QueryCallsResponse;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/util/List;
-	public final fun component2 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/android/video/generated/models/QueryCallsResponse;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/video/android/core/model/QueriedCalls;
-	public static synthetic fun copy$default (Lio/getstream/video/android/core/model/QueriedCalls;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/video/android/core/model/QueriedCalls;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Lio/getstream/android/video/generated/models/QueryCallsResponse;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/video/android/core/model/QueriedCalls;
+	public static synthetic fun copy$default (Lio/getstream/video/android/core/model/QueriedCalls;Ljava/util/List;Lio/getstream/android/video/generated/models/QueryCallsResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/video/android/core/model/QueriedCalls;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCalls ()Ljava/util/List;
 	public final fun getNext ()Ljava/lang/String;
+	public final fun getOriginal ()Lio/getstream/android/video/generated/models/QueryCallsResponse;
 	public final fun getPrev ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/InternalStreamVideoApi.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/InternalStreamVideoApi.kt
@@ -41,5 +41,5 @@ public annotation class InternalStreamVideoApi
 @RequiresOptIn(
     message = "This is an experimental API. It may change in the future or maybe removed.",
     level = RequiresOptIn.Level.WARNING,
-    )
+)
 public annotation class ExperimentalStreamVideoApi

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/InternalStreamVideoApi.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/InternalStreamVideoApi.kt
@@ -29,3 +29,16 @@ package io.getstream.video.android.core.internal
     level = RequiresOptIn.Level.ERROR,
 )
 public annotation class InternalStreamVideoApi
+
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.TYPEALIAS,
+)
+@Retention(AnnotationRetention.BINARY)
+@RequiresOptIn(
+    message = "This is an experimental API. It may change in the future or maybe removed.",
+    level = RequiresOptIn.Level.WARNING,
+)public annotation class ExperimentalStreamVideoApi

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/InternalStreamVideoApi.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/InternalStreamVideoApi.kt
@@ -41,4 +41,5 @@ public annotation class InternalStreamVideoApi
 @RequiresOptIn(
     message = "This is an experimental API. It may change in the future or maybe removed.",
     level = RequiresOptIn.Level.WARNING,
-)public annotation class ExperimentalStreamVideoApi
+    )
+public annotation class ExperimentalStreamVideoApi

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/QueriedCalls.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/QueriedCalls.kt
@@ -18,7 +18,6 @@ package io.getstream.video.android.core.model
 
 import androidx.compose.runtime.Stable
 import io.getstream.android.video.generated.models.QueryCallsResponse
-import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.internal.ExperimentalStreamVideoApi
 
 @Stable

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/QueriedCalls.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/model/QueriedCalls.kt
@@ -17,10 +17,15 @@
 package io.getstream.video.android.core.model
 
 import androidx.compose.runtime.Stable
+import io.getstream.android.video.generated.models.QueryCallsResponse
+import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.internal.ExperimentalStreamVideoApi
 
 @Stable
 public data class QueriedCalls(
     public val calls: List<CallData>,
+    @ExperimentalStreamVideoApi
+    public val original: QueryCallsResponse,
     public val next: String?,
     public val prev: String?,
 )

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/DomainUtils.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/DomainUtils.kt
@@ -120,6 +120,7 @@ internal fun UserResponse.toUser(): User {
 @JvmSynthetic
 internal fun QueryCallsResponse.toQueriedCalls(): QueriedCalls {
     return QueriedCalls(
+        original = this,
         calls = calls.toCallData(),
         next = next,
         prev = prev,


### PR DESCRIPTION
### 🎯 Goal

Allow access to original call response data as an experimental feature.

### 🛠 Implementation details

Propagate the original response as an experimental. This is marked as experimental because the API response may change.