### PR TITLE
Improve Last Participant Leave Policy

### DIFF
--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -728,9 +728,9 @@ public abstract class StreamCallActivity : ComponentActivity() {
             }
 
             is ParticipantLeftEvent, is CallSessionParticipantLeftEvent -> {
-                val total = call.state.participantCounts.value?.total
+                val total = call.state.participants.value.size
                 logger.d { "Participant left, remaining: $total" }
-                if (total != null && total <= 2) {
+                if (total <= 1) {
                     onLastParticipant(call)
                 }
             }


### PR DESCRIPTION
### 🎯 Goal

Refine the **Last Participant Leave Policy**.
According to this policy, when there is **one or zero participants remaining in a call**, the current user should automatically leave the call.

### 🛠 Implementation details

Instead of relying on a cached or potentially stale `participantCount`,
we will use the **`ParticipantState`** to determine the number of active participants in the call.

Here’s a more polished and clearer version of your text:
