### PR TITLE
Deprecate Old Feedback API and Introduce Improved Version

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -1,6 +1,7 @@
 public abstract interface class io/getstream/android/video/generated/apis/ProductvideoApi {
 	public abstract fun acceptCall (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun blockUser (Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/video/generated/models/BlockUserRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun collectUserFeedback (Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/video/generated/models/CollectUserFeedbackRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun collectUserFeedback (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/video/generated/models/CollectUserFeedbackRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createDevice (Lio/getstream/android/video/generated/models/CreateDeviceRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun createGuest (Lio/getstream/android/video/generated/models/CreateGuestRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/android/video/generated/apis/ProductvideoApi.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/android/video/generated/apis/ProductvideoApi.kt
@@ -133,11 +133,29 @@ interface ProductvideoApi {
      * Collect user feedback
      *
      */
+    @Deprecated(
+        "This method is deprecated. Please use the version without the sessionId in the path: collectUserFeedback(type, id, body).",
+        replaceWith = ReplaceWith(
+            expression = "collectUserFeedback(type, id, collectUserFeedbackRequest)",
+        ),
+    )
     @POST("/video/call/{type}/{id}/feedback/{session}")
     suspend fun collectUserFeedback(
         @Path("type") type: kotlin.String,
         @Path("id") id: kotlin.String,
         @Path("session") session: kotlin.String,
+        @Body collectUserFeedbackRequest:
+        io.getstream.android.video.generated.models.CollectUserFeedbackRequest,
+    ): io.getstream.android.video.generated.models.CollectUserFeedbackResponse
+
+    /**
+     * Collect user feedback
+     *
+     */
+    @POST("/video/call/{type}/{id}/feedback")
+    suspend fun collectUserFeedback(
+        @Path("type") type: kotlin.String,
+        @Path("id") id: kotlin.String,
         @Body collectUserFeedbackRequest:
         io.getstream.android.video.generated.models.CollectUserFeedbackRequest,
     ): io.getstream.android.video.generated.models.CollectUserFeedbackResponse

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -1014,7 +1014,6 @@ internal class StreamVideoClient internal constructor(
         coordinatorConnectionModule.api.collectUserFeedback(
             type = callType,
             id = id,
-            session = sessionId,
             collectUserFeedbackRequest = CollectUserFeedbackRequest(
                 rating = rating,
                 sdk = "stream-video-android",


### PR DESCRIPTION
### 🎯 Goal

Deprecate Old Feedback API and Introduce Improved Version

Previously, we were sending a locally generated session ID (UUID) with the feedback request, which caused issues like 404 errors. With this PR, the feedback API no longer requires a session ID to be sent manually. This simplifies the flow and reduces the chances of mismatches or errors.

### 🛠 Implementation details

Changes:

Deprecated the old `collectUserFeedback` API that required a `session ID` in the path.

Introduced a new version of the API: `collectUserFeedback(type, id, body)`, which no longer requires the `session ID`.

Updated all internal usage to rely on the new API.

**Deprecated Endpoint:**

```kotlin
@Deprecated(
    "This method is deprecated. Please use the version without the sessionId in the path: collectUserFeedback(type, id, body).",
    replaceWith = ReplaceWith(
        expression = "collectUserFeedback(type, id, collectUserFeedbackRequest)",
    ),
)
@POST("/video/call/{type}/{id}/feedback/{session}")
suspend fun collectUserFeedback(
    @Path("type") type: String,
    @Path("id") id: String,
    @Path("session") session: String,
    @Body collectUserFeedbackRequest: CollectUserFeedbackRequest,
): CollectUserFeedbackResponse
```

**New Endpoint:**

```kotlin
@POST("/video/call/{type}/{id}/feedback")
suspend fun collectUserFeedback(
    @Path("type") type: String,
    @Path("id") id: String,
    @Body collectUserFeedbackRequest: CollectUserFeedbackRequest,
): CollectUserFeedbackResponse
```
