### PR TITLE
Improve destroyed calls event processing

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -524,11 +524,7 @@ internal class StreamVideoClient internal constructor(
         // call level subscriptions
         if (selectedCid.isNotEmpty()) {
             calls[selectedCid]?.fireEvent(event)
-            safeCall {
-                destroyedCalls.snapshot().forEach { (_, call) ->
-                    call.fireEvent(event)
-                }
-            }
+            notifyDestroyedCalls(event)
         }
 
         if (selectedCid.isNotEmpty()) {
@@ -552,13 +548,35 @@ internal class StreamVideoClient internal constructor(
                 it.session?.handleEvent(event)
                 it.handleEvent(event)
             }
-            safeCall {
-                destroyedCalls.snapshot().forEach { (_, call) ->
-                    call.let {
-                        // No session here
+            deliverIntentToDestroyedCalls(event)
+        }
+    }
+
+    private fun shouldProcessDestroyedCall(event: VideoEvent, callCid: String): Boolean {
+        return when (event) {
+            is WSCallEvent -> event.getCallCID() == callCid
+            else -> true
+        }
+    }
+
+    private fun deliverIntentToDestroyedCalls(event: VideoEvent) {
+        safeCall {
+            destroyedCalls.snapshot().forEach { (_, call) ->
+                call.let {
+                    if (shouldProcessDestroyedCall(event, call.cid)) {
                         it.state.handleEvent(event)
                         it.handleEvent(event)
                     }
+                }
+            }
+        }
+    }
+
+    private fun notifyDestroyedCalls(event: VideoEvent) {
+        safeCall {
+            destroyedCalls.snapshot().forEach { (_, call) ->
+                if (shouldProcessDestroyedCall(event, call.cid)) {
+                    call.fireEvent(event)
                 }
             }
         }


### PR DESCRIPTION
### 🎯 Goal

[AND-631]

Improve destroyed calls event processing by fixing event fire logic.
**Problem**: Previously, events were being sent to all destroyed call objects regardless of relevance, causing unnecessary processing and potential side effects.

**Solution**: Filter events to only notify destroyed calls when the event's call.cid matches the destroyed call's ID.

### 🛠 Implementation details

**WSCallEvent filtering**: Compare event.getCallCID() with call.cid before processing
**Non-WSCallEvent handling**: Maintain existing behavior (send to all destroyed calls)

### Future Improvements

The current implementation maintains legacy behavior for non-WSCallEvent types. This can be optimized further in future iterations once we validate the impact across all event types.
