### PR TITLE
Ensure caller avatar is visible on incoming call UI

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -739,6 +739,19 @@ public class CallState(
             is CallRingEvent -> {
                 getOrCreateMembers(event.members)
                 updateFromResponse(event.call)
+
+                // Fill caller in members if not present
+                val memberMap = _members.value.toSortedMap()
+                if (!memberMap.contains(event.call.createdBy.id)) {
+                    memberMap[event.call.createdBy.id] = MemberState(
+                        user = event.call.createdBy.toUser(),
+                        role = event.call.createdBy.role,
+                        custom = emptyMap(),
+                        createdAt = event.call.createdAt,
+                        updatedAt = event.call.updatedAt,
+                    )
+                    _members.value = memberMap
+                }
             }
 
             is CallUpdatedEvent -> {


### PR DESCRIPTION
### 🎯 Goal

Fix the issue where the caller’s avatar was not visible on the incoming call screen.

### Implementation
The root cause was that the `members` on the incoming call screen did not include the caller's information, leading to the avatar being missing.
This PR ensures that the caller is included in the `memberList` by explicitly adding their details during the `CallRing` event.


### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Provide the patch code here
```

</details>