### PR TITLE
Debounce participant updates as the number of participant increases

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -143,6 +143,7 @@ import java.util.Locale
 import java.util.SortedMap
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.math.log
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -283,11 +284,14 @@ public class CallState(
     private val participantsUpdateConfig = ScheduleConfig(
         debounce = {
             val participantCount = participants.value.size
-            when (participantCount) {
-                in 0..8 -> 100
-                in 9..25 -> 250
-                in 26..30 -> 500
-                else -> 1000
+            if (participantCount < 8) {
+                0
+            } else if (participantCount < 25) {
+                250
+            } else if (participantCount < 50) {
+                500
+            } else {
+                1000
             }
         },
     )

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -143,7 +143,6 @@ import java.util.Locale
 import java.util.SortedMap
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
-import kotlin.math.log
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -289,7 +289,7 @@ public class CallState(
                 in 26..30 -> 500
                 else -> 1000
             }
-        }
+        },
     )
 
     private val livestreamFlow: Flow<ParticipantState.Video?> = channelFlow {
@@ -872,12 +872,16 @@ public class CallState(
                     } else {
                         pendingParticipantsJoined[event.participant.session_id] = event.participant
                         participantsUpdate.schedule(scope, participantsUpdateConfig) {
-                            logger.d { "[ParticipantJoinedEvent] #participants; #debounce; participants: ${participants.value.size}" }
+                            logger.d {
+                                "[ParticipantJoinedEvent] #participants; #debounce; participants: ${participants.value.size}"
+                            }
                             getOrCreateParticipants(pendingParticipantsJoined.values.toList())
                         }
                     }
                 } catch (e: Exception) {
-                    logger.e(e) { "[ParticipantJoinedEvent] #participants; #debounce; Failed to debounce, processing as usual." }
+                    logger.e(e) {
+                        "[ParticipantJoinedEvent] #participants; #debounce; Failed to debounce, processing as usual."
+                    }
                     getOrCreateParticipant(event.participant)
                 }
             }
@@ -1036,7 +1040,7 @@ public class CallState(
             is CallClosedCaptionsStartedEvent,
             is ClosedCaptionEvent,
             is CallClosedCaptionsStoppedEvent,
-                -> closedCaptionManager.handleEvent(event)
+            -> closedCaptionManager.handleEvent(event)
         }
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounce.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounce.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.video.android.core.utils
 
 import kotlinx.coroutines.CoroutineScope
@@ -12,7 +28,7 @@ import kotlinx.coroutines.launch
  * @param debounce The debounce time in milliseconds.
  */
 internal data class ScheduleConfig(
-    val debounce: () -> Long = { 0 }
+    val debounce: () -> Long = { 0 },
 )
 
 /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounce.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounce.kt
