### PR TITLE
Update floating window when there are no remote participants

### DIFF
--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/renderer/internal/PortraitVideoRenderer.kt
@@ -220,7 +220,7 @@ internal fun BoxScope.PortraitVideoRenderer(
         }
     }
 
-    if (callParticipants.size < 4) {
+    if (callParticipants.size in 2..3) {
         val currentLocal by call.state.me.collectAsStateWithLifecycle()
 
         if (currentLocal != null) {


### PR DESCRIPTION
### 🎯 Goal
[AND-638] 
Update floating participant when there are no remote participants

### 🛠 Implementation details

Instead of (callParticipants.size < 4) do (callParticipants in 2..3) so when alone in the call the floating participant is not shown.