### PR TITLE
[AND-588] Prevent unintended recomposition in Livestream Audience tutorial

### DIFF
--- a/tutorials/tutorial-livestream/src/main/kotlin/io/getstream/video/android/tutorial/livestream/LiveGuest.kt
+++ b/tutorials/tutorial-livestream/src/main/kotlin/io/getstream/video/android/tutorial/livestream/LiveGuest.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -44,7 +45,7 @@ fun LiveAudience(
     )
 
     // Step 2 - join a call, which type is `default` and id is `123`.
-    val call = client.call("livestream", callId)
+    val call = remember(callId) { client.call("livestream", callId) }
 
     LaunchedEffect(call) {
         call.microphone.setEnabled(false, fromUser = true)


### PR DESCRIPTION
### 🎯 Goal

Prevent unintended recomposition in Livestream Audience tutorial

### 🛠 Implementation details

Wrapped `client.call(...)` in `remember(callId)` to ensure a stable call reference across recompositions. 
This prevents LaunchedEffect and other recomposition-sensitive logic from running multiple times unnecessarily.