### PR TITLE
Forward push payload for custom notification handling

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9923,37 +9923,40 @@ public class io/getstream/video/android/core/notifications/DefaultNotificationHa
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelName ()Ljava/lang/String;
 	public final fun getHideRingingNotificationInForeground ()Z
-	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public final fun getIntentResolver ()Lio/getstream/video/android/core/notifications/DefaultStreamIntentResolver;
 	public fun getLeaveAction (Landroid/app/PendingIntent;)Landroidx/core/app/NotificationCompat$Action;
 	public fun getMediaNotificationConfig ()Lio/getstream/video/android/core/notifications/medianotifications/MediaNotificationConfig;
-	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
+	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)Landroid/app/Notification;
 	public fun getNotification (Lkotlin/jvm/functions/Function1;)Landroid/app/Notification;
 	public final fun getNotificationIconRes ()I
 	protected final fun getNotificationManager ()Landroidx/core/app/NotificationManagerCompat;
 	public fun getNotificationUpdates (Lkotlinx/coroutines/CoroutineScope;Lio/getstream/video/android/core/Call;Lio/getstream/video/android/model/User;Lkotlin/jvm/functions/Function1;)V
-	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
+	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroid/app/Notification;
 	public fun getRejectAction (Landroid/app/PendingIntent;)Landroidx/core/app/NotificationCompat$Action;
-	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public fun getSettingUpCallNotification ()Landroid/app/Notification;
 	public fun isInForeground ()Z
 	public fun maybeCreateChannel (Ljava/lang/String;Landroid/content/Context;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun maybeCreateChannel$default (Lio/getstream/video/android/core/notifications/DefaultNotificationHandler;Ljava/lang/String;Landroid/content/Context;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 	public fun onPermissionDenied ()V
 	public fun onPermissionGranted ()V
 	public fun onPermissionRationale ()V
 	public fun onPermissionRequested ()V
-	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 	public fun showLiveCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;I)V
+	public fun showLiveCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
 	public fun showMissedCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;I)V
+	public fun showMissedCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
 	public fun showNotificationCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;I)V
-	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun showNotificationCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/video/android/core/notifications/DefaultNotificationHandler$Companion {
@@ -10068,41 +10071,49 @@ public class io/getstream/video/android/core/notifications/handlers/DefaultStrea
 	public fun initialPlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;)V
 	public fun provideMediaSession (Landroid/app/Application;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Landroid/support/v4/media/session/MediaSessionCompat$Callback;)Landroid/support/v4/media/session/MediaSessionCompat;
 	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler : io/getstream/android/push/permissions/NotificationPermissionHandler, io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler, io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider, io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider {
 	public fun <init> (Landroid/app/Application;Landroidx/core/app/NotificationManagerCompat;Lio/getstream/android/push/permissions/NotificationPermissionHandler;Lio/getstream/video/android/core/notifications/StreamIntentResolver;ZLio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationChannels;Landroid/support/v4/media/session/MediaSessionCompat$Callback;Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Landroid/app/Application;Landroidx/core/app/NotificationManagerCompat;Lio/getstream/android/push/permissions/NotificationPermissionHandler;Lio/getstream/video/android/core/notifications/StreamIntentResolver;ZLio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationChannels;Landroid/support/v4/media/session/MediaSessionCompat$Callback;Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
-	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
-	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
-	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
+	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)Landroid/app/Notification;
+	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroid/app/Notification;
+	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public fun getSettingUpCallNotification ()Landroid/app/Notification;
 	public fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 	public fun onPermissionDenied ()V
 	public fun onPermissionGranted ()V
 	public fun onPermissionRationale ()V
 	public fun onPermissionRequested ()V
-	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController : io/getstream/video/android/core/notifications/handlers/StreamMediaSessionControllerWithPayload {
 	public abstract fun clear (Lio/getstream/video/android/model/StreamCallId;)V
 	public abstract fun initialMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/MediaMetadataCompat$Builder;)V
 	public abstract fun initialPlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;)V
 	public abstract fun provideMediaSession (Landroid/app/Application;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Landroid/support/v4/media/session/MediaSessionCompat$Callback;)Landroid/support/v4/media/session/MediaSessionCompat;