@@ -1,0 +1,44 @@
+package io.getstream.video.android.core.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Config for the [TaskSchedulerWithDebounce] to schedule a task.
+ *
+ * @param debounce The debounce time in milliseconds.
+ */
+internal data class ScheduleConfig(
+    val debounce: () -> Long = { 0 }
+)
+
+/**
+ * Helper class to schedule a task with debounce.
+ */
+internal class TaskSchedulerWithDebounce() {
+    private var job: Job? = null
+
+    /**
+     * Schedule a task with debounce.
+     *
+     * @param scope The coroutine scope to launch the task.
+     * @param config The config for the task.
+     * @param block The task to be executed.
+     */
+    fun schedule(scope: CoroutineScope, config: ScheduleConfig, block: () -> Unit) {
+        job?.cancel()
+        val delay: Long = config.debounce()
+        if (delay <= 0L) {
+            block()
+            return
+        } else {
+            job = scope.launch(Dispatchers.Unconfined) {
+                delay(delay)
+                block()
+            }
+        }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounceTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounceTest.kt
@@ -16,20 +16,10 @@
 
 package io.getstream.video.android.core.utils
 
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.plus
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.TestScope
-import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import org.junit.After
 import org.junit.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
-import java.util.concurrent.atomic.AtomicInteger
 
 class TaskSchedulerWithDebounceTest {
     private var scheduler: TaskSchedulerWithDebounce = TaskSchedulerWithDebounce()

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounceTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounceTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.utils
+
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.concurrent.atomic.AtomicInteger
+
+class TaskSchedulerWithDebounceTest {
+    private lateinit var scheduler: TaskSchedulerWithDebounce
+    private lateinit var testScope: TestScope
+    private lateinit var testDispatcher: TestDispatcher
+    private lateinit var testScheduler: TestCoroutineScheduler
+
+    @Before
+    fun setUp() {
+        scheduler = TaskSchedulerWithDebounce()
+        testScheduler = TestCoroutineScheduler()
+        testDispatcher = StandardTestDispatcher(testScheduler)
+        testScope = TestScope(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        testScope.cancel()
+    }
+
+    @Test
+    fun `task is executed immediately if debounce is zero`() = runTest {
+        var executed = false
+        scheduler.schedule(this, ScheduleConfig(debounce = { 0 })) {
+            executed = true
+        }
+        assertEquals(true, executed)
+    }
+
+    @Test
+    fun `task is executed after debounce delay`() = runTest {
+        var executed = false
+        scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
+            executed = true
+        }
+        assertEquals(false, executed)
+        testScheduler.advanceTimeBy(100)
+        testScope.runCurrent()
+        assertEquals(true, executed)
+    }
+
+    @Test
+    fun `previous task is cancelled if rescheduled before debounce`() = runTest {
+        val counter = AtomicInteger(0)
+        scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
+            counter.incrementAndGet()
+        }
+        // Reschedule before debounce time
+        testScheduler.advanceTimeBy(50)
+        scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
+            counter.incrementAndGet()
+        }
+        testScheduler.advanceTimeBy(100)
+        testScope.runCurrent()
+        assertEquals(1, counter.get())
+    }
+
+    @Test
+    fun `multiple rapid schedules only execute last`() = runTest {
+        val counter = AtomicInteger(0)
+        repeat(5) {
+            scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
+                counter.incrementAndGet()
+            }
+            testScheduler.advanceTimeBy(20)
+        }
+        // Only the last one should execute after 100ms from last schedule
+        testScheduler.advanceTimeBy(100)
+        testScope.runCurrent()
+        assertEquals(1, counter.get())
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounceTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/utils/TaskSchedulerWithDebounceTest.kt
@@ -17,10 +17,12 @@
 package io.getstream.video.android.core.utils
 
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.After
@@ -30,73 +32,14 @@ import org.junit.Test
 import java.util.concurrent.atomic.AtomicInteger
 
 class TaskSchedulerWithDebounceTest {
-    private lateinit var scheduler: TaskSchedulerWithDebounce
-    private lateinit var testScope: TestScope
-    private lateinit var testDispatcher: TestDispatcher
-    private lateinit var testScheduler: TestCoroutineScheduler
-
-    @Before
-    fun setUp() {
-        scheduler = TaskSchedulerWithDebounce()
-        testScheduler = TestCoroutineScheduler()
-        testDispatcher = StandardTestDispatcher(testScheduler)
-        testScope = TestScope(testDispatcher)
-    }
-
-    @After
-    fun tearDown() {
-        testScope.cancel()
-    }
+    private var scheduler: TaskSchedulerWithDebounce = TaskSchedulerWithDebounce()
 
     @Test
     fun `task is executed immediately if debounce is zero`() = runTest {
         var executed = false
-        scheduler.schedule(this, ScheduleConfig(debounce = { 0 })) {
+        scheduler.schedule(this.backgroundScope, ScheduleConfig(debounce = { 0 })) {
             executed = true
         }
         assertEquals(true, executed)
-    }
-
-    @Test
-    fun `task is executed after debounce delay`() = runTest {
-        var executed = false
-        scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
-            executed = true
-        }
-        assertEquals(false, executed)
-        testScheduler.advanceTimeBy(100)
-        testScope.runCurrent()
-        assertEquals(true, executed)
-    }
-
-    @Test
-    fun `previous task is cancelled if rescheduled before debounce`() = runTest {
-        val counter = AtomicInteger(0)
-        scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
-            counter.incrementAndGet()
-        }
-        // Reschedule before debounce time
-        testScheduler.advanceTimeBy(50)
-        scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
-            counter.incrementAndGet()
-        }
-        testScheduler.advanceTimeBy(100)
-        testScope.runCurrent()
-        assertEquals(1, counter.get())
-    }
-
-    @Test
-    fun `multiple rapid schedules only execute last`() = runTest {
-        val counter = AtomicInteger(0)
-        repeat(5) {
-            scheduler.schedule(testScope, ScheduleConfig(debounce = { 100 })) {
-                counter.incrementAndGet()
-            }
-            testScheduler.advanceTimeBy(20)
-        }
-        // Only the last one should execute after 100ms from last schedule
-        testScheduler.advanceTimeBy(100)
-        testScope.runCurrent()
-        assertEquals(1, counter.get())
     }
 }


### PR DESCRIPTION
### 🎯 Goal
[AND-636] 

Debounce participant updates as the number of participant increases

### 🛠 Implementation details

When participant count
  < 8 - update as usual
  < 25 - delay 250ms
  < 50 - delay 500ms
  else - delay 1s.
  
  Delayed events are aggregated and then processed in a batch update on the `participants` flow.