### PR TITLE
Handle “accept call” action in onNewIntent and update intent reference

### DIFF
--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -62,6 +62,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun onIntentAction (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun onIntentAction$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public fun onLastParticipant (Lio/getstream/video/android/core/Call;)V
+	protected fun onNewIntent (Landroid/content/Intent;)V
 	public fun onPause ()V
 	public fun onPause (Lio/getstream/video/android/core/Call;)V
 	public fun onPictureInPicture (Lio/getstream/video/android/core/Call;)V

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -256,7 +256,9 @@ public abstract class StreamCallActivity : ComponentActivity() {
                     intent,
                     onSuccess = { _, _, call, action ->
                         logger.d { "Calling [onNewIntent(intent)], because call is initialized $call, action=$action" }
-                        onIntentAction(call, action, onError = onErrorFinish) { successCall -> }
+                        onIntentAction(call, action, onError = onErrorFinish) { successCall ->
+                            applyDashboardSettings(successCall)
+                        }
                     },
                     onError = {
                         // We are not calling onErrorFinish here on purpose

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -236,6 +236,40 @@ public abstract class StreamCallActivity : ComponentActivity() {
         )
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        /**
+         * Necessary because the intent is read during the activity's lifecycle methods.
+         */
+        setIntent(intent)
+        when (intent.action) {
+            NotificationHandler.ACTION_ACCEPT_CALL -> {
+                // Exit case
+                // TODO Later
+                // If already in call, then should we do nothing or allow to connect with new call
+                val activeCall = StreamVideo.instance().state.activeCall.value
+                if (activeCall != null) return
+
+                initializeCallOrFail(
+                    null,
+                    null,
+                    intent,
+                    onSuccess = { _, _, call, action ->
+                        logger.d { "Calling [onNewIntent(intent)], because call is initialized $call, action=$action" }
+                        onIntentAction(call, action, onError = onErrorFinish) { successCall -> }
+                    },
+                    onError = {
+                        // We are not calling onErrorFinish here on purpose
+                        // we want to crash if we cannot initialize the call
+                        logger.e(it) { "Failed to initialize call." }
+                        throw it
+                    },
+                )
+            }
+            else -> {}
+        }
+    }
+
     public override fun onResume() {
         super.onResume()
         withCachedCall {


### PR DESCRIPTION
### 🎯 Goal

This PR ensures correct intent handling for call actions by:

1. Calling `setIntent(intent)` inside `onNewIntent()` so that lifecycle methods like `onResume()` always receive the latest intent.
2. Handling the **"accept call"** action directly within `onNewIntent()` to allow faster and more reliable call acceptance when the activity is already running.


### 🛠 Implementation details

_Describe the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| https://github.com/user-attachments/assets/6ebf8282-9d78-4229-b3b2-c665a604907b | https://github.com/user-attachments/assets/33907a3b-5f80-41b0-9e5e-a2ebda9af76c |