### PR TITLE
Improve Call Screen Behavior on Decline

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -48,6 +48,11 @@ import kotlinx.coroutines.runBlocking
 class CallActivity : ComposeStreamCallActivity() {
 
     override val uiDelegate: StreamActivityUiDelegate<StreamCallActivity> = StreamDemoUiDelegate()
+
+    @Deprecated(
+        "Override loadConfigFromIntent instead ",
+        level = DeprecationLevel.WARNING,
+    )
     override val configuration: StreamCallActivityConfiguration =
         StreamCallActivityConfiguration(
             closeScreenOnCallEnded = false,

--- a/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
@@ -41,10 +41,12 @@ import io.getstream.video.android.tooling.util.StreamBuildFlavorUtil
 import io.getstream.video.android.ui.AppNavHost
 import io.getstream.video.android.ui.AppScreens
 import io.getstream.video.android.ui.common.StreamCallActivity
+import io.getstream.video.android.ui.common.StreamCallActivityConfiguration
 import io.getstream.video.android.util.InAppUpdateHelper
 import io.getstream.video.android.util.InstallReferrer
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
@@ -104,23 +106,34 @@ class MainActivity : ComponentActivity() {
         observeIncomingCall()
     }
 
+    /**
+     * Observes incoming calls in real-time.
+     *
+     * - First, it waits for the StreamVideo instance to be available.
+     * - Then it watches for a "ringing" call (i.e., someone is calling).
+     * - Once a ringing call is found, it listens for its ringing state updates.
+     * - If the ringing state changes to "Incoming", it means we are receiving a call.
+     * - At that point, it starts the incoming call screen using `startIncomingCallActivity()`.
+     *
+     * This flow automatically stops and restarts if the instance or call changes,
+     * ensuring we always react to the latest incoming call state.
+     */
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun observeIncomingCall() {
         lifecycleScope.launch {
-            StreamVideo.instanceState.flatMapLatest { instance ->
-                instance?.state?.ringingCall ?: flowOf(null)
-            }.collectLatest { call ->
-                if (call != null) {
-                    lifecycleScope.launch {
-                        // Monitor the ringingState on a non-null call
-                        call.state.ringingState.collectLatest {
-                            if (it is RingingState.Incoming) {
-                                startIncomingCallActivity(call)
-                            }
-                        }
+            StreamVideo.instanceState
+                .flatMapLatest { instance ->
+                    instance?.state?.ringingCall ?: flowOf(null)
+                }
+                .flatMapLatest { call ->
+                    call?.state?.ringingState ?: emptyFlow()
+                }
+                .collectLatest { ringingState ->
+                    val currentCall = StreamVideo.instanceState.value?.state?.ringingCall?.value
+                    if (ringingState is RingingState.Incoming) {
+                        currentCall?.let { startIncomingCallActivity(it) }
                     }
                 }
-            }
         }
     }
 
@@ -128,6 +141,7 @@ class MainActivity : ComponentActivity() {
         val intent = StreamCallActivity.callIntent(
             context = this,
             cid = StreamCallId.fromCallCid(call.cid),
+            configuration = StreamCallActivityConfiguration(closeScreenOnCallEnded = true),
             members = emptyList(),
             leaveWhenLastInCall = true,
             action = NotificationHandler.ACTION_INCOMING_CALL,

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -5645,6 +5645,7 @@ public final class io/getstream/video/android/core/CallState {
 	public final fun updateParticipantSortingOrder (Ljava/util/Comparator;)V
 	public final fun updateParticipantVisibility (Ljava/lang/String;Lio/getstream/video/android/core/model/VisibilityOnScreenState;)V
 	public final fun updateParticipantVisibilityFlow (Lkotlinx/coroutines/flow/Flow;)V
+	public final fun updateRejectedBy (Ljava/util/Set;)V
 	public final fun upsertParticipants (Ljava/util/List;)V
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1525,6 +1525,10 @@ public class CallState(
             null
         }
     }
+
+    fun updateRejectedBy(userId: Set<String>) {
+        _rejectedBy.value = userId
+    }
 }
 
 private fun MemberResponse.toMemberState(): MemberState {

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -41,6 +41,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public final fun enterPictureInPicture ()V
 	public fun get (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun get$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	public final fun getConfig ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	public fun getConfiguration ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	protected final fun getOnErrorFinish ()Lkotlin/jvm/functions/Function2;
 	protected final fun getOnSuccessFinish ()Lkotlin/jvm/functions/Function2;
@@ -50,6 +51,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public static synthetic fun join$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public fun leave (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun leave$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
+	protected final fun loadConfigFromIntent (Landroid/content/Intent;)Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	public fun onBackPressed (Lio/getstream/video/android/core/Call;)V
 	public fun onCallAction (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/call/state/CallAction;)V
 	public fun onCallEvent (Lio/getstream/video/android/core/Call;Lio/getstream/android/video/generated/models/VideoEvent;)V

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -62,6 +62,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun onIntentAction (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public static synthetic fun onIntentAction$default (Lio/getstream/video/android/ui/common/StreamCallActivity;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)V
 	public fun onLastParticipant (Lio/getstream/video/android/core/Call;)V
+	protected fun onNewIntent (Landroid/content/Intent;)V
 	public fun onPause ()V
 	public fun onPause (Lio/getstream/video/android/core/Call;)V
 	public fun onPictureInPicture (Lio/getstream/video/android/core/Call;)V

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -256,7 +256,9 @@ public abstract class StreamCallActivity : ComponentActivity() {
                     intent,
                     onSuccess = { _, _, call, action ->
                         logger.d { "Calling [onNewIntent(intent)], because call is initialized $call, action=$action" }
-                        onIntentAction(call, action, onError = onErrorFinish) { successCall -> }
+                        onIntentAction(call, action, onError = onErrorFinish) { successCall ->
+                            applyDashboardSettings(successCall)
+                        }
                     },
                     onError = {
                         // We are not calling onErrorFinish here on purpose

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -236,6 +236,40 @@ public abstract class StreamCallActivity : ComponentActivity() {
         )
     }
 
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        /**
+         * Necessary because the intent is read during the activity's lifecycle methods.
+         */
+        setIntent(intent)
+        when (intent.action) {
+            NotificationHandler.ACTION_ACCEPT_CALL -> {
+                // Exit case
+                // TODO Later
+                // If already in call, then should we do nothing or allow to connect with new call
+                val activeCall = StreamVideo.instance().state.activeCall.value
+                if (activeCall != null) return
+
+                initializeCallOrFail(
+                    null,
+                    null,
+                    intent,
+                    onSuccess = { _, _, call, action ->
+                        logger.d { "Calling [onNewIntent(intent)], because call is initialized $call, action=$action" }
+                        onIntentAction(call, action, onError = onErrorFinish) { successCall -> }
+                    },
+                    onError = {
+                        // We are not calling onErrorFinish here on purpose
+                        // we want to crash if we cannot initialize the call
+                        logger.e(it) { "Failed to initialize call." }
+                        throw it
+                    },
+                )
+            }
+            else -> {}
+        }
+    }
+
     public override fun onResume() {
         super.onResume()
         withCachedCall {


### PR DESCRIPTION
### 🎯 Goal

:iphone: Scenario: Inconsistent Call Screen Behavior on Decline
Setup:
iOS user (A) initiates a group call to two Android users: (B) and (C).
The call enters the Ringing state on both Android devices.
Issue:
User B declines the call.
:x: Problem: Despite declining, User B remains stuck on the calling screen, with the progress bar still visible.
:white_check_mark: Expected behavior: User B should be navigated back to the main activity immediately after declining.
Later, User C also declines the call.
:white_check_mark: Now, User B is finally redirected back to the main screen, even though they had already declined earlier.
Conclusion:
There seems to be a UI or state handling issue where the call screen doesn't dismiss immediately after a decline unless all recipients decline.

### 🛠 Implementation details

Here’s a clean and professional PR description you can use (or adapt) for your pull request:

---

### 🛠️ Problem

The existing approach for loading `StreamCallActivityConfiguration` was flawed.

* The configuration was being initialized via a public `val`:

  ```kotlin
  open val configuration: StreamCallActivityConfiguration
  ```
* This was accessed during the **activity's construction phase**, before `onCreate` was invoked.
* As a result, `intent` was `null` when the configuration was read, leading to incorrect or default behavior.

---

### ✅ Solution

To resolve this issue:

* Configuration is now initialized **explicitly inside `onCreate()`** by reading from the intent.
* To support `singleTop` or `singleTask` launch modes, configuration is **also re-initialized in `onNewIntent()`**.

---

### ⚠️ Deprecated API

```kotlin
@Deprecated(
    message = "Accessing configuration before onCreate may lead to unintended behavior. Use getConfiguration() instead.",
    replaceWith = ReplaceWith("getConfiguration()")
)
open val configuration: StreamCallActivityConfiguration
```

---

### 🆕 Updated API

Use this method instead:

```kotlin
protected fun getConfiguration(): StreamCallActivityConfiguration
```

* Backed by a properly initialized field.
* Must be called **after `onCreate()`** or after calling `initializeConfig(intent)`.

Additionally:

```kotlin
protected fun initializeConfig(intent: Intent?) {
    config = loadConfigFromIntent(intent)
}
```

And

```kotlin
protected fun loadConfigFromIntent(intent: Intent?): StreamCallActivityConfiguration
```

---

### 🔁 Migration Notes

* Replace direct access to `configuration` with `getConfiguration()` in custom implementations.
* If overriding behavior, call `initializeConfig(intent)` in your `onCreate()` and `onNewIntent()` methods.

Let me know if you’d like a changelog or sample migration snippet too.


### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Make a group call

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>


