### PR TITLE
[AND-570] Add experimental support for injecting interceptors and WebSocket listeners

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9117,6 +9117,16 @@ public final class io/getstream/video/android/core/header/VersionPrefixHeader$Ui
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/video/android/core/interceptor/StreamOkhttpInterceptorRegistry {
+	public static final field INSTANCE Lio/getstream/video/android/core/interceptor/StreamOkhttpInterceptorRegistry;
+	public final fun register (Lokhttp3/Interceptor;)V
+}
+
+public final class io/getstream/video/android/core/interceptor/StreamWebSocketListenerRegistry {
+	public static final field INSTANCE Lio/getstream/video/android/core/interceptor/StreamWebSocketListenerRegistry;
+	public final fun register (Lokhttp3/WebSocketListener;)V
+}
+
 public abstract interface annotation class io/getstream/video/android/core/internal/ExperimentalStreamVideoApi : java/lang/annotation/Annotation {
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/interceptor/StreamOkhttpInterceptorRegistry.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/interceptor/StreamOkhttpInterceptorRegistry.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.interceptor
+
+import io.getstream.video.android.core.internal.ExperimentalStreamVideoApi
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+
+object StreamOkhttpInterceptorRegistry {
+    private val interceptors = mutableListOf<Interceptor>()
+
+    @ExperimentalStreamVideoApi
+    fun register(interceptor: Interceptor) {
+        interceptors += interceptor
+    }
+
+    internal fun applyTo(builder: OkHttpClient.Builder) {
+        interceptors.forEach { builder.addInterceptor(it) }
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/interceptor/StreamWebSocketListenerRegistry.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/interceptor/StreamWebSocketListenerRegistry.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.interceptor
+
+import io.getstream.video.android.core.internal.ExperimentalStreamVideoApi
+import okhttp3.Response
+import okhttp3.WebSocket
+import okhttp3.WebSocketListener
+import okio.ByteString
+
+object StreamWebSocketListenerRegistry {
+    private val listeners = mutableListOf<WebSocketListener>()
+
+    @ExperimentalStreamVideoApi
+    fun register(listener: WebSocketListener) {
+        listeners += listener
+    }
+
+    internal fun wrap(baseListener: WebSocketListener): WebSocketListener {
+        return object : WebSocketListener() {
+            override fun onOpen(webSocket: WebSocket, response: Response) {
+                listeners.forEach { it.onOpen(webSocket, response) }
+                baseListener.onOpen(webSocket, response)
+            }
+
+            override fun onMessage(webSocket: WebSocket, text: String) {
+                listeners.forEach { it.onMessage(webSocket, text) }
+                baseListener.onMessage(webSocket, text)
+            }
+
+            override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
+                listeners.forEach { it.onMessage(webSocket, bytes) }
+                baseListener.onMessage(webSocket, bytes)
+            }
+
+            override fun onClosing(webSocket: WebSocket, code: Int, reason: String) {
+                listeners.forEach { it.onClosing(webSocket, code, reason) }
+                baseListener.onClosing(webSocket, code, reason)
+            }
+
+            override fun onClosed(webSocket: WebSocket, code: Int, reason: String) {
+                listeners.forEach { it.onClosed(webSocket, code, reason) }
+                baseListener.onClosed(webSocket, code, reason)
+            }
+
+            override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+                listeners.forEach { it.onFailure(webSocket, t, response) }
+                baseListener.onFailure(webSocket, t, response)
+            }
+        }
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/CoordinatorConnectionModule.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/CoordinatorConnectionModule.kt
@@ -23,6 +23,7 @@ import io.getstream.android.video.generated.apis.ProductvideoApi
 import io.getstream.android.video.generated.infrastructure.Serializer
 import io.getstream.log.streamLog
 import io.getstream.video.android.core.header.HeadersUtil
+import io.getstream.video.android.core.interceptor.StreamOkhttpInterceptorRegistry
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.getstream.video.android.core.logging.LoggingLevel
 import io.getstream.video.android.core.socket.common.token.TokenProvider
@@ -79,7 +80,11 @@ internal class CoordinatorConnectionModule(
         .connectTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
         .writeTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
         .readTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
-        .callTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS).build()
+        .callTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+        .apply {
+            StreamOkhttpInterceptorRegistry.applyTo(this)
+        }
+        .build()
     override val networkStateProvider: NetworkStateProvider by lazy {
         NetworkStateProvider(
             scope,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/common/SocketFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/common/SocketFactory.kt
@@ -19,6 +19,7 @@ package io.getstream.video.android.core.socket.common
 import io.getstream.android.video.generated.models.VideoEvent
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.header.HeadersUtil
+import io.getstream.video.android.core.interceptor.StreamWebSocketListenerRegistry
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.UnsupportedEncodingException
@@ -34,7 +35,10 @@ internal class SocketFactory<V, P : GenericParser<V>, C : ConnectionConf>(
     fun <T : VideoEvent> createSocket(connectionConf: C, tag: String): StreamWebSocket<V, P> {
         val request = buildRequest(connectionConf)
         logger.i { "[createSocket] new web socket: ${request.url}" }
-        return StreamWebSocket(tag, parser) { httpClient.newWebSocket(request, it) }
+        return StreamWebSocket(tag, parser) { baseListener ->
+            val wrappedListener = StreamWebSocketListenerRegistry.wrap(baseListener)
+            httpClient.newWebSocket(request, wrappedListener)
+        }
     }
 
     @Throws(UnsupportedEncodingException::class)


### PR DESCRIPTION
### 🎯 Goal

To introduce **non-invasive extension points** in the video-stream SDK that enable external tools—such as a network monitoring SDK—to observe HTTP and WebSocket traffic.

These hooks are:

* **Optional**: they do nothing unless an external module registers listeners/interceptors.
* **Experimental**: intended for internal or debugging use, not part of the core SDK contract.
* **Safe**: they preserve all existing behavior and are only activated at runtime.

This setup allows us to monitor or log SDK network activity (e.g. for QA or debugging) without modifying core SDK logic or affecting production performance.

### 🛠 Implementation details

- Applied `StreamOkhttpInterceptorRegistry.applyTo(builder)` in the HTTP client builder to allow external interceptors to be added dynamically.
- Wrapped internal WebSocket listener using `StreamWebSocketListenerRegistry.wrap(...)` to broadcast socket events to all registered listeners.
- Both registries are marked with `@ExperimentalMonitoringApi` to signal intended internal/advanced usage only.
These APIs are safe to include and will only be active when the external monitoring SDK is present and explicitly registers listeners or interceptors.

### ✅ How to Use the New Hooks

To start monitoring HTTP and WebSocket traffic from the video-stream SDK, an external SDK (such as a network monitor) can register interceptors and WebSocket listeners as follows:

---

#### 1. **Register an OkHttp Interceptor**

```kotlin
// Register a custom interceptor (e.g., for logging or monitoring)
StreamOkhttpInterceptorRegistry.register(MyCustomInterceptor())
```

This interceptor will be injected into the SDK’s internal OkHttpClient when the SDK is initialized.

---

#### 2. **Register a WebSocket Listener**

```kotlin
// Register a WebSocket listener to observe socket-level events
StreamWebSocketListenerRegistry.register(MyWebSocketListener())
```

All registered listeners will be notified of WebSocket events such as `onOpen`, `onMessage`, `onFailure`, etc., in addition to the SDK's internal logic.

---

#### 3. **Important Note**

These APIs are marked with `@ExperimentalMonitoringApi` and should only be used for:

* Debugging
* QA instrumentation
* Internal tooling

They are **not intended** for general use and may change or be removed in future releases.