-	public abstract fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateMetadata$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updatePlaybackState$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionControllerWithPayload {
+	public abstract fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors : io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload {
 	public fun <init> ()V
 	public fun onBuildIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroidx/core/app/NotificationCompat$Builder;
 	public fun onBuildMediaNotificationMetadata (Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/model/StreamCallId;)Landroid/support/v4/media/MediaMetadataCompat$Builder;
@@ -10115,6 +10126,16 @@ public class io/getstream/video/android/core/notifications/handlers/StreamNotifi
 	public fun onBuildOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroidx/core/app/NotificationCompat$Builder;
 	public static synthetic fun onBuildOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors;Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/lang/Object;)Landroidx/core/app/NotificationCompat$Builder;
 	public fun onCreateMediaSessionCompat (Landroid/app/Application;Ljava/lang/String;)Landroid/support/v4/media/session/MediaSessionCompat;
+}
+
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload {
+	public fun <init> ()V
+	public fun onBuildIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildMissedCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Ljava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildOngoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public static synthetic fun onBuildOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;ILjava/lang/Object;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public static synthetic fun onBuildOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Landroidx/core/app/NotificationCompat$Builder;
 }
 
 public final class io/getstream/video/android/core/notifications/handlers/StreamNotificationChannelInfo {
@@ -10152,25 +10173,42 @@ public final class io/getstream/video/android/core/notifications/handlers/Stream
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler {
-	public abstract fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public abstract fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public abstract fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public abstract fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler : io/getstream/video/android/core/notifications/handlers/StreamNotificationHandlerWithPayload {
+	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider {
-	public abstract fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
-	public abstract fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationHandlerWithPayload {
+	public abstract fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider : io/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload {
+	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
 	public static synthetic fun getMissedCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ILjava/lang/Object;)Landroid/app/Notification;
-	public abstract fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
+	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
 	public static synthetic fun getOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZIILjava/lang/Object;)Landroid/app/Notification;
-	public abstract fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
 	public static synthetic fun getRingingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/lang/Object;)Landroid/app/Notification;
 	public abstract fun getSettingUpCallNotification ()Landroid/app/Notification;
 }
 
-public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload {
+	public abstract fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
+	public abstract fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)Landroid/app/Notification;
+	public static synthetic fun getMissedCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Landroid/app/Notification;
+	public abstract fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroid/app/Notification;
+	public static synthetic fun getOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;ILjava/lang/Object;)Landroid/app/Notification;
+	public abstract fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
+	public static synthetic fun getRingingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Landroid/app/Notification;
+}
+
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors : io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload {
 	public fun <init> ()V
 	public fun onUpdateIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun onUpdateIncomingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -10187,11 +10225,36 @@ public class io/getstream/video/android/core/notifications/handlers/StreamNotifi
 	public static synthetic fun onUpdateOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider {
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload {
+	public fun <init> ()V
+	public fun onUpdateIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateIncomingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateMediaNotificationMetadata (Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateMediaNotificationMetadata$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateMediaNotificationPlaybackState (Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateMediaNotificationPlaybackState$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateOngoingCallMediaNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateOngoingCallMediaNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateOngoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider : io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProviderWithPayload {
 	public abstract fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateIncomingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateOngoingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateOutgoingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProviderWithPayload {
+	public abstract fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver : android/content/BroadcastReceiver {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -123,7 +123,11 @@ constructor(
     private val logger by taggedLogger("Video:StreamNotificationHandler")
 
     // START REGION : On push arrived
-    override fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onRingingCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onRingingCall] #ringing; callId: ${callId.id}" }
         CallService.showIncomingCall(
             application,
@@ -135,11 +139,16 @@ constructor(
                 callId,
                 callDisplayName,
                 shouldHaveContentIntent = true,
+                payload,
             ),
         )
     }
 
-    override fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onLiveCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onLiveCall] callId: ${callId.id}, callDisplayName: $callDisplayName" }
         val notificationId = callId.hashCode()
         val liveCallPendingIntent =
@@ -158,7 +167,11 @@ constructor(
         }.showNotification(notificationId)
     }
 
-    override fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onMissedCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onMissedCall] #ringing; callId: ${callId.id}" }
         val notificationId = callId.hashCode()
         val intent = intentResolver.searchMissedCallPendingIntent(callId, notificationId) ?: run {
@@ -171,7 +184,11 @@ constructor(
         ).showNotification(notificationId = callId.hashCode())
     }
 
-    override fun onNotification(callId: StreamCallId, callDisplayName: String) {
+    override fun onNotification(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onNotification] callId: ${callId.id}, callDisplayName: $callDisplayName" }
         val notificationId = callId.hashCode()
         val intent = intentResolver.searchNotificationCallPendingIntent(callId, notificationId)
@@ -192,6 +209,7 @@ constructor(
     override fun getMissedCallNotification(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d { "[getMissedCallNotification] callId: ${callId.id}, callDisplayName: $callDisplayName" }
         val notificationId = callId.hashCode()
@@ -227,6 +245,7 @@ constructor(
         callId: StreamCallId,
         callDisplayName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[getRingingCallNotification] callId: ${callId.id}, ringingState: $ringingState, callDisplayName: $callDisplayName, shouldHaveContentIntent: $shouldHaveContentIntent"
@@ -243,6 +262,7 @@ constructor(
                     rejectCallPendingIntent,
                     callDisplayName,
                     shouldHaveContentIntent,
+                    payload,
                 )
             } else {
                 logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -271,6 +291,7 @@ constructor(
         ringingState: RingingState,
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
         shouldHaveContentIntent: Boolean,
         intercept: NotificationCompat.Builder.() -> NotificationCompat.Builder,
     ): Notification? {
@@ -288,6 +309,7 @@ constructor(
                     acceptCallPendingIntent,
                     rejectCallPendingIntent,
                     callDisplayName,
+                    payload,
                     shouldHaveContentIntent,
                     intercept,
                 )
@@ -304,6 +326,7 @@ constructor(
                     callId,
                     callDisplayName,
                     isOutgoingCall = true,
+                    payload = payload,
                 )
             } else {
                 logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -319,6 +342,7 @@ constructor(
         acceptCallPendingIntent: PendingIntent,
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
+        payload: Map<String, Any?>,
         shouldHaveContentIntent: Boolean,
         intercept: NotificationCompat.Builder.() -> NotificationCompat.Builder,
     ): Notification {
@@ -363,6 +387,7 @@ constructor(
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[getIncomingCallNotification] callerName: $callerName, shouldHaveContentIntent: $shouldHaveContentIntent"
@@ -372,6 +397,7 @@ constructor(
             acceptCallPendingIntent,
             rejectCallPendingIntent,
             callerName,
+            payload,
             shouldHaveContentIntent,
         ) {
             initialNotificationBuilderInterceptor.onBuildIncomingCallNotification(
@@ -381,6 +407,7 @@ constructor(
                 rejectCallPendingIntent,
                 callerName,
                 shouldHaveContentIntent,
+                payload,
             )
         }
     }
@@ -404,6 +431,7 @@ constructor(
     private inline fun getOngoingCallNotificationInternal(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
         mediaNotificationIntercept: NotificationCompat.Builder.() -> NotificationCompat.Builder = { this },
@@ -428,6 +456,7 @@ constructor(
         return if (mediaNotificationCallTypes.contains(callId.type)) {
             getMinimalMediaStyleNotification(
                 callId,
+                payload,
                 mediaNotificationIntercept,
                 playbackStateIntercept,
                 metadataIntercept,
@@ -437,6 +466,7 @@ constructor(
             getSimpleOngoingCallNotification(
                 callId,
                 callDisplayName,
+                payload,
                 isOutgoingCall,
                 remoteParticipantCount,
                 notificationBuildIntercept,
@@ -449,6 +479,7 @@ constructor(
         callDisplayName: String?,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[getOngoingCallNotification] callId: ${callId.id}, callDisplayName: $callDisplayName, isOutgoingCall: $isOutgoingCall, remoteParticipantCount: $remoteParticipantCount"
@@ -456,6 +487,7 @@ constructor(
         return getOngoingCallNotificationInternal(
             callId,
             callDisplayName,
+            payload,
             isOutgoingCall,
             remoteParticipantCount,
             mediaNotificationIntercept = {
@@ -500,6 +532,7 @@ constructor(
                     callDisplayName,
                     isOutgoingCall,
                     remoteParticipantCount,
+                    payload,
                 )
             },
         )
@@ -510,6 +543,7 @@ constructor(
     private inline fun getSimpleOngoingCallNotification(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
         intercept: NotificationCompat.Builder.() -> NotificationCompat.Builder,
@@ -646,6 +680,7 @@ constructor(
     override suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[onUpdateIncomingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
@@ -669,6 +704,7 @@ constructor(
                             rejectCallPendingIntent,
                             callDisplayName,
                             true,
+                            payload,
                         )
                     } else {
                         logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -678,14 +714,17 @@ constructor(
                     initial,
                     callDisplayName,
                     call,
+                    payload,
                 )
             },
+            payload = payload,
         )
     }
 
     override suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[updateOngoingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
@@ -743,19 +782,23 @@ constructor(
                     this,
                     callId,
                     callDisplayName,
+                    payload = payload,
                 )
                 updateNotificationBuilderInterceptor.onUpdateOngoingCallNotification(
                     initial,
                     callDisplayName,
                     call,
+                    payload,
                 )
             },
+            payload = payload,
         )
     }
 
     override suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[updateOutgoingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
@@ -771,13 +814,16 @@ constructor(
                     call.state.ringingState.value,
                     StreamCallId.fromCallCid(call.cid),
                     callDisplayName,
+                    payload = payload,
                 )
                 updateNotificationBuilderInterceptor.onUpdateOutgoingCallNotification(
                     initial,
                     callDisplayName,
                     call,
+                    payload,
                 )
             },
+            payload = payload,
         )
     }
 
@@ -894,6 +940,7 @@ constructor(
     @OptIn(ExperimentalStreamVideoApi::class)
     private inline fun getMinimalMediaStyleNotification(
         callId: StreamCallId,
+        payload: Map<String, Any?>,
         notificationBuildIntercept: NotificationCompat.Builder.() -> NotificationCompat.Builder = { this },
         playbackStateIntercept: PlaybackStateCompat.Builder.() -> Unit = { },
         metadataIntercept: MediaMetadataCompat.Builder.() -> Unit = { },

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -27,39 +27,94 @@ import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.RingingState
 import io.getstream.video.android.model.StreamCallId
 
-interface StreamNotificationHandler {
+interface StreamNotificationHandlerWithPayload {
     /**
      * Customize the notification when you receive a push notification for ringing call,
      * which has further two types [RingingState.Incoming] and [RingingState.Outgoing]
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onRingingCall(callId: StreamCallId, callDisplayName: String)
+
+    fun onRingingCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 
     /**
      * Customize the notification when you receive a push notification for Missed Call
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onMissedCall(callId: StreamCallId, callDisplayName: String)
+    fun onMissedCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 
     /**
      * Customize the notification when you receive a push notification for general usage
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onNotification(callId: StreamCallId, callDisplayName: String)
+    fun onNotification(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 
     /**
      * Customize the notification when you receive a push notification for Live Call
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onLiveCall(callId: StreamCallId, callDisplayName: String)
+    fun onLiveCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 }
 
-interface StreamNotificationProvider {
+interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
+    /**
+     * Customize the notification when you receive a push notification for ringing call,
+     * which has further two types [RingingState.Incoming] and [RingingState.Outgoing]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
+        onRingingCall(callId, callDisplayName, emptyMap())
+    }
 
+    /**
+     * Customize the notification when you receive a push notification for Missed Call
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
+        onMissedCall(callId, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for general usage
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onNotification(callId: StreamCallId, callDisplayName: String) {
+        onNotification(callId, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for Live Call
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
+        onLiveCall(callId, callDisplayName, emptyMap())
+    }
+}
+
+interface StreamNotificationProviderWithPayload {
     /**
      * Customize the notification when you receive a push notification for ringing call with type [RingingState.Incoming]
      * @param fullScreenPendingIntent A high-priority intent that launches an activity in full-screen mode, bypassing the lock screen.
@@ -75,6 +130,7 @@ interface StreamNotificationProvider {
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -90,6 +146,7 @@ interface StreamNotificationProvider {
         callDisplayName: String? = null,
         isOutgoingCall: Boolean = false,
         remoteParticipantCount: Int = 0,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -105,6 +162,7 @@ interface StreamNotificationProvider {
         callId: StreamCallId,
         callDisplayName: String? = null,
         shouldHaveContentIntent: Boolean = true,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -117,7 +175,113 @@ interface StreamNotificationProvider {
     fun getMissedCallNotification(
         callId: StreamCallId,
         callDisplayName: String? = null,
+        payload: Map<String, Any?>,
     ): Notification?
+}
+
+interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
+
+    /**
+     * Customize the notification when you receive a push notification for ringing call with type [RingingState.Incoming]
+     * @param fullScreenPendingIntent A high-priority intent that launches an activity in full-screen mode, bypassing the lock screen.
+     * @param acceptCallPendingIntent The intent triggered when accepting the call from the notification.
+     * @param rejectCallPendingIntent The intent triggered when rejecting the call from the notification.
+     * @param callerName The name of the caller to display in the notification
+     * @param shouldHaveContentIntent If true, clicking the notification triggers [fullScreenPendingIntent].
+     * @return A [Notification] object customized for the incoming call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getIncomingCallNotification(
+        fullScreenPendingIntent: PendingIntent,
+        acceptCallPendingIntent: PendingIntent,
+        rejectCallPendingIntent: PendingIntent,
+        callerName: String?,
+        shouldHaveContentIntent: Boolean,
+    ): Notification? {
+        return getIncomingCallNotification(
+            fullScreenPendingIntent,
+            acceptCallPendingIntent,
+            rejectCallPendingIntent,
+            callerName,
+            shouldHaveContentIntent,
+            emptyMap(),
+        )
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for ringing call with type [RingingState.Outgoing] and [RingingState.Active]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param isOutgoingCall True if the call is outgoing [RingingState.Outgoing], false if it is an active call [RingingState.Active].
+     * @param remoteParticipantCount Count of remote participant
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getOngoingCallNotification(
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        isOutgoingCall: Boolean = false,
+        remoteParticipantCount: Int = 0,
+    ): Notification? {
+        return getOngoingCallNotification(
+            callId,
+            callDisplayName,
+            isOutgoingCall,
+            remoteParticipantCount,
+            emptyMap(),
+        )
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for ringing call
+     * @param ringingState The current state of ringing call, represented by [RingingState]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param shouldHaveContentIntent If set to true then it will launch a screen when the user will click on the notification
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getRingingCallNotification(
+        ringingState: RingingState,
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        shouldHaveContentIntent: Boolean = true,
+    ): Notification? {
+        return getRingingCallNotification(
+            ringingState,
+            callId,
+            callDisplayName,
+            shouldHaveContentIntent,
+            emptyMap(),
+        )
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for Missed Call
+     *
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @return A [Notification] object customized for the missed call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getMissedCallNotification(
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+    ): Notification? {
+        return getMissedCallNotification(callId, callDisplayName, emptyMap())
+    }
 
     /**
      * Temporary notification. Sometimes the system needs to show a notification while the call is not ready.
@@ -128,7 +292,7 @@ interface StreamNotificationProvider {
     fun getSettingUpCallNotification(): Notification?
 }
 
-interface StreamNotificationUpdatesProvider {
+interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderWithPayload {
 
     /**
      * Get subsequent updates to notifications.
@@ -145,9 +309,64 @@ interface StreamNotificationUpdatesProvider {
      * @param call The Stream call object.
      * @return A [Notification] object customized for the ongoing call.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
+    ): Notification? {
+        return updateOngoingCallNotification(call, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Update the ringing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ringing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    suspend fun updateOutgoingCallNotification(
+        call: Call,
+        callDisplayName: String?,
+    ): Notification? {
+        return updateOutgoingCallNotification(call, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Update the ringing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ringing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    suspend fun updateIncomingCallNotification(
+        call: Call,
+        callDisplayName: String,
+    ): Notification? {
+        return updateIncomingCallNotification(call, callDisplayName, emptyMap())
+    }
+}
+
+interface StreamNotificationUpdatesProviderWithPayload {
+
+    /**
+     * Update the ongoing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    suspend fun updateOngoingCallNotification(
+        call: Call,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -159,6 +378,7 @@ interface StreamNotificationUpdatesProvider {
     suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -170,13 +390,15 @@ interface StreamNotificationUpdatesProvider {
     suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification?
 }
 
 /**
  * Interceptor for notification builders.
  */
-open class StreamNotificationBuilderInterceptors {
+open class StreamNotificationBuilderInterceptors :
+    StreamNotificationBuilderInterceptorsWithPayload() {
 
     /**
      * Intercept the notification builder and modify it before it is posted.
@@ -188,6 +410,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param callerName The name of the caller to display in the notification.
      * @param shouldHaveContentIntent If true, clicking the notification triggers [fullScreenPendingIntent].
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildIncomingCallNotification(
         builder: NotificationCompat.Builder,
         fullScreenPendingIntent: PendingIntent,
@@ -207,6 +433,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param isOutgoingCall True if the call is outgoing, false if it is an active call.
      * @param remoteParticipantCount Count of remote participant.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildOngoingCallNotification(
         builder: NotificationCompat.Builder,
         callId: StreamCallId,
@@ -230,6 +460,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param builder The notification builder.
      * @param callDisplayName The name of the caller to display in the notification.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildMissedCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String?,
@@ -246,6 +480,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param callDisplayName The name of the caller to display in the notification
      * @param shouldHaveContentIntent If set to true then it will launch a screen when the user will click on the notification
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildOutgoingCallNotification(
         builder: NotificationCompat.Builder,
         ringingState: RingingState,
@@ -309,10 +547,88 @@ open class StreamNotificationBuilderInterceptors {
     }
 }
 
+open class StreamNotificationBuilderInterceptorsWithPayload {
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param fullScreenPendingIntent A high-priority intent that launches an activity in full-screen mode, bypassing the lock screen.
+     * @param acceptCallPendingIntent The intent triggered when accepting the call from the notification.
+     * @param rejectCallPendingIntent The intent triggered when rejecting the call from the notification.
+     * @param callerName The name of the caller to display in the notification.
+     * @param shouldHaveContentIntent If true, clicking the notification triggers [fullScreenPendingIntent].
+     */
+    open fun onBuildIncomingCallNotification(
+        builder: NotificationCompat.Builder,
+        fullScreenPendingIntent: PendingIntent,
+        acceptCallPendingIntent: PendingIntent,
+        rejectCallPendingIntent: PendingIntent,
+        callerName: String?,
+        shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     * @param isOutgoingCall True if the call is outgoing, false if it is an active call.
+     * @param remoteParticipantCount Count of remote participant.
+     */
+    open fun onBuildOngoingCallNotification(
+        builder: NotificationCompat.Builder,
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        isOutgoingCall: Boolean = false,
+        remoteParticipantCount: Int = 0,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     */
+    open fun onBuildMissedCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String?,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param ringingState The current state of ringing call, represented by [RingingState]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param shouldHaveContentIntent If set to true then it will launch a screen when the user will click on the notification
+     */
+    open fun onBuildOutgoingCallNotification(
+        builder: NotificationCompat.Builder,
+        ringingState: RingingState,
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        shouldHaveContentIntent: Boolean = true,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+}
+
 /**
  * Interceptor for notification updates.
  */
-open class StreamNotificationUpdateInterceptors {
+open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterceptorsWithPayload() {
 
     /**
      * Intercept the notification builder and modify it before it is posted.
@@ -321,6 +637,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification.
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateOngoingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -336,6 +656,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification.
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateOngoingCallMediaNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -351,6 +675,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateOutgoingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -366,6 +694,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateIncomingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -381,6 +713,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param call The Stream call object.
      * @param callDisplayName The name of the caller to display in the notification.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateMediaNotificationMetadata(
         builder: MediaMetadataCompat.Builder,
         call: Call,
@@ -396,6 +732,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param call The Stream call object.
      * @param callDisplayName The name of the caller to display in the notification.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateMediaNotificationPlaybackState(
         builder: PlaybackStateCompat.Builder,
         call: Call,
@@ -415,5 +755,104 @@ open class StreamNotificationUpdateInterceptors {
         channelId: String,
     ): MediaSessionCompat? {
         return null
+    }
+}
+
+open class StreamNotificationUpdateInterceptorsWithPayload {
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     * @param call the stream call
+     */
+    open suspend fun onUpdateOngoingCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     * @param call the stream call
+     */
+    open suspend fun onUpdateOngoingCallMediaNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param call the stream call
+     */
+    open suspend fun onUpdateOutgoingCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param call the stream call
+     */
+    open suspend fun onUpdateIncomingCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the media notification metadata builder and modify it before it is posted for updating.
+     *
+     * @param builder The media metadata builder.
+     * @param call The Stream call object.
+     * @param callDisplayName The name of the caller to display in the notification.
+     */
+    open suspend fun onUpdateMediaNotificationMetadata(
+        builder: MediaMetadataCompat.Builder,
+        call: Call,
+        callDisplayName: String? = null,
+        payload: Map<String, Any?>,
+    ): MediaMetadataCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the media notification playback state builder and modify it before it is posted for updating.
+     *
+     * @param builder The media playback state builder.
+     * @param call The Stream call object.
+     * @param callDisplayName The name of the caller to display in the notification.
+     */
+    open suspend fun onUpdateMediaNotificationPlaybackState(
+        builder: PlaybackStateCompat.Builder,
+        call: Call,
+        callDisplayName: String? = null,
+        payload: Map<String, Any?>,
+    ): PlaybackStateCompat.Builder {
+        return builder
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
@@ -30,19 +30,36 @@ import io.getstream.video.android.model.User
 import kotlinx.coroutines.CoroutineScope
 
 internal object NoOpNotificationHandler : NotificationHandler {
-    override fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
+
+    override fun onRingingCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
-    override fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onMissedCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
-    override fun onNotification(callId: StreamCallId, callDisplayName: String) {
+    override fun onNotification(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
-    override fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onLiveCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
@@ -52,6 +69,7 @@ internal object NoOpNotificationHandler : NotificationHandler {
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getOngoingCallNotification(
@@ -59,22 +77,26 @@ internal object NoOpNotificationHandler : NotificationHandler {
         callDisplayName: String?,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
+        payload: Map<String, Any?>,
     ): Notification? = null
-
     override suspend fun onCallNotificationUpdate(call: Call): Notification? = null
+
     override suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getRingingCallNotification(
@@ -82,11 +104,13 @@ internal object NoOpNotificationHandler : NotificationHandler {
         callId: StreamCallId,
         callDisplayName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getMissedCallNotification(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getSettingUpCallNotification(): Notification? = null
@@ -124,6 +148,7 @@ internal object NoOpNotificationHandler : NotificationHandler {
         callId: StreamCallId,
         mediaNotificationConfig: MediaNotificationConfig,
         remoteParticipantCount: Int,
+
     ): NotificationCompat.Builder? {
         return null
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -62,22 +62,22 @@ internal class VideoPushDelegate : PushDelegate() {
 
     private fun handleRingType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("ring-type-notification")?.onRingingCall(callId, callDisplayName)
+        getStreamVideo("ring-type-notification")?.onRingingCall(callId, callDisplayName, payload)
     }
 
     private fun handleMissedType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("missed-type-notification")?.onMissedCall(callId, callDisplayName)
+        getStreamVideo("missed-type-notification")?.onMissedCall(callId, callDisplayName, payload)
     }
 
     private fun handleNotificationType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("generic-notification")?.onNotification(callId, callDisplayName)
+        getStreamVideo("generic-notification")?.onNotification(callId, callDisplayName, payload)
     }
 
     private fun handleLiveStartedType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName)
+        getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName, payload)
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Enhance the notification handling flow by **forwarding the full push notification payload (key-value pairs) to the `StreamNotificationHandler` interface**.
This allows client applications to **access the original push payload and consume custom fields (e.g., dynamic titles, metadata) directly**, which was not possible before.

### 🛠 Implementation details

Existing API will new extend new interface which has `payload:Map<String, Any?>`

**New APIs Added**

Class/Interface | Methods
-- | --
StreamNotificationHandlerWithPayload | onRingingCall(callId, callDisplayName, payload)onMissedCall(callId, callDisplayName, payload)onNotification(callId, callDisplayName, payload)onLiveCall(callId, callDisplayName, payload)
StreamNotificationProviderWithPayload | getIncomingCallNotification(..., payload)getOngoingCallNotification(..., payload)getRingingCallNotification(..., payload)getMissedCallNotification(..., payload)
StreamNotificationUpdatesProviderWithPayload | updateOngoingCallNotification(call, callDisplayName, payload)updateOutgoingCallNotification(call, callDisplayName, payload)updateIncomingCallNotification(call, callDisplayName, payload)
StreamNotificationBuilderInterceptorsWithPayload | onBuildIncomingCallNotification(..., payload)onBuildOngoingCallNotification(..., payload)onBuildMissedCallNotification(..., payload)onBuildOutgoingCallNotification(..., payload)
StreamNotificationUpdateInterceptorsWithPayload | onUpdateOngoingCallNotification(..., payload)onUpdateOngoingCallMediaNotification(..., payload)onUpdateOutgoingCallNotification(..., payload)onUpdateIncomingCallNotification(..., payload)onUpdateMediaNotificationMetadata(..., payload)onUpdateMediaNotificationPlaybackState(..., payload)


**Deprecated APIs**

Class/Interface | Methods
-- | --
StreamNotificationHandler | onRingingCall(callId, callDisplayName)
onMissedCall(callId, callDisplayName)
onNotification(callId, callDisplayName)
onLiveCall(callId, callDisplayName)
StreamNotificationProvider | getIncomingCallNotification(..., shouldHaveContentIntent)
getOngoingCallNotification(callId, callDisplayName, isOutgoingCall, remoteParticipantCount)
getRingingCallNotification(ringingState, callId, callDisplayName, shouldHaveContentIntent)
getMissedCallNotification(callId, callDisplayName)
StreamNotificationUpdatesProvider | updateOngoingCallNotification(call, callDisplayName)
updateOutgoingCallNotification(call, callDisplayName)
updateIncomingCallNotification(call, callDisplayName)
StreamNotificationBuilderInterceptors | onBuildIncomingCallNotification(...)
onBuildOngoingCallNotification(...)
onBuildMissedCallNotification(...)
onBuildOutgoingCallNotification(...)
StreamNotificationUpdateInterceptors | onUpdateOngoingCallNotification(...)
onUpdateOngoingCallMediaNotification(...)
onUpdateOutgoingCallNotification(...)
onUpdateIncomingCallNotification(...)
onUpdateMediaNotificationMetadata(...)
onUpdateMediaNotificationPlaybackState(...)





