### PR TITLE
[AND-554] Keep the needed calls separately to preserve updates.

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -757,7 +757,6 @@ public class Call(
 
     private fun leave(disconnectionReason: Throwable?) = atomicLeave {
         session?.leaveWithReason(disconnectionReason?.message ?: "user")
-        session?.cleanup()
         leaveTimeoutAfterDisconnect?.cancel()
         network.unsubscribe(listener)
         sfuListener?.cancel()
@@ -772,11 +771,11 @@ public class Call(
 
         sfuSocketReconnectionTime = null
         stopScreenSharing()
-        (client as StreamVideoClient).onCallCleanUp(this)
         camera.disable()
         microphone.disable()
         client.state.removeActiveCall() // Will also stop CallService
         client.state.removeRingingCall()
+        (client as StreamVideoClient).onCallCleanUp(this)
         cleanup()
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -523,7 +523,7 @@ internal class StreamVideoClient internal constructor(
             calls[selectedCid]?.fireEvent(event)
             safeCall {
                 destroyedCalls.forEach {
-                    fireEvent(event)
+                    it.fireEvent(event)
                 }
             }
         }


### PR DESCRIPTION
### 🎯 Goal

When a call is left it is destroyed and removed from the internal state management of the SDK client. To prevent this if a configuration requires it we are going to keep these calls

### 🛠 Implementation details

Add a `destroyedCalls` list that holds the old call objects in case subscriptions are still valid for those objects.