### PR TITLE
Add missing PAT for SDK size updates workflow

### DIFF
--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -18,6 +18,7 @@ jobs:
       modules: "stream-video-android-core stream-video-android-ui-xml stream-video-android-ui-compose"
       metrics-project: "stream-video-android-metrics"
     secrets:
+      GITHUB_PAT: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}
       BUILD_CACHE_AWS_REGION: ${{ secrets.BUILD_CACHE_AWS_REGION }}
       BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}
       BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
A GitHub PAT is required to run the `sdk-size-updates` workflow to push the size updates