### PR TITLE
[AND-581]: Improve the logic to pause and play livestream of Guest user

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -5587,6 +5587,7 @@ public final class io/getstream/video/android/core/CallState {
 	public final fun getLiveDuration ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getLiveDurationInMs ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getLivestream ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun getLivestreamAudio ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getLocalParticipant ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getMe ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getMember (Ljava/lang/String;)Lio/getstream/video/android/core/MemberState;

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/livestream/LivestreamRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/livestream/LivestreamRenderer.kt
@@ -59,6 +59,7 @@ internal fun LivestreamRenderer(
     livestreamFlow: Flow<ParticipantState.Video?> = call.state.livestream,
 ) {
     val livestream by livestreamFlow.collectAsStateWithLifecycle(null)
+    val livestreamAudio by call.state.livestreamAudio.collectAsStateWithLifecycle(null)
     var videoTextureView: VideoTextureViewRenderer? by remember { mutableStateOf(null) }
     var isPaused by rememberSaveable { mutableStateOf(false) }
 
@@ -70,6 +71,7 @@ internal fun LivestreamRenderer(
                 .clickable(enabled = enablePausing) {
                     if (onPausedPlayer != null) {
                         isPaused = !isPaused
+                        livestreamAudio?.track?.audio?.setEnabled(!isPaused)
                         livestream?.track?.video?.setEnabled(!isPaused)
                         onPausedPlayer.invoke(isPaused)
 


### PR DESCRIPTION
### 🎯 Goal

Improve the logic to pause and play livestream of Guest user

### 🛠 Implementation details

Create `livestreamAudioFlow` which is a clone of  `livestreamFlow` but `livestreamAudioFlow` will only influence the audio tracks

### ⚠️ Note

The internal of `livestream` in class `CallState` is slightly changed. It will only video track it. Please review it carefully

### APIs to toggle Pause and Play Livestream has been updated

### Before

```kotlin
livestream?.track?.video?.setEnabled(true)
```

### After
```kotlin
livestreamAudio?.track?.audio?.setEnabled(true)
livestream?.track?.video?.setEnabled(true)
```