### PR TITLE
Improve call rejection from Notification Button

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -33,7 +33,6 @@ import io.getstream.video.android.compose.ui.StreamCallActivityComposeDelegate
 import io.getstream.video.android.compose.ui.components.call.activecall.AudioOnlyCallContent
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.StreamVideo
-import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.ui.call.CallScreen
 import io.getstream.video.android.ui.common.StreamActivityUiDelegate
@@ -52,19 +51,6 @@ class CallActivity : ComposeStreamCallActivity() {
     override fun loadConfigFromIntent(intent: Intent?): StreamCallActivityConfiguration {
         return super.loadConfigFromIntent(intent)
             .copy(closeScreenOnCallEnded = false, canSkipPermissionRationale = false)
-    }
-
-    override fun onNewIntent(intent: Intent) {
-        super.onNewIntent(intent)
-
-        if (intent.action == NotificationHandler.ACTION_ACCEPT_CALL) {
-            val activeCall = StreamVideo.instance().state.activeCall.value
-            if (activeCall != null) {
-                leave(activeCall)
-                finish()
-                startActivity(intent)
-            }
-        }
     }
 
     @StreamCallActivityDelicateApi

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9954,9 +9954,9 @@ public class io/getstream/video/android/core/notifications/DefaultNotificationHa
 	public fun showMissedCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
 	public fun showNotificationCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;I)V
 	public fun showNotificationCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
-	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/video/android/core/notifications/DefaultNotificationHandler$Companion {
@@ -10071,8 +10071,7 @@ public class io/getstream/video/android/core/notifications/handlers/DefaultStrea
 	public fun initialPlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;)V
 	public fun provideMediaSession (Landroid/app/Application;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Landroid/support/v4/media/session/MediaSessionCompat$Callback;)Landroid/support/v4/media/session/MediaSessionCompat;
 	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler : io/getstream/android/push/permissions/NotificationPermissionHandler, io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler, io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider, io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider {
@@ -10092,25 +10091,18 @@ public class io/getstream/video/android/core/notifications/handlers/StreamDefaul
 	public fun onPermissionRationale ()V
 	public fun onPermissionRequested ()V
 	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
-	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController : io/getstream/video/android/core/notifications/handlers/StreamMediaSessionControllerWithPayload {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController {
 	public abstract fun clear (Lio/getstream/video/android/model/StreamCallId;)V
 	public abstract fun initialMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/MediaMetadataCompat$Builder;)V
 	public abstract fun initialPlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;)V
 	public abstract fun provideMediaSession (Landroid/app/Application;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Landroid/support/v4/media/session/MediaSessionCompat$Callback;)Landroid/support/v4/media/session/MediaSessionCompat;
-	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updateMetadata$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updatePlaybackState$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionControllerWithPayload {
-	public abstract fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors : io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload {
@@ -10208,7 +10200,7 @@ public abstract interface class io/getstream/video/android/core/notifications/ha
 	public static synthetic fun getRingingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Landroid/app/Notification;
 }
 
-public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors : io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload {
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors {
 	public fun <init> ()V
 	public fun onUpdateIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun onUpdateIncomingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -10225,36 +10217,11 @@ public class io/getstream/video/android/core/notifications/handlers/StreamNotifi
 	public static synthetic fun onUpdateOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload {
-	public fun <init> ()V
-	public fun onUpdateIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun onUpdateIncomingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public fun onUpdateMediaNotificationMetadata (Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun onUpdateMediaNotificationMetadata$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public fun onUpdateMediaNotificationPlaybackState (Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun onUpdateMediaNotificationPlaybackState$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public fun onUpdateOngoingCallMediaNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun onUpdateOngoingCallMediaNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public fun onUpdateOngoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun onUpdateOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public fun onUpdateOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun onUpdateOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-}
-
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider : io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProviderWithPayload {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider {
 	public abstract fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updateIncomingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updateOngoingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun updateOutgoingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProviderWithPayload {
-	public abstract fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver : android/content/BroadcastReceiver {

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9962,19 +9962,34 @@ public class io/getstream/video/android/core/notifications/DefaultNotificationHa
 public final class io/getstream/video/android/core/notifications/DefaultNotificationHandler$Companion {
 }
 
+public class io/getstream/video/android/core/notifications/DefaultNotificationIntentBundleResolver : io/getstream/video/android/core/notifications/NotificationIntentBundleResolver {
+	public fun <init> ()V
+	public fun getAcceptCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public fun getDefaultBundle (Ljava/util/Map;)Landroid/os/Bundle;
+	public fun getEndCallPendingBundle (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/os/Bundle;
+	public fun getIncomingCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public fun getLiveCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public fun getMissedCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public fun getNotificationCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public fun getOngoingCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public fun getOutgoingCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public fun getRejectCallBundle (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/os/Bundle;
+}
+
 public final class io/getstream/video/android/core/notifications/DefaultStreamIntentResolver : io/getstream/video/android/core/notifications/StreamIntentResolver {
-	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Lio/getstream/video/android/core/notifications/NotificationIntentBundleResolver;)V
 	public final fun getContext ()Landroid/content/Context;
-	public fun getDefaultPendingIntent ()Landroid/app/PendingIntent;
-	public fun searchAcceptCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public fun searchEndCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;)Landroid/app/PendingIntent;
-	public fun searchIncomingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public fun searchLiveCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public fun searchMissedCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public fun searchNotificationCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public fun searchOngoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public fun searchOutgoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public fun searchRejectCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;)Landroid/app/PendingIntent;
+	public fun getDefaultPendingIntent (Ljava/util/Map;)Landroid/app/PendingIntent;
+	public final fun getNotificationIntentBundleResolver ()Lio/getstream/video/android/core/notifications/NotificationIntentBundleResolver;
+	public fun searchAcceptCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchEndCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchIncomingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchLiveCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchMissedCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchNotificationCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchOngoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchOutgoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public fun searchRejectCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/app/PendingIntent;
 }
 
 public final class io/getstream/video/android/core/notifications/NotificationConfig {
@@ -10040,20 +10055,49 @@ public final class io/getstream/video/android/core/notifications/NotificationHan
 	public static final field INTENT_EXTRA_NOTIFICATION_ID Ljava/lang/String;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/StreamIntentResolver {
-	public abstract fun getDefaultPendingIntent ()Landroid/app/PendingIntent;
-	public abstract fun searchAcceptCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
+public abstract interface class io/getstream/video/android/core/notifications/NotificationIntentBundleResolver {
+	public abstract fun getAcceptCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getDefaultBundle (Ljava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getEndCallPendingBundle (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getIncomingCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getLiveCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getMissedCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getNotificationCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getOngoingCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getOutgoingCallBundle (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/os/Bundle;
+	public abstract fun getRejectCallBundle (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/os/Bundle;
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/StreamIntentResolver : io/getstream/video/android/core/notifications/StreamIntentResolverWithPayload {
+	public fun getDefaultPendingIntent ()Landroid/app/PendingIntent;
+	public fun searchAcceptCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
 	public static synthetic fun searchAcceptCallPendingIntent$default (Lio/getstream/video/android/core/notifications/StreamIntentResolver;Lio/getstream/video/android/model/StreamCallId;IILjava/lang/Object;)Landroid/app/PendingIntent;
-	public abstract fun searchEndCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;)Landroid/app/PendingIntent;
-	public abstract fun searchIncomingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
+	public fun searchEndCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;)Landroid/app/PendingIntent;
+	public fun searchIncomingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
 	public static synthetic fun searchIncomingCallPendingIntent$default (Lio/getstream/video/android/core/notifications/StreamIntentResolver;Lio/getstream/video/android/model/StreamCallId;IILjava/lang/Object;)Landroid/app/PendingIntent;
-	public abstract fun searchLiveCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public abstract fun searchMissedCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public abstract fun searchNotificationCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public abstract fun searchOngoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
-	public abstract fun searchOutgoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
+	public fun searchLiveCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
+	public fun searchMissedCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
+	public fun searchNotificationCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
+	public fun searchOngoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
+	public fun searchOutgoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;I)Landroid/app/PendingIntent;
 	public static synthetic fun searchOutgoingCallPendingIntent$default (Lio/getstream/video/android/core/notifications/StreamIntentResolver;Lio/getstream/video/android/model/StreamCallId;IILjava/lang/Object;)Landroid/app/PendingIntent;
-	public abstract fun searchRejectCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;)Landroid/app/PendingIntent;
+	public fun searchRejectCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;)Landroid/app/PendingIntent;
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/StreamIntentResolverWithPayload {
+	public abstract fun getDefaultPendingIntent (Ljava/util/Map;)Landroid/app/PendingIntent;
+	public abstract fun searchAcceptCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public static synthetic fun searchAcceptCallPendingIntent$default (Lio/getstream/video/android/core/notifications/StreamIntentResolverWithPayload;Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;ILjava/lang/Object;)Landroid/app/PendingIntent;
+	public abstract fun searchEndCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/app/PendingIntent;
+	public abstract fun searchIncomingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public static synthetic fun searchIncomingCallPendingIntent$default (Lio/getstream/video/android/core/notifications/StreamIntentResolverWithPayload;Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;ILjava/lang/Object;)Landroid/app/PendingIntent;
+	public abstract fun searchLiveCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public abstract fun searchMissedCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public abstract fun searchNotificationCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public abstract fun searchOngoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public abstract fun searchOutgoingCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;)Landroid/app/PendingIntent;
+	public static synthetic fun searchOutgoingCallPendingIntent$default (Lio/getstream/video/android/core/notifications/StreamIntentResolverWithPayload;Lio/getstream/video/android/model/StreamCallId;ILjava/util/Map;ILjava/lang/Object;)Landroid/app/PendingIntent;
+	public abstract fun searchRejectCallPendingIntent (Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroid/app/PendingIntent;
 }
 
 public class io/getstream/video/android/core/notifications/handlers/CompatibilityStreamNotificationHandler : io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler, io/getstream/video/android/core/notifications/NotificationHandler {

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9923,37 +9923,40 @@ public class io/getstream/video/android/core/notifications/DefaultNotificationHa
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelName ()Ljava/lang/String;
 	public final fun getHideRingingNotificationInForeground ()Z
-	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public final fun getIntentResolver ()Lio/getstream/video/android/core/notifications/DefaultStreamIntentResolver;
 	public fun getLeaveAction (Landroid/app/PendingIntent;)Landroidx/core/app/NotificationCompat$Action;
 	public fun getMediaNotificationConfig ()Lio/getstream/video/android/core/notifications/medianotifications/MediaNotificationConfig;
-	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
+	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)Landroid/app/Notification;
 	public fun getNotification (Lkotlin/jvm/functions/Function1;)Landroid/app/Notification;
 	public final fun getNotificationIconRes ()I
 	protected final fun getNotificationManager ()Landroidx/core/app/NotificationManagerCompat;
 	public fun getNotificationUpdates (Lkotlinx/coroutines/CoroutineScope;Lio/getstream/video/android/core/Call;Lio/getstream/video/android/model/User;Lkotlin/jvm/functions/Function1;)V
-	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
+	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroid/app/Notification;
 	public fun getRejectAction (Landroid/app/PendingIntent;)Landroidx/core/app/NotificationCompat$Action;
-	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public fun getSettingUpCallNotification ()Landroid/app/Notification;
 	public fun isInForeground ()Z
 	public fun maybeCreateChannel (Ljava/lang/String;Landroid/content/Context;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun maybeCreateChannel$default (Lio/getstream/video/android/core/notifications/DefaultNotificationHandler;Ljava/lang/String;Landroid/content/Context;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 	public fun onPermissionDenied ()V
 	public fun onPermissionGranted ()V
 	public fun onPermissionRationale ()V
 	public fun onPermissionRequested ()V
-	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 	public fun showLiveCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;I)V
+	public fun showLiveCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
 	public fun showMissedCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;I)V
+	public fun showMissedCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
 	public fun showNotificationCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;I)V
-	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun showNotificationCallNotification (Landroid/app/PendingIntent;Ljava/lang/String;ILjava/util/Map;)V
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/video/android/core/notifications/DefaultNotificationHandler$Companion {
@@ -10068,41 +10071,49 @@ public class io/getstream/video/android/core/notifications/handlers/DefaultStrea
 	public fun initialPlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;)V
 	public fun provideMediaSession (Landroid/app/Application;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Landroid/support/v4/media/session/MediaSessionCompat$Callback;)Landroid/support/v4/media/session/MediaSessionCompat;
 	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public class io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler : io/getstream/android/push/permissions/NotificationPermissionHandler, io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler, io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider, io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider {
 	public fun <init> (Landroid/app/Application;Landroidx/core/app/NotificationManagerCompat;Lio/getstream/android/push/permissions/NotificationPermissionHandler;Lio/getstream/video/android/core/notifications/StreamIntentResolver;ZLio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationChannels;Landroid/support/v4/media/session/MediaSessionCompat$Callback;Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Lkotlin/jvm/functions/Function2;)V
 	public synthetic fun <init> (Landroid/app/Application;Landroidx/core/app/NotificationManagerCompat;Lio/getstream/android/push/permissions/NotificationPermissionHandler;Lio/getstream/video/android/core/notifications/StreamIntentResolver;ZLio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Lio/getstream/video/android/core/notifications/handlers/StreamNotificationChannels;Landroid/support/v4/media/session/MediaSessionCompat$Callback;Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
-	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
-	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
-	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
+	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)Landroid/app/Notification;
+	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroid/app/Notification;
+	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public fun getSettingUpCallNotification ()Landroid/app/Notification;
 	public fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 	public fun onPermissionDenied ()V
 	public fun onPermissionGranted ()V
 	public fun onPermissionRationale ()V
 	public fun onPermissionRequested ()V
-	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController : io/getstream/video/android/core/notifications/handlers/StreamMediaSessionControllerWithPayload {
 	public abstract fun clear (Lio/getstream/video/android/model/StreamCallId;)V
 	public abstract fun initialMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/MediaMetadataCompat$Builder;)V
 	public abstract fun initialPlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/model/StreamCallId;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;)V
 	public abstract fun provideMediaSession (Landroid/app/Application;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Landroid/support/v4/media/session/MediaSessionCompat$Callback;)Landroid/support/v4/media/session/MediaSessionCompat;
-	public abstract fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateMetadata$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updatePlaybackState$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamMediaSessionController;Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
-public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamMediaSessionControllerWithPayload {
+	public abstract fun updateMetadata (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePlaybackState (Landroid/content/Context;Landroid/support/v4/media/session/MediaSessionCompat;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors : io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload {
 	public fun <init> ()V
 	public fun onBuildIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroidx/core/app/NotificationCompat$Builder;
 	public fun onBuildMediaNotificationMetadata (Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/model/StreamCallId;)Landroid/support/v4/media/MediaMetadataCompat$Builder;
@@ -10115,6 +10126,16 @@ public class io/getstream/video/android/core/notifications/handlers/StreamNotifi
 	public fun onBuildOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroidx/core/app/NotificationCompat$Builder;
 	public static synthetic fun onBuildOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptors;Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/lang/Object;)Landroidx/core/app/NotificationCompat$Builder;
 	public fun onCreateMediaSessionCompat (Landroid/app/Application;Ljava/lang/String;)Landroid/support/v4/media/session/MediaSessionCompat;
+}
+
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload {
+	public fun <init> ()V
+	public fun onBuildIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildMissedCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Ljava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildOngoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public static synthetic fun onBuildOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;ILjava/lang/Object;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public static synthetic fun onBuildOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Landroidx/core/app/NotificationCompat$Builder;
 }
 
 public final class io/getstream/video/android/core/notifications/handlers/StreamNotificationChannelInfo {
@@ -10152,25 +10173,42 @@ public final class io/getstream/video/android/core/notifications/handlers/Stream
 	public fun toString ()Ljava/lang/String;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler {
-	public abstract fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public abstract fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public abstract fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
-	public abstract fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler : io/getstream/video/android/core/notifications/handlers/StreamNotificationHandlerWithPayload {
+	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
+	public fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)V
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider {
-	public abstract fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
-	public abstract fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationHandlerWithPayload {
+	public abstract fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun onNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider : io/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload {
+	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
 	public static synthetic fun getMissedCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ILjava/lang/Object;)Landroid/app/Notification;
-	public abstract fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
+	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZI)Landroid/app/Notification;
 	public static synthetic fun getOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZIILjava/lang/Object;)Landroid/app/Notification;
-	public abstract fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
+	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
 	public static synthetic fun getRingingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/lang/Object;)Landroid/app/Notification;
 	public abstract fun getSettingUpCallNotification ()Landroid/app/Notification;
 }
 
-public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload {
+	public abstract fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
+	public abstract fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)Landroid/app/Notification;
+	public static synthetic fun getMissedCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Landroid/app/Notification;
+	public abstract fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroid/app/Notification;
+	public static synthetic fun getOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;ILjava/lang/Object;)Landroid/app/Notification;
+	public abstract fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
+	public static synthetic fun getRingingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Landroid/app/Notification;
+}
+
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors : io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload {
 	public fun <init> ()V
 	public fun onUpdateIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun onUpdateIncomingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -10187,11 +10225,36 @@ public class io/getstream/video/android/core/notifications/handlers/StreamNotifi
 	public static synthetic fun onUpdateOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptors;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider {
+public class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload {
+	public fun <init> ()V
+	public fun onUpdateIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateIncomingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateMediaNotificationMetadata (Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateMediaNotificationMetadata$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroid/support/v4/media/MediaMetadataCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateMediaNotificationPlaybackState (Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateMediaNotificationPlaybackState$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroid/support/v4/media/session/PlaybackStateCompat$Builder;Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateOngoingCallMediaNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateOngoingCallMediaNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateOngoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun onUpdateOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateOutgoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdateInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Lio/getstream/video/android/core/Call;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider : io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProviderWithPayload {
 	public abstract fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateIncomingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateOngoingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateOutgoingCallNotification$suspendImpl (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProvider;Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationUpdatesProviderWithPayload {
+	public abstract fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver : android/content/BroadcastReceiver {

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -10123,7 +10123,9 @@ public class io/getstream/video/android/core/notifications/handlers/StreamNotifi
 public class io/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload {
 	public fun <init> ()V
 	public fun onBuildIncomingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;ZLjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildMediaNotificationStyle (Landroidx/media/app/NotificationCompat$MediaStyle;Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroidx/media/app/NotificationCompat$MediaStyle;
 	public fun onBuildMissedCallNotification (Landroidx/core/app/NotificationCompat$Builder;Ljava/lang/String;Ljava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
+	public fun onBuildOngoingCallMediaNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/model/StreamCallId;Ljava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
 	public fun onBuildOngoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;
 	public static synthetic fun onBuildOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationBuilderInterceptorsWithPayload;Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;ILjava/lang/Object;)Landroidx/core/app/NotificationCompat$Builder;
 	public fun onBuildOutgoingCallNotification (Landroidx/core/app/NotificationCompat$Builder;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroidx/core/app/NotificationCompat$Builder;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -289,19 +289,16 @@ public open class DefaultNotificationHandler(
     override suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
-        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getIncomingCallNotification(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -640,7 +640,7 @@ public open class DefaultNotificationHandler(
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open fun showNotificationCallNotification(
         notificationPendingIntent: PendingIntent,
@@ -671,7 +671,7 @@ public open class DefaultNotificationHandler(
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open fun showMissedCallNotification(
         notificationPendingIntent: PendingIntent,
@@ -701,7 +701,7 @@ public open class DefaultNotificationHandler(
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open fun showLiveCallNotification(
         liveCallPendingIntent: PendingIntent,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -84,7 +84,8 @@ public open class DefaultNotificationHandler(
     NotificationPermissionHandler by notificationPermissionHandler {
 
     private val logger by taggedLogger("Call:NotificationHandler")
-    val intentResolver = DefaultStreamIntentResolver(application)
+    val intentResolver =
+        DefaultStreamIntentResolver(application, DefaultNotificationIntentBundleResolver())
     protected val notificationManager: NotificationManagerCompat by lazy {
         NotificationManagerCompat.from(application).also {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -149,9 +150,18 @@ public open class DefaultNotificationHandler(
         payload: Map<String, Any?>,
     ): Notification? {
         return if (ringingState is RingingState.Incoming) {
-            val fullScreenPendingIntent = intentResolver.searchIncomingCallPendingIntent(callId)
-            val acceptCallPendingIntent = intentResolver.searchAcceptCallPendingIntent(callId)
-            val rejectCallPendingIntent = intentResolver.searchRejectCallPendingIntent(callId)
+            val fullScreenPendingIntent = intentResolver.searchIncomingCallPendingIntent(
+                callId,
+                payload = payload,
+            )
+            val acceptCallPendingIntent = intentResolver.searchAcceptCallPendingIntent(
+                callId,
+                payload = payload,
+            )
+            val rejectCallPendingIntent = intentResolver.searchRejectCallPendingIntent(
+                callId,
+                payload = payload,
+            )
 
             if (fullScreenPendingIntent != null && acceptCallPendingIntent != null && rejectCallPendingIntent != null) {
                 getIncomingCallNotification(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -392,6 +392,7 @@ public open class DefaultNotificationHandler(
                     notificationPendingIntent,
                     callDisplayName,
                     notificationId,
+                    payload,
                 )
             } ?: logger.e { "Couldn't find any activity for $ACTION_NOTIFICATION" }
     }
@@ -404,6 +405,7 @@ public open class DefaultNotificationHandler(
                     liveCallPendingIntent,
                     callDisplayName,
                     notificationId,
+                    payload,
                 )
             } ?: logger.e { "Couldn't find any activity for $ACTION_LIVE_CALL" }
     }
@@ -526,6 +528,7 @@ public open class DefaultNotificationHandler(
         call: Call,
         localUser: User,
         onUpdate: (Notification) -> Unit,
+
     ) {
         val streamVideoClient = StreamVideo.instanceOrNull() as? StreamVideoClient
 
@@ -567,6 +570,7 @@ public open class DefaultNotificationHandler(
                             callDisplayName = callDisplayName,
                             isOutgoingCall = true,
                             remoteParticipantCount = remoteMembersCount,
+                            payload = emptyMap(),
                         )?.let {
                             onUpdate(it)
                         }
@@ -601,6 +605,7 @@ public open class DefaultNotificationHandler(
                                     callId = StreamCallId.fromCallCid(call.cid),
                                     callDisplayName = callDisplayName,
                                     remoteParticipantCount = currentRemoteParticipantCount,
+                                    payload = emptyMap(),
                                 )?.let {
                                     onUpdate(it)
                                 }
@@ -635,6 +640,7 @@ public open class DefaultNotificationHandler(
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open fun showNotificationCallNotification(
         notificationPendingIntent: PendingIntent,
@@ -665,6 +671,7 @@ public open class DefaultNotificationHandler(
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open fun showMissedCallNotification(
         notificationPendingIntent: PendingIntent,
@@ -694,6 +701,7 @@ public open class DefaultNotificationHandler(
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open fun showLiveCallNotification(
         liveCallPendingIntent: PendingIntent,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationIntentBundleResolver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationIntentBundleResolver.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications
+
+import android.app.PendingIntent
+import android.os.Bundle
+import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_ONGOING_CALL
+import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_REJECT_CALL
+import io.getstream.video.android.model.StreamCallId
+
+public open class DefaultNotificationIntentBundleResolver : NotificationIntentBundleResolver {
+    /**
+     * Search for an activity that can receive incoming calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    override fun getIncomingCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    /**
+     * Search for an activity that is used for outgoing calls.
+     * Calls are considered outgoing until the call is accepted.
+     *
+     * @param callId the call id
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    override fun getOutgoingCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    /**
+     * Search for an activity that can receive live calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    override fun getNotificationCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    /**
+     * Search for an activity that can receive missed calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    override fun getMissedCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    override fun getDefaultBundle(payload: Map<String, Any?>): Bundle = Bundle()
+
+    /**
+     * Search for an activity that can receive live calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    override fun getLiveCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    /**
+     * Search for an activity that can accept call from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     * @return The [PendingIntent] which can trigger a component to consume accept call events.
+     */
+    override fun getAcceptCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    /**
+     * Searches for a broadcast receiver that can consume the [ACTION_REJECT_CALL] intent to reject
+     * a call from the Stream Server.
+     *
+     * @param callId The ID of the call.
+     * @param payload The payload from Push Notification
+     * @return The [PendingIntent] which can trigger a component to consume the call rejection event.
+     */
+    override fun getRejectCallBundle(
+        callId: StreamCallId,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    /**
+     * Searches for a broadcast receiver that can consume the [ACTION_REJECT_CALL] intent to reject
+     * a call from the Stream Server.
+     *
+     * @param callId The ID of the call.
+     * @param payload The payload from Push Notification
+     * @return The [PendingIntent] which can trigger a component to consume the call rejection event.
+     */
+    override fun getEndCallPendingBundle(
+        callId: StreamCallId,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+
+    /**
+     * Searches an activity that will accept the [ACTION_ONGOING_CALL] intent and jump right back into the call.
+     *
+     * @param callId the call id
+     * @param payload The payload from Push Notification
+     * @param notificationId the notification ID.
+     */
+    override fun getOngoingCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle = Bundle()
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationIntentBundleResolver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/NotificationIntentBundleResolver.kt
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications
+
+import android.app.PendingIntent
+import android.os.Bundle
+import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_ONGOING_CALL
+import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_REJECT_CALL
+import io.getstream.video.android.model.StreamCallId
+
+public interface NotificationIntentBundleResolver {
+    /**
+     * Search for an activity that can receive incoming calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    fun getIncomingCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    /**
+     * Search for an activity that is used for outgoing calls.
+     * Calls are considered outgoing until the call is accepted.
+     *
+     * @param callId the call id
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    fun getOutgoingCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    /**
+     * Search for an activity that can receive live calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    fun getNotificationCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    /**
+     * Search for an activity that can receive missed calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    fun getMissedCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    fun getDefaultBundle(payload: Map<String, Any?>): Bundle
+
+    /**
+     * Search for an activity that can receive live calls from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     */
+    fun getLiveCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    /**
+     * Search for an activity that can accept call from Stream Server.
+     *
+     * @param callId The call id from the incoming call.
+     * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
+     * @return The [PendingIntent] which can trigger a component to consume accept call events.
+     */
+    fun getAcceptCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    /**
+     * Searches for a broadcast receiver that can consume the [ACTION_REJECT_CALL] intent to reject
+     * a call from the Stream Server.
+     *
+     * @param callId The ID of the call.
+     * @param payload The payload from Push Notification
+     * @return The [PendingIntent] which can trigger a component to consume the call rejection event.
+     */
+    fun getRejectCallBundle(
+        callId: StreamCallId,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    /**
+     * Searches for a broadcast receiver that can consume the [ACTION_REJECT_CALL] intent to reject
+     * a call from the Stream Server.
+     *
+     * @param callId The ID of the call.
+     * @param payload The payload from Push Notification
+     * @return The [PendingIntent] which can trigger a component to consume the call rejection event.
+     */
+    fun getEndCallPendingBundle(
+        callId: StreamCallId,
+        payload: Map<String, Any?>,
+    ): Bundle
+
+    /**
+     * Searches an activity that will accept the [ACTION_ONGOING_CALL] intent and jump right back into the call.
+     *
+     * @param callId the call id
+     * @param payload The payload from Push Notification
+     * @param notificationId the notification ID.
+     */
+    fun getOngoingCallBundle(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): Bundle
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/StreamIntentResolverWithPayload.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/StreamIntentResolverWithPayload.kt
@@ -21,30 +21,19 @@ import io.getstream.video.android.core.notifications.NotificationHandler.Compani
 import io.getstream.video.android.core.notifications.NotificationHandler.Companion.ACTION_REJECT_CALL
 import io.getstream.video.android.model.StreamCallId
 
-/**
- * We'll deprecate this [StreamIntentResolver] soon
- * Use the [StreamIntentResolverWithPayload]
- */
-interface StreamIntentResolver : StreamIntentResolverWithPayload {
+interface StreamIntentResolverWithPayload {
     /**
      * Search for an activity that can receive incoming calls from Stream Server.
      *
      * @param callId The call id from the incoming call.
      * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith(
-            "searchIncomingCallPendingIntent(callId, notificationId, payload)",
-        ),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchIncomingCallPendingIntent(
         callId: StreamCallId,
         notificationId: Int = NotificationHandler.INCOMING_CALL_NOTIFICATION_ID,
-    ): PendingIntent? {
-        return searchIncomingCallPendingIntent(callId, notificationId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
     /**
      * Search for an activity that is used for outgoing calls.
@@ -52,155 +41,105 @@ interface StreamIntentResolver : StreamIntentResolverWithPayload {
      *
      * @param callId the call id
      * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith(
-            "searchOutgoingCallPendingIntent(callId, notificationId, payload)",
-        ),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchOutgoingCallPendingIntent(
         callId: StreamCallId,
         notificationId: Int = NotificationHandler.INCOMING_CALL_NOTIFICATION_ID,
-    ): PendingIntent? {
-        return searchIncomingCallPendingIntent(callId, notificationId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
     /**
      * Search for an activity that can receive live calls from Stream Server.
      *
      * @param callId The call id from the incoming call.
      * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith(
-            "searchNotificationCallPendingIntent(callId, notificationId, payload)",
-        ),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchNotificationCallPendingIntent(
         callId: StreamCallId,
         notificationId: Int,
-    ): PendingIntent? {
-        return searchNotificationCallPendingIntent(callId, notificationId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
     /**
      * Search for an activity that can receive missed calls from Stream Server.
      *
      * @param callId The call id from the incoming call.
      * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("searchMissedCallPendingIntent(callId, notificationId, payload)"),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchMissedCallPendingIntent(
         callId: StreamCallId,
         notificationId: Int,
-    ): PendingIntent? {
-        return searchMissedCallPendingIntent(callId, notificationId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("getDefaultPendingIntent(payload)"),
-        level = DeprecationLevel.WARNING,
-    )
-    fun getDefaultPendingIntent(): PendingIntent {
-        return getDefaultPendingIntent(emptyMap())
-    }
+    fun getDefaultPendingIntent(payload: Map<String, Any?>): PendingIntent
 
     /**
      * Search for an activity that can receive live calls from Stream Server.
      *
      * @param callId The call id from the incoming call.
      * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("searchLiveCallPendingIntent(callId, notificationId, payload)"),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchLiveCallPendingIntent(
         callId: StreamCallId,
         notificationId: Int,
-    ): PendingIntent? {
-        return searchLiveCallPendingIntent(callId, notificationId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
     /**
      * Search for an activity that can accept call from Stream Server.
      *
      * @param callId The call id from the incoming call.
      * @param notificationId the notification ID.
+     * @param payload The payload from Push Notification
      * @return The [PendingIntent] which can trigger a component to consume accept call events.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("searchAcceptCallPendingIntent(callId, notificationId, payload)"),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchAcceptCallPendingIntent(
         callId: StreamCallId,
         notificationId: Int = NotificationHandler.INCOMING_CALL_NOTIFICATION_ID,
-    ): PendingIntent? {
-        return searchAcceptCallPendingIntent(callId, notificationId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
     /**
      * Searches for a broadcast receiver that can consume the [ACTION_REJECT_CALL] intent to reject
      * a call from the Stream Server.
      *
      * @param callId The ID of the call.
+     * @param payload The payload from Push Notification
      * @return The [PendingIntent] which can trigger a component to consume the call rejection event.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("searchRejectCallPendingIntent(callId, payload)"),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchRejectCallPendingIntent(
         callId: StreamCallId,
-    ): PendingIntent? {
-        return searchRejectCallPendingIntent(callId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
     /**
      * Searches for a broadcast receiver that can consume the [ACTION_REJECT_CALL] intent to reject
      * a call from the Stream Server.
      *
      * @param callId The ID of the call.
+     * @param payload The payload from Push Notification
      * @return The [PendingIntent] which can trigger a component to consume the call rejection event.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("searchEndCallPendingIntent(callId, payload)"),
-        level = DeprecationLevel.WARNING,
-    )
     fun searchEndCallPendingIntent(
         callId: StreamCallId,
-    ): PendingIntent? {
-        return searchEndCallPendingIntent(callId, emptyMap())
-    }
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 
     /**
      * Searches an activity that will accept the [ACTION_ONGOING_CALL] intent and jump right back into the call.
      *
      * @param callId the call id
+     * @param payload The payload from Push Notification
      * @param notificationId the notification ID.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith(
-            "searchOngoingCallPendingIntent(callId, notificationId, payload)",
-        ),
-        level = DeprecationLevel.WARNING,
-    )
-    fun searchOngoingCallPendingIntent(callId: StreamCallId, notificationId: Int): PendingIntent? {
-        return searchOngoingCallPendingIntent(callId, notificationId, emptyMap())
-    }
+    fun searchOngoingCallPendingIntent(
+        callId: StreamCallId,
+        notificationId: Int,
+        payload: Map<String, Any?>,
+    ): PendingIntent?
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/CompatibilityStreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/CompatibilityStreamNotificationHandler.kt
@@ -27,6 +27,7 @@ import io.getstream.android.push.permissions.NotificationPermissionHandler
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.R
 import io.getstream.video.android.core.internal.ExperimentalStreamVideoApi
+import io.getstream.video.android.core.notifications.DefaultNotificationIntentBundleResolver
 import io.getstream.video.android.core.notifications.DefaultStreamIntentResolver
 import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.core.notifications.StreamIntentResolver
@@ -51,7 +52,8 @@ constructor(
     notificationManager: NotificationManagerCompat = NotificationManagerCompat.from(
         application.applicationContext,
     ),
-    intentResolver: StreamIntentResolver = DefaultStreamIntentResolver(application),
+    intentResolver: StreamIntentResolver =
+        DefaultStreamIntentResolver(application, DefaultNotificationIntentBundleResolver()),
     hideRingingNotificationInForeground: Boolean = false,
     initialNotificationBuilderInterceptor: StreamNotificationBuilderInterceptors =
         StreamNotificationBuilderInterceptors(),

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -637,7 +637,6 @@ constructor(
             updateOutgoingCallNotification(
                 call = call,
                 callDisplayName = callDisplayName,
-                payload = emptyMap(), // TODO Rahul check 1
             )
         } else if (ringingState is RingingState.Incoming) {
             logger.d { "[onCallNotificationUpdate] Handling incoming call" }
@@ -649,7 +648,6 @@ constructor(
             updateIncomingCallNotification(
                 call = call,
                 callDisplayName = callDisplayName,
-                payload = emptyMap(), // TODO Rahul check 2
             )
         } else if (ringingState is RingingState.Active) {
             logger.d { "[onCallNotificationUpdate] Handling active call" }
@@ -673,7 +671,6 @@ constructor(
             updateOngoingCallNotification(
                 call = call,
                 callDisplayName = callDisplayName,
-                payload = emptyMap(), // TODO Rahul check 3
             )
         } else {
             logger.d { "[onCallNotificationUpdate] Unhandled ringing state: $ringingState" }
@@ -686,12 +683,12 @@ constructor(
     override suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[onUpdateIncomingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
         }
         val callId = StreamCallId.fromCallCid(call.cid)
+        val payload = emptyMap<String, Any?>()
         return getRingingCallNotificationInternal(
             ringingState = call.state.ringingState.value,
             callId = callId,
@@ -720,7 +717,6 @@ constructor(
                     initial,
                     callDisplayName,
                     call,
-                    payload,
                 )
             },
             payload = payload,
@@ -730,8 +726,8 @@ constructor(
     override suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification? {
+        val payload = emptyMap<String, Any?>()
         logger.d {
             "[updateOngoingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
         }
@@ -753,7 +749,6 @@ constructor(
                     mediaSession,
                     call,
                     callDisplayName,
-                    payload,
                     this,
                 )
             },
@@ -769,7 +764,6 @@ constructor(
                     mediaSession,
                     call,
                     callDisplayName,
-                    payload,
                     this,
                 )
             },
@@ -783,7 +777,6 @@ constructor(
                     initialInterceptor,
                     callDisplayName,
                     call,
-                    payload,
                 )
             },
             notificationBuildIntercept = {
@@ -797,7 +790,6 @@ constructor(
                     initial,
                     callDisplayName,
                     call,
-                    payload,
                 )
             },
             payload = payload,
@@ -807,11 +799,11 @@ constructor(
     override suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
-        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[updateOutgoingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
         }
+        val payload = emptyMap<String, Any?>()
         return getRingingCallNotificationInternal(
             ringingState = call.state.ringingState.value,
             callId = StreamCallId.fromCallCid(call.cid),
@@ -829,7 +821,6 @@ constructor(
                     initial,
                     callDisplayName,
                     call,
-                    payload,
                 )
             },
             payload = payload,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -181,6 +181,7 @@ constructor(
         getMissedCallNotification(
             callId,
             callDisplayName,
+            payload,
         ).showNotification(notificationId = callId.hashCode())
     }
 
@@ -236,6 +237,7 @@ constructor(
             initialNotificationBuilderInterceptor.onBuildMissedCallNotification(
                 this,
                 callDisplayName,
+                payload,
             )
         }
     }
@@ -277,6 +279,7 @@ constructor(
                     callId,
                     callDisplayName,
                     isOutgoingCall = true,
+                    payload = payload,
                 )
             } else {
                 logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -634,6 +637,7 @@ constructor(
             updateOutgoingCallNotification(
                 call = call,
                 callDisplayName = callDisplayName,
+                payload = emptyMap(), // TODO Rahul check 1
             )
         } else if (ringingState is RingingState.Incoming) {
             logger.d { "[onCallNotificationUpdate] Handling incoming call" }
@@ -645,6 +649,7 @@ constructor(
             updateIncomingCallNotification(
                 call = call,
                 callDisplayName = callDisplayName,
+                payload = emptyMap(), // TODO Rahul check 2
             )
         } else if (ringingState is RingingState.Active) {
             logger.d { "[onCallNotificationUpdate] Handling active call" }
@@ -668,6 +673,7 @@ constructor(
             updateOngoingCallNotification(
                 call = call,
                 callDisplayName = callDisplayName,
+                payload = emptyMap(), // TODO Rahul check 3
             )
         } else {
             logger.d { "[onCallNotificationUpdate] Unhandled ringing state: $ringingState" }
@@ -747,6 +753,7 @@ constructor(
                     mediaSession,
                     call,
                     callDisplayName,
+                    payload,
                     this,
                 )
             },
@@ -762,6 +769,7 @@ constructor(
                     mediaSession,
                     call,
                     callDisplayName,
+                    payload,
                     this,
                 )
             },
@@ -775,6 +783,7 @@ constructor(
                     initialInterceptor,
                     callDisplayName,
                     call,
+                    payload,
                 )
             },
             notificationBuildIntercept = {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -123,7 +123,11 @@ constructor(
     private val logger by taggedLogger("Video:StreamNotificationHandler")
 
     // START REGION : On push arrived
-    override fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onRingingCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onRingingCall] #ringing; callId: ${callId.id}" }
         CallService.showIncomingCall(
             application,
@@ -135,11 +139,16 @@ constructor(
                 callId,
                 callDisplayName,
                 shouldHaveContentIntent = true,
+                payload,
             ),
         )
     }
 
-    override fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onLiveCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onLiveCall] callId: ${callId.id}, callDisplayName: $callDisplayName" }
         val notificationId = callId.hashCode()
         val liveCallPendingIntent =
@@ -158,7 +167,11 @@ constructor(
         }.showNotification(notificationId)
     }
 
-    override fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onMissedCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onMissedCall] #ringing; callId: ${callId.id}" }
         val notificationId = callId.hashCode()
         val intent = intentResolver.searchMissedCallPendingIntent(callId, notificationId) ?: run {
@@ -171,7 +184,11 @@ constructor(
         ).showNotification(notificationId = callId.hashCode())
     }
 
-    override fun onNotification(callId: StreamCallId, callDisplayName: String) {
+    override fun onNotification(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         logger.d { "[onNotification] callId: ${callId.id}, callDisplayName: $callDisplayName" }
         val notificationId = callId.hashCode()
         val intent = intentResolver.searchNotificationCallPendingIntent(callId, notificationId)
@@ -192,6 +209,7 @@ constructor(
     override fun getMissedCallNotification(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d { "[getMissedCallNotification] callId: ${callId.id}, callDisplayName: $callDisplayName" }
         val notificationId = callId.hashCode()
@@ -227,6 +245,7 @@ constructor(
         callId: StreamCallId,
         callDisplayName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[getRingingCallNotification] callId: ${callId.id}, ringingState: $ringingState, callDisplayName: $callDisplayName, shouldHaveContentIntent: $shouldHaveContentIntent"
@@ -243,6 +262,7 @@ constructor(
                     rejectCallPendingIntent,
                     callDisplayName,
                     shouldHaveContentIntent,
+                    payload,
                 )
             } else {
                 logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -271,6 +291,7 @@ constructor(
         ringingState: RingingState,
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
         shouldHaveContentIntent: Boolean,
         intercept: NotificationCompat.Builder.() -> NotificationCompat.Builder,
     ): Notification? {
@@ -288,6 +309,7 @@ constructor(
                     acceptCallPendingIntent,
                     rejectCallPendingIntent,
                     callDisplayName,
+                    payload,
                     shouldHaveContentIntent,
                     intercept,
                 )
@@ -304,6 +326,7 @@ constructor(
                     callId,
                     callDisplayName,
                     isOutgoingCall = true,
+                    payload = payload,
                 )
             } else {
                 logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -319,6 +342,7 @@ constructor(
         acceptCallPendingIntent: PendingIntent,
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
+        payload: Map<String, Any?>,
         shouldHaveContentIntent: Boolean,
         intercept: NotificationCompat.Builder.() -> NotificationCompat.Builder,
     ): Notification {
@@ -363,6 +387,7 @@ constructor(
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[getIncomingCallNotification] callerName: $callerName, shouldHaveContentIntent: $shouldHaveContentIntent"
@@ -372,6 +397,7 @@ constructor(
             acceptCallPendingIntent,
             rejectCallPendingIntent,
             callerName,
+            payload,
             shouldHaveContentIntent,
         ) {
             initialNotificationBuilderInterceptor.onBuildIncomingCallNotification(
@@ -381,6 +407,7 @@ constructor(
                 rejectCallPendingIntent,
                 callerName,
                 shouldHaveContentIntent,
+                payload,
             )
         }
     }
@@ -404,6 +431,7 @@ constructor(
     private inline fun getOngoingCallNotificationInternal(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
         mediaNotificationIntercept: NotificationCompat.Builder.() -> NotificationCompat.Builder = { this },
@@ -428,6 +456,7 @@ constructor(
         return if (mediaNotificationCallTypes.contains(callId.type)) {
             getMinimalMediaStyleNotification(
                 callId,
+                payload,
                 mediaNotificationIntercept,
                 playbackStateIntercept,
                 metadataIntercept,
@@ -437,6 +466,7 @@ constructor(
             getSimpleOngoingCallNotification(
                 callId,
                 callDisplayName,
+                payload,
                 isOutgoingCall,
                 remoteParticipantCount,
                 notificationBuildIntercept,
@@ -449,6 +479,7 @@ constructor(
         callDisplayName: String?,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[getOngoingCallNotification] callId: ${callId.id}, callDisplayName: $callDisplayName, isOutgoingCall: $isOutgoingCall, remoteParticipantCount: $remoteParticipantCount"
@@ -456,6 +487,7 @@ constructor(
         return getOngoingCallNotificationInternal(
             callId,
             callDisplayName,
+            payload,
             isOutgoingCall,
             remoteParticipantCount,
             mediaNotificationIntercept = {
@@ -500,6 +532,7 @@ constructor(
                     callDisplayName,
                     isOutgoingCall,
                     remoteParticipantCount,
+                    payload,
                 )
             },
         )
@@ -510,6 +543,7 @@ constructor(
     private inline fun getSimpleOngoingCallNotification(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
         intercept: NotificationCompat.Builder.() -> NotificationCompat.Builder,
@@ -646,6 +680,7 @@ constructor(
     override suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[onUpdateIncomingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
@@ -669,6 +704,7 @@ constructor(
                             rejectCallPendingIntent,
                             callDisplayName,
                             true,
+                            payload,
                         )
                     } else {
                         logger.e { "Ringing call notification not shown, one of the intents is null." }
@@ -678,14 +714,17 @@ constructor(
                     initial,
                     callDisplayName,
                     call,
+                    payload,
                 )
             },
+            payload = payload,
         )
     }
 
     override suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[updateOngoingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
@@ -743,19 +782,23 @@ constructor(
                     this,
                     callId,
                     callDisplayName,
+                    payload = payload,
                 )
                 updateNotificationBuilderInterceptor.onUpdateOngoingCallNotification(
                     initial,
                     callDisplayName,
                     call,
+                    payload,
                 )
             },
+            payload = payload,
         )
     }
 
     override suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? {
         logger.d {
             "[updateOutgoingCallNotification] callId: ${call.cid}, callDisplayName: $callDisplayName"
@@ -771,13 +814,16 @@ constructor(
                     call.state.ringingState.value,
                     StreamCallId.fromCallCid(call.cid),
                     callDisplayName,
+                    payload = payload,
                 )
                 updateNotificationBuilderInterceptor.onUpdateOutgoingCallNotification(
                     initial,
                     callDisplayName,
                     call,
+                    payload,
                 )
             },
+            payload = payload,
         )
     }
 
@@ -894,6 +940,7 @@ constructor(
     @OptIn(ExperimentalStreamVideoApi::class)
     private inline fun getMinimalMediaStyleNotification(
         callId: StreamCallId,
+        payload: Map<String, Any?>,
         notificationBuildIntercept: NotificationCompat.Builder.() -> NotificationCompat.Builder = { this },
         playbackStateIntercept: PlaybackStateCompat.Builder.() -> Unit = { },
         metadataIntercept: MediaMetadataCompat.Builder.() -> Unit = { },

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
@@ -294,11 +294,6 @@ open class DefaultStreamMediaSessionController(
             1f,
         )
 
-        updateInterceptors.onUpdateMediaNotificationPlaybackState(
-            playbackStateBuilder,
-            call,
-            callDisplayName,
-        )
         val intercepted = updateInterceptors.onUpdateMediaNotificationPlaybackState(
             playbackStateBuilder,
             call,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
@@ -38,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap
  * Controller for managing media sessions.
  */
 @ExperimentalStreamVideoApi
-interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload {
+interface StreamMediaSessionController {
 
     /**
      * Create or get already created media session for the call.
@@ -88,20 +88,13 @@ interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload
      * @param callDisplayName The call display name.
      * @param metadataBuilder The metadata builder.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     suspend fun updateMetadata(
         context: Context,
         mediaSession: MediaSessionCompat,
         call: Call,
         callDisplayName: String?,
         metadataBuilder: MediaMetadataCompat.Builder,
-    ) {
-        updateMetadata(context, mediaSession, call, callDisplayName, emptyMap(), metadataBuilder)
-    }
+    )
 
     /**
      * Update the media session playback state.
@@ -111,27 +104,13 @@ interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload
      * @param callDisplayName The call display name.
      * @param playbackStateBuilder The playback state builder.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     suspend fun updatePlaybackState(
         context: Context,
         mediaSession: MediaSessionCompat,
         call: Call,
         callDisplayName: String?,
         playbackStateBuilder: PlaybackStateCompat.Builder,
-    ) {
-        updatePlaybackState(
-            context,
-            mediaSession,
-            call,
-            callDisplayName,
-            emptyMap(),
-            playbackStateBuilder,
-        )
-    }
+    )
 
     /**
      * Clear the media session for the call.
@@ -139,47 +118,6 @@ interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload
      * @param callId The call id.
      */
     fun clear(callId: StreamCallId)
-}
-
-/**
- * Controller for managing media sessions.
- */
-@ExperimentalStreamVideoApi
-interface StreamMediaSessionControllerWithPayload {
-
-    /**
-     * Update the media session metadata.
-     *
-     * @param mediaSession The media session.
-     * @param call The call.
-     * @param callDisplayName The call display name.
-     * @param metadataBuilder The metadata builder.
-     */
-    suspend fun updateMetadata(
-        context: Context,
-        mediaSession: MediaSessionCompat,
-        call: Call,
-        callDisplayName: String?,
-        payload: Map<String, Any?>,
-        metadataBuilder: MediaMetadataCompat.Builder,
-    )
-
-    /**
-     * Update the media session playback state.
-     *
-     * @param mediaSession The media session.
-     * @param call The call.
-     * @param callDisplayName The call display name.
-     * @param playbackStateBuilder The playback state builder.
-     */
-    suspend fun updatePlaybackState(
-        context: Context,
-        mediaSession: MediaSessionCompat,
-        call: Call,
-        callDisplayName: String?,
-        payload: Map<String, Any?>,
-        playbackStateBuilder: PlaybackStateCompat.Builder,
-    )
 }
 
 /**
@@ -240,7 +178,6 @@ open class DefaultStreamMediaSessionController(
                                         mediaSession,
                                         call,
                                         null,
-                                        emptyMap(), // TODO Rahul check 4
                                         PlaybackStateCompat.Builder(),
                                     )
                                 }
@@ -261,7 +198,6 @@ open class DefaultStreamMediaSessionController(
                                         mediaSession,
                                         call,
                                         null,
-                                        emptyMap(), // TODO Rahul check 5
                                         PlaybackStateCompat.Builder(),
                                     )
                                 }
@@ -318,16 +254,6 @@ open class DefaultStreamMediaSessionController(
         callDisplayName: String?,
         metadataBuilder: MediaMetadataCompat.Builder,
     ) {
-    }
-
-    override suspend fun updateMetadata(
-        context: Context,
-        mediaSession: MediaSessionCompat,
-        call: Call,
-        callDisplayName: String?,
-        payload: Map<String, Any?>,
-        metadataBuilder: MediaMetadataCompat.Builder,
-    ) {
         logger.d { "[updateMetadata] Updating media metadata for session: $mediaSession" }
         metadataBuilder.putLong(
             MediaMetadataCompat.METADATA_KEY_DURATION,
@@ -341,7 +267,6 @@ open class DefaultStreamMediaSessionController(
             interceptedInitial,
             call,
             callDisplayName,
-            payload,
         )
         mediaSession.setMetadata(intercepted.build())
     }
@@ -351,7 +276,6 @@ open class DefaultStreamMediaSessionController(
         mediaSession: MediaSessionCompat,
         call: Call,
         callDisplayName: String?,
-        payload: Map<String, Any?>,
         playbackStateBuilder: PlaybackStateCompat.Builder,
     ) {
         logger.d { "[updatePlaybackState] Updating media metadata for session: $mediaSession" }
@@ -374,13 +298,11 @@ open class DefaultStreamMediaSessionController(
             playbackStateBuilder,
             call,
             callDisplayName,
-            payload,
         )
         val intercepted = updateInterceptors.onUpdateMediaNotificationPlaybackState(
             playbackStateBuilder,
             call,
             callDisplayName,
-            payload,
         )
         mediaSession.setPlaybackState(intercepted.build())
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
@@ -91,6 +91,7 @@ interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     suspend fun updateMetadata(
         context: Context,
@@ -113,6 +114,7 @@ interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     suspend fun updatePlaybackState(
         context: Context,
@@ -238,6 +240,7 @@ open class DefaultStreamMediaSessionController(
                                         mediaSession,
                                         call,
                                         null,
+                                        emptyMap(), // TODO Rahul check 4
                                         PlaybackStateCompat.Builder(),
                                     )
                                 }
@@ -258,6 +261,7 @@ open class DefaultStreamMediaSessionController(
                                         mediaSession,
                                         call,
                                         null,
+                                        emptyMap(), // TODO Rahul check 5
                                         PlaybackStateCompat.Builder(),
                                     )
                                 }
@@ -370,6 +374,7 @@ open class DefaultStreamMediaSessionController(
             playbackStateBuilder,
             call,
             callDisplayName,
+            payload,
         )
         val intercepted = updateInterceptors.onUpdateMediaNotificationPlaybackState(
             playbackStateBuilder,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamMediaSessionController.kt
@@ -91,7 +91,7 @@ interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     suspend fun updateMetadata(
         context: Context,
@@ -114,7 +114,7 @@ interface StreamMediaSessionController : StreamMediaSessionControllerWithPayload
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     suspend fun updatePlaybackState(
         context: Context,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -68,7 +68,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith("onRingingCall(callId, callDisplayName, emptyMap())"),
         level = DeprecationLevel.WARNING,
     )
     fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
@@ -82,7 +82,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith("onMissedCall(callId, callDisplayName, emptyMap())"),
         level = DeprecationLevel.WARNING,
     )
     fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
@@ -96,7 +96,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith("onNotification(callId, callDisplayName, emptyMap())"),
         level = DeprecationLevel.WARNING,
     )
     fun onNotification(callId: StreamCallId, callDisplayName: String) {
@@ -110,7 +110,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith("onLiveCall(callId, callDisplayName, emptyMap())"),
         level = DeprecationLevel.WARNING,
     )
     fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
@@ -196,7 +196,9 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith(
+            "getIncomingCallNotification(fullScreenPendingIntent,acceptCallPendingIntent,rejectCallPendingIntent,callerName,shouldHaveContentIntent,emptyMap()",
+        ),
         level = DeprecationLevel.WARNING,
     )
     fun getIncomingCallNotification(
@@ -226,7 +228,9 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith(
+            "getOngoingCallNotification(callId,callDisplayName,isOutgoingCall,remoteParticipantCount)",
+        ),
         level = DeprecationLevel.WARNING,
     )
     fun getOngoingCallNotification(
@@ -254,7 +258,9 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith(
+            "getRingingCallNotification(ringingState,callId,callDisplayName,shouldHaveContentIntent)",
+        ),
         level = DeprecationLevel.WARNING,
     )
     fun getRingingCallNotification(
@@ -281,7 +287,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith("getMissedCallNotification(callId,callDisplayName,emptyMap())"),
         level = DeprecationLevel.WARNING,
     )
     fun getMissedCallNotification(
@@ -363,7 +369,9 @@ open class StreamNotificationBuilderInterceptors :
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith(
+            "onBuildIncomingCallNotification(builder,fullScreenPendingIntent,acceptCallPendingIntent,rejectCallPendingIntent,callerName,shouldHaveContentIntent,emptyMap())",
+        ),
         level = DeprecationLevel.WARNING,
     )
     open fun onBuildIncomingCallNotification(
@@ -374,7 +382,15 @@ open class StreamNotificationBuilderInterceptors :
         callerName: String?,
         shouldHaveContentIntent: Boolean,
     ): NotificationCompat.Builder {
-        return builder
+        return onBuildIncomingCallNotification(
+            builder,
+            fullScreenPendingIntent,
+            acceptCallPendingIntent,
+            rejectCallPendingIntent,
+            callerName,
+            shouldHaveContentIntent,
+            emptyMap(),
+        )
     }
 
     /**
@@ -387,7 +403,9 @@ open class StreamNotificationBuilderInterceptors :
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith(
+            "onBuildOngoingCallNotification(builder,callId,callDisplayName,isOutgoingCall,remoteParticipantCount,emptyMap())",
+        ),
         level = DeprecationLevel.WARNING,
     )
     open fun onBuildOngoingCallNotification(
@@ -397,14 +415,26 @@ open class StreamNotificationBuilderInterceptors :
         isOutgoingCall: Boolean = false,
         remoteParticipantCount: Int = 0,
     ): NotificationCompat.Builder {
-        return builder
+        return onBuildOngoingCallNotification(
+            builder,
+            callId,
+            callDisplayName,
+            isOutgoingCall,
+            remoteParticipantCount,
+            emptyMap(),
+        )
     }
 
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("onBuildOngoingCallMediaNotification(builder,callId,emptyMap())"),
+        level = DeprecationLevel.WARNING,
+    )
     open fun onBuildOngoingCallMediaNotification(
         builder: NotificationCompat.Builder,
         callId: StreamCallId,
     ): NotificationCompat.Builder {
-        return builder
+        return onBuildOngoingCallMediaNotification(builder, callId, emptyMap())
     }
 
     /**
@@ -415,14 +445,16 @@ open class StreamNotificationBuilderInterceptors :
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith(
+            "onBuildMissedCallNotification(builder,callDisplayName,emptyMap())",
+        ),
         level = DeprecationLevel.WARNING,
     )
     open fun onBuildMissedCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String?,
     ): NotificationCompat.Builder {
-        return builder
+        return onBuildMissedCallNotification(builder, callDisplayName, emptyMap())
     }
 
     /**
@@ -436,7 +468,9 @@ open class StreamNotificationBuilderInterceptors :
      */
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        replaceWith = ReplaceWith(
+            "onBuildOutgoingCallNotification(builder,ringingState,callId,callDisplayName,shouldHaveContentIntent,emptyMap())",
+        ),
         level = DeprecationLevel.WARNING,
     )
     open fun onBuildOutgoingCallNotification(
@@ -446,7 +480,14 @@ open class StreamNotificationBuilderInterceptors :
         callDisplayName: String? = null,
         shouldHaveContentIntent: Boolean = true,
     ): NotificationCompat.Builder {
-        return builder
+        return onBuildOutgoingCallNotification(
+            builder,
+            ringingState,
+            callId,
+            callDisplayName,
+            shouldHaveContentIntent,
+            emptyMap(),
+        )
     }
 
     /**
@@ -485,7 +526,7 @@ open class StreamNotificationBuilderInterceptors :
         style: androidx.media.app.NotificationCompat.MediaStyle,
         callId: StreamCallId,
     ): androidx.media.app.NotificationCompat.MediaStyle {
-        return style
+        return onBuildMediaNotificationStyle(style, callId, emptyMap())
     }
 
     /**
@@ -545,6 +586,14 @@ open class StreamNotificationBuilderInterceptorsWithPayload {
         return builder
     }
 
+    open fun onBuildOngoingCallMediaNotification(
+        builder: NotificationCompat.Builder,
+        callId: StreamCallId,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
     /**
      * Intercept the notification builder and modify it before it is posted.
      *
@@ -577,6 +626,20 @@ open class StreamNotificationBuilderInterceptorsWithPayload {
         payload: Map<String, Any?>,
     ): NotificationCompat.Builder {
         return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify the media style before it is posted.
+     *
+     * @param style The media style.
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     */
+    open fun onBuildMediaNotificationStyle(
+        style: androidx.media.app.NotificationCompat.MediaStyle,
+        callId: StreamCallId,
+        payload: Map<String, Any?>,
+    ): androidx.media.app.NotificationCompat.MediaStyle {
+        return style
     }
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -27,39 +27,94 @@ import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.RingingState
 import io.getstream.video.android.model.StreamCallId
 
-interface StreamNotificationHandler {
+interface StreamNotificationHandlerWithPayload {
     /**
      * Customize the notification when you receive a push notification for ringing call,
      * which has further two types [RingingState.Incoming] and [RingingState.Outgoing]
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onRingingCall(callId: StreamCallId, callDisplayName: String)
+
+    fun onRingingCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 
     /**
      * Customize the notification when you receive a push notification for Missed Call
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onMissedCall(callId: StreamCallId, callDisplayName: String)
+    fun onMissedCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 
     /**
      * Customize the notification when you receive a push notification for general usage
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onNotification(callId: StreamCallId, callDisplayName: String)
+    fun onNotification(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 
     /**
      * Customize the notification when you receive a push notification for Live Call
      * @param callId An instance of [StreamCallId] representing the call identifier
      * @param callDisplayName The name of the caller to display in the notification
      */
-    fun onLiveCall(callId: StreamCallId, callDisplayName: String)
+    fun onLiveCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 }
 
-interface StreamNotificationProvider {
+interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
+    /**
+     * Customize the notification when you receive a push notification for ringing call,
+     * which has further two types [RingingState.Incoming] and [RingingState.Outgoing]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
+        onRingingCall(callId, callDisplayName, emptyMap())
+    }
 
+    /**
+     * Customize the notification when you receive a push notification for Missed Call
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
+        onMissedCall(callId, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for general usage
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onNotification(callId: StreamCallId, callDisplayName: String) {
+        onNotification(callId, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for Live Call
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
+        onLiveCall(callId, callDisplayName, emptyMap())
+    }
+}
+
+interface StreamNotificationProviderWithPayload {
     /**
      * Customize the notification when you receive a push notification for ringing call with type [RingingState.Incoming]
      * @param fullScreenPendingIntent A high-priority intent that launches an activity in full-screen mode, bypassing the lock screen.
@@ -75,6 +130,7 @@ interface StreamNotificationProvider {
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -90,6 +146,7 @@ interface StreamNotificationProvider {
         callDisplayName: String? = null,
         isOutgoingCall: Boolean = false,
         remoteParticipantCount: Int = 0,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -105,6 +162,7 @@ interface StreamNotificationProvider {
         callId: StreamCallId,
         callDisplayName: String? = null,
         shouldHaveContentIntent: Boolean = true,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -117,7 +175,113 @@ interface StreamNotificationProvider {
     fun getMissedCallNotification(
         callId: StreamCallId,
         callDisplayName: String? = null,
+        payload: Map<String, Any?>,
     ): Notification?
+}
+
+interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
+
+    /**
+     * Customize the notification when you receive a push notification for ringing call with type [RingingState.Incoming]
+     * @param fullScreenPendingIntent A high-priority intent that launches an activity in full-screen mode, bypassing the lock screen.
+     * @param acceptCallPendingIntent The intent triggered when accepting the call from the notification.
+     * @param rejectCallPendingIntent The intent triggered when rejecting the call from the notification.
+     * @param callerName The name of the caller to display in the notification
+     * @param shouldHaveContentIntent If true, clicking the notification triggers [fullScreenPendingIntent].
+     * @return A [Notification] object customized for the incoming call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getIncomingCallNotification(
+        fullScreenPendingIntent: PendingIntent,
+        acceptCallPendingIntent: PendingIntent,
+        rejectCallPendingIntent: PendingIntent,
+        callerName: String?,
+        shouldHaveContentIntent: Boolean,
+    ): Notification? {
+        return getIncomingCallNotification(
+            fullScreenPendingIntent,
+            acceptCallPendingIntent,
+            rejectCallPendingIntent,
+            callerName,
+            shouldHaveContentIntent,
+            emptyMap(),
+        )
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for ringing call with type [RingingState.Outgoing] and [RingingState.Active]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param isOutgoingCall True if the call is outgoing [RingingState.Outgoing], false if it is an active call [RingingState.Active].
+     * @param remoteParticipantCount Count of remote participant
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getOngoingCallNotification(
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        isOutgoingCall: Boolean = false,
+        remoteParticipantCount: Int = 0,
+    ): Notification? {
+        return getOngoingCallNotification(
+            callId,
+            callDisplayName,
+            isOutgoingCall,
+            remoteParticipantCount,
+            emptyMap(),
+        )
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for ringing call
+     * @param ringingState The current state of ringing call, represented by [RingingState]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param shouldHaveContentIntent If set to true then it will launch a screen when the user will click on the notification
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getRingingCallNotification(
+        ringingState: RingingState,
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        shouldHaveContentIntent: Boolean = true,
+    ): Notification? {
+        return getRingingCallNotification(
+            ringingState,
+            callId,
+            callDisplayName,
+            shouldHaveContentIntent,
+            emptyMap(),
+        )
+    }
+
+    /**
+     * Customize the notification when you receive a push notification for Missed Call
+     *
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @return A [Notification] object customized for the missed call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    fun getMissedCallNotification(
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+    ): Notification? {
+        return getMissedCallNotification(callId, callDisplayName, emptyMap())
+    }
 
     /**
      * Temporary notification. Sometimes the system needs to show a notification while the call is not ready.
@@ -128,7 +292,7 @@ interface StreamNotificationProvider {
     fun getSettingUpCallNotification(): Notification?
 }
 
-interface StreamNotificationUpdatesProvider {
+interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderWithPayload {
 
     /**
      * Get subsequent updates to notifications.
@@ -145,9 +309,64 @@ interface StreamNotificationUpdatesProvider {
      * @param call The Stream call object.
      * @return A [Notification] object customized for the ongoing call.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
+    ): Notification? {
+        return updateOngoingCallNotification(call, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Update the ringing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ringing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    suspend fun updateOutgoingCallNotification(
+        call: Call,
+        callDisplayName: String?,
+    ): Notification? {
+        return updateOutgoingCallNotification(call, callDisplayName, emptyMap())
+    }
+
+    /**
+     * Update the ringing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ringing call.
+     */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
+    suspend fun updateIncomingCallNotification(
+        call: Call,
+        callDisplayName: String,
+    ): Notification? {
+        return updateIncomingCallNotification(call, callDisplayName, emptyMap())
+    }
+}
+
+interface StreamNotificationUpdatesProviderWithPayload {
+
+    /**
+     * Update the ongoing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    suspend fun updateOngoingCallNotification(
+        call: Call,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -159,6 +378,7 @@ interface StreamNotificationUpdatesProvider {
     suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -170,13 +390,15 @@ interface StreamNotificationUpdatesProvider {
     suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification?
 }
 
 /**
  * Interceptor for notification builders.
  */
-open class StreamNotificationBuilderInterceptors {
+open class StreamNotificationBuilderInterceptors :
+    StreamNotificationBuilderInterceptorsWithPayload() {
 
     /**
      * Intercept the notification builder and modify it before it is posted.
@@ -188,6 +410,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param callerName The name of the caller to display in the notification.
      * @param shouldHaveContentIntent If true, clicking the notification triggers [fullScreenPendingIntent].
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildIncomingCallNotification(
         builder: NotificationCompat.Builder,
         fullScreenPendingIntent: PendingIntent,
@@ -207,6 +433,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param isOutgoingCall True if the call is outgoing, false if it is an active call.
      * @param remoteParticipantCount Count of remote participant.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildOngoingCallNotification(
         builder: NotificationCompat.Builder,
         callId: StreamCallId,
@@ -230,6 +460,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param builder The notification builder.
      * @param callDisplayName The name of the caller to display in the notification.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildMissedCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String?,
@@ -246,6 +480,10 @@ open class StreamNotificationBuilderInterceptors {
      * @param callDisplayName The name of the caller to display in the notification
      * @param shouldHaveContentIntent If set to true then it will launch a screen when the user will click on the notification
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open fun onBuildOutgoingCallNotification(
         builder: NotificationCompat.Builder,
         ringingState: RingingState,
@@ -309,10 +547,88 @@ open class StreamNotificationBuilderInterceptors {
     }
 }
 
+open class StreamNotificationBuilderInterceptorsWithPayload {
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param fullScreenPendingIntent A high-priority intent that launches an activity in full-screen mode, bypassing the lock screen.
+     * @param acceptCallPendingIntent The intent triggered when accepting the call from the notification.
+     * @param rejectCallPendingIntent The intent triggered when rejecting the call from the notification.
+     * @param callerName The name of the caller to display in the notification.
+     * @param shouldHaveContentIntent If true, clicking the notification triggers [fullScreenPendingIntent].
+     */
+    open fun onBuildIncomingCallNotification(
+        builder: NotificationCompat.Builder,
+        fullScreenPendingIntent: PendingIntent,
+        acceptCallPendingIntent: PendingIntent,
+        rejectCallPendingIntent: PendingIntent,
+        callerName: String?,
+        shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     * @param isOutgoingCall True if the call is outgoing, false if it is an active call.
+     * @param remoteParticipantCount Count of remote participant.
+     */
+    open fun onBuildOngoingCallNotification(
+        builder: NotificationCompat.Builder,
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        isOutgoingCall: Boolean = false,
+        remoteParticipantCount: Int = 0,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     */
+    open fun onBuildMissedCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String?,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param ringingState The current state of ringing call, represented by [RingingState]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param shouldHaveContentIntent If set to true then it will launch a screen when the user will click on the notification
+     */
+    open fun onBuildOutgoingCallNotification(
+        builder: NotificationCompat.Builder,
+        ringingState: RingingState,
+        callId: StreamCallId,
+        callDisplayName: String? = null,
+        shouldHaveContentIntent: Boolean = true,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+}
+
 /**
  * Interceptor for notification updates.
  */
-open class StreamNotificationUpdateInterceptors {
+open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterceptorsWithPayload() {
 
     /**
      * Intercept the notification builder and modify it before it is posted.
@@ -321,6 +637,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification.
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateOngoingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -336,6 +656,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification.
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateOngoingCallMediaNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -351,6 +675,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateOutgoingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -366,6 +694,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param callDisplayName The name of the caller to display in the notification
      * @param call the stream call
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateIncomingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -381,6 +713,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param call The Stream call object.
      * @param callDisplayName The name of the caller to display in the notification.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateMediaNotificationMetadata(
         builder: MediaMetadataCompat.Builder,
         call: Call,
@@ -396,6 +732,10 @@ open class StreamNotificationUpdateInterceptors {
      * @param call The Stream call object.
      * @param callDisplayName The name of the caller to display in the notification.
      */
+    @Deprecated(
+        "Use the one with payload: Map<String, Any?>",
+        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+    )
     open suspend fun onUpdateMediaNotificationPlaybackState(
         builder: PlaybackStateCompat.Builder,
         call: Call,
@@ -415,5 +755,104 @@ open class StreamNotificationUpdateInterceptors {
         channelId: String,
     ): MediaSessionCompat? {
         return null
+    }
+}
+
+open class StreamNotificationUpdateInterceptorsWithPayload {
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     * @param call the stream call
+     */
+    open suspend fun onUpdateOngoingCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification.
+     * @param call the stream call
+     */
+    open suspend fun onUpdateOngoingCallMediaNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param call the stream call
+     */
+    open suspend fun onUpdateOutgoingCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the notification builder and modify it before it is posted.
+     *
+     * @param builder The notification builder.
+     * @param callDisplayName The name of the caller to display in the notification
+     * @param call the stream call
+     */
+    open suspend fun onUpdateIncomingCallNotification(
+        builder: NotificationCompat.Builder,
+        callDisplayName: String? = null,
+        call: Call,
+        payload: Map<String, Any?>,
+    ): NotificationCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the media notification metadata builder and modify it before it is posted for updating.
+     *
+     * @param builder The media metadata builder.
+     * @param call The Stream call object.
+     * @param callDisplayName The name of the caller to display in the notification.
+     */
+    open suspend fun onUpdateMediaNotificationMetadata(
+        builder: MediaMetadataCompat.Builder,
+        call: Call,
+        callDisplayName: String? = null,
+        payload: Map<String, Any?>,
+    ): MediaMetadataCompat.Builder {
+        return builder
+    }
+
+    /**
+     * Intercept the media notification playback state builder and modify it before it is posted for updating.
+     *
+     * @param builder The media playback state builder.
+     * @param call The Stream call object.
+     * @param callDisplayName The name of the caller to display in the notification.
+     */
+    open suspend fun onUpdateMediaNotificationPlaybackState(
+        builder: PlaybackStateCompat.Builder,
+        call: Call,
+        callDisplayName: String? = null,
+        payload: Map<String, Any?>,
+    ): PlaybackStateCompat.Builder {
+        return builder
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -69,6 +69,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
         onRingingCall(callId, callDisplayName, emptyMap())
@@ -82,6 +83,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
         onMissedCall(callId, callDisplayName, emptyMap())
@@ -95,6 +97,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun onNotification(callId: StreamCallId, callDisplayName: String) {
         onNotification(callId, callDisplayName, emptyMap())
@@ -108,6 +111,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
         onLiveCall(callId, callDisplayName, emptyMap())
@@ -193,6 +197,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun getIncomingCallNotification(
         fullScreenPendingIntent: PendingIntent,
@@ -222,6 +227,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun getOngoingCallNotification(
         callId: StreamCallId,
@@ -249,6 +255,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun getRingingCallNotification(
         ringingState: RingingState,
@@ -275,6 +282,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     fun getMissedCallNotification(
         callId: StreamCallId,
@@ -312,6 +320,7 @@ interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderW
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     suspend fun updateOngoingCallNotification(
         call: Call,
@@ -329,6 +338,7 @@ interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderW
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     suspend fun updateOutgoingCallNotification(
         call: Call,
@@ -346,6 +356,7 @@ interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderW
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     suspend fun updateIncomingCallNotification(
         call: Call,
@@ -413,6 +424,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open fun onBuildIncomingCallNotification(
         builder: NotificationCompat.Builder,
@@ -436,6 +448,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open fun onBuildOngoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -463,6 +476,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open fun onBuildMissedCallNotification(
         builder: NotificationCompat.Builder,
@@ -483,6 +497,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open fun onBuildOutgoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -640,6 +655,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open suspend fun onUpdateOngoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -659,6 +675,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open suspend fun onUpdateOngoingCallMediaNotification(
         builder: NotificationCompat.Builder,
@@ -678,6 +695,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open suspend fun onUpdateOutgoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -697,6 +715,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open suspend fun onUpdateIncomingCallNotification(
         builder: NotificationCompat.Builder,
@@ -716,6 +735,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open suspend fun onUpdateMediaNotificationMetadata(
         builder: MediaMetadataCompat.Builder,
@@ -735,6 +755,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
+        level = DeprecationLevel.ERROR,
     )
     open suspend fun onUpdateMediaNotificationPlaybackState(
         builder: PlaybackStateCompat.Builder,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -27,38 +27,6 @@ import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.RingingState
 import io.getstream.video.android.model.StreamCallId
 
-interface StreamNotificationHandlerWithPayload {
-    /**
-     * Customize the notification when you receive a push notification for ringing call,
-     * which has further two types [RingingState.Incoming] and [RingingState.Outgoing]
-     * @param callId An instance of [StreamCallId] representing the call identifier
-     * @param callDisplayName The name of the caller to display in the notification
-     */
-
-    fun onRingingCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
-
-    /**
-     * Customize the notification when you receive a push notification for Missed Call
-     * @param callId An instance of [StreamCallId] representing the call identifier
-     * @param callDisplayName The name of the caller to display in the notification
-     */
-    fun onMissedCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
-
-    /**
-     * Customize the notification when you receive a push notification for general usage
-     * @param callId An instance of [StreamCallId] representing the call identifier
-     * @param callDisplayName The name of the caller to display in the notification
-     */
-    fun onNotification(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
-
-    /**
-     * Customize the notification when you receive a push notification for Live Call
-     * @param callId An instance of [StreamCallId] representing the call identifier
-     * @param callDisplayName The name of the caller to display in the notification
-     */
-    fun onLiveCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
-}
-
 interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     /**
      * Customize the notification when you receive a push notification for ringing call,
@@ -116,6 +84,38 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
         onLiveCall(callId, callDisplayName, emptyMap())
     }
+}
+
+interface StreamNotificationHandlerWithPayload {
+    /**
+     * Customize the notification when you receive a push notification for ringing call,
+     * which has further two types [RingingState.Incoming] and [RingingState.Outgoing]
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+
+    fun onRingingCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
+
+    /**
+     * Customize the notification when you receive a push notification for Missed Call
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    fun onMissedCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
+
+    /**
+     * Customize the notification when you receive a push notification for general usage
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    fun onNotification(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
+
+    /**
+     * Customize the notification when you receive a push notification for Live Call
+     * @param callId An instance of [StreamCallId] representing the call identifier
+     * @param callDisplayName The name of the caller to display in the notification
+     */
+    fun onLiveCall(callId: StreamCallId, callDisplayName: String, payload: Map<String, Any?>)
 }
 
 interface StreamNotificationProviderWithPayload {
@@ -180,6 +180,51 @@ interface StreamNotificationProviderWithPayload {
         callId: StreamCallId,
         callDisplayName: String? = null,
         payload: Map<String, Any?>,
+    ): Notification?
+}
+
+interface StreamNotificationUpdatesProvider {
+
+    /**
+     * Get subsequent updates to notifications.
+     * Initially, notifications are posted by one of the other methods, and then this method can be used to re-post them with updated content.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    suspend fun onCallNotificationUpdate(call: Call): Notification?
+
+    /**
+     * Update the ongoing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ongoing call.
+     */
+    suspend fun updateOngoingCallNotification(
+        call: Call,
+        callDisplayName: String,
+    ): Notification?
+
+    /**
+     * Update the ringing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ringing call.
+     */
+    suspend fun updateOutgoingCallNotification(
+        call: Call,
+        callDisplayName: String?,
+    ): Notification?
+
+    /**
+     * Update the ringing call notification.
+     *
+     * @param call The Stream call object.
+     * @return A [Notification] object customized for the ringing call.
+     */
+    suspend fun updateIncomingCallNotification(
+        call: Call,
+        callDisplayName: String,
     ): Notification?
 }
 
@@ -304,51 +349,6 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
      * @return A [Notification] object.
      */
     fun getSettingUpCallNotification(): Notification?
-}
-
-interface StreamNotificationUpdatesProvider {
-
-    /**
-     * Get subsequent updates to notifications.
-     * Initially, notifications are posted by one of the other methods, and then this method can be used to re-post them with updated content.
-     *
-     * @param call The Stream call object.
-     * @return A [Notification] object customized for the ongoing call.
-     */
-    suspend fun onCallNotificationUpdate(call: Call): Notification?
-
-    /**
-     * Update the ongoing call notification.
-     *
-     * @param call The Stream call object.
-     * @return A [Notification] object customized for the ongoing call.
-     */
-    suspend fun updateOngoingCallNotification(
-        call: Call,
-        callDisplayName: String,
-    ): Notification?
-
-    /**
-     * Update the ringing call notification.
-     *
-     * @param call The Stream call object.
-     * @return A [Notification] object customized for the ringing call.
-     */
-    suspend fun updateOutgoingCallNotification(
-        call: Call,
-        callDisplayName: String?,
-    ): Notification?
-
-    /**
-     * Update the ringing call notification.
-     *
-     * @param call The Stream call object.
-     * @return A [Notification] object customized for the ringing call.
-     */
-    suspend fun updateIncomingCallNotification(
-        call: Call,
-        callDisplayName: String,
-    ): Notification?
 }
 
 /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -69,7 +69,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
         onRingingCall(callId, callDisplayName, emptyMap())
@@ -83,7 +83,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
         onMissedCall(callId, callDisplayName, emptyMap())
@@ -97,7 +97,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun onNotification(callId: StreamCallId, callDisplayName: String) {
         onNotification(callId, callDisplayName, emptyMap())
@@ -111,7 +111,7 @@ interface StreamNotificationHandler : StreamNotificationHandlerWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
         onLiveCall(callId, callDisplayName, emptyMap())
@@ -197,7 +197,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun getIncomingCallNotification(
         fullScreenPendingIntent: PendingIntent,
@@ -227,7 +227,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun getOngoingCallNotification(
         callId: StreamCallId,
@@ -255,7 +255,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun getRingingCallNotification(
         ringingState: RingingState,
@@ -282,7 +282,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     fun getMissedCallNotification(
         callId: StreamCallId,
@@ -320,7 +320,7 @@ interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderW
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     suspend fun updateOngoingCallNotification(
         call: Call,
@@ -338,7 +338,7 @@ interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderW
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     suspend fun updateOutgoingCallNotification(
         call: Call,
@@ -356,7 +356,7 @@ interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderW
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     suspend fun updateIncomingCallNotification(
         call: Call,
@@ -424,7 +424,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open fun onBuildIncomingCallNotification(
         builder: NotificationCompat.Builder,
@@ -448,7 +448,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open fun onBuildOngoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -476,7 +476,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open fun onBuildMissedCallNotification(
         builder: NotificationCompat.Builder,
@@ -497,7 +497,7 @@ open class StreamNotificationBuilderInterceptors :
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open fun onBuildOutgoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -655,7 +655,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open suspend fun onUpdateOngoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -675,7 +675,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open suspend fun onUpdateOngoingCallMediaNotification(
         builder: NotificationCompat.Builder,
@@ -695,7 +695,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open suspend fun onUpdateOutgoingCallNotification(
         builder: NotificationCompat.Builder,
@@ -715,7 +715,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open suspend fun onUpdateIncomingCallNotification(
         builder: NotificationCompat.Builder,
@@ -735,7 +735,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open suspend fun onUpdateMediaNotificationMetadata(
         builder: MediaMetadataCompat.Builder,
@@ -755,7 +755,7 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
     @Deprecated(
         "Use the one with payload: Map<String, Any?>",
         replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.ERROR,
+        level = DeprecationLevel.WARNING,
     )
     open suspend fun onUpdateMediaNotificationPlaybackState(
         builder: PlaybackStateCompat.Builder,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -300,7 +300,7 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
     fun getSettingUpCallNotification(): Notification?
 }
 
-interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderWithPayload {
+interface StreamNotificationUpdatesProvider {
 
     /**
      * Get subsequent updates to notifications.
@@ -317,67 +317,9 @@ interface StreamNotificationUpdatesProvider : StreamNotificationUpdatesProviderW
      * @param call The Stream call object.
      * @return A [Notification] object customized for the ongoing call.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
-    ): Notification? {
-        return updateOngoingCallNotification(call, callDisplayName, emptyMap())
-    }
-
-    /**
-     * Update the ringing call notification.
-     *
-     * @param call The Stream call object.
-     * @return A [Notification] object customized for the ringing call.
-     */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
-    suspend fun updateOutgoingCallNotification(
-        call: Call,
-        callDisplayName: String?,
-    ): Notification? {
-        return updateOutgoingCallNotification(call, callDisplayName, emptyMap())
-    }
-
-    /**
-     * Update the ringing call notification.
-     *
-     * @param call The Stream call object.
-     * @return A [Notification] object customized for the ringing call.
-     */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
-    suspend fun updateIncomingCallNotification(
-        call: Call,
-        callDisplayName: String,
-    ): Notification? {
-        return updateIncomingCallNotification(call, callDisplayName, emptyMap())
-    }
-}
-
-interface StreamNotificationUpdatesProviderWithPayload {
-
-    /**
-     * Update the ongoing call notification.
-     *
-     * @param call The Stream call object.
-     * @return A [Notification] object customized for the ongoing call.
-     */
-    suspend fun updateOngoingCallNotification(
-        call: Call,
-        callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -389,7 +331,6 @@ interface StreamNotificationUpdatesProviderWithPayload {
     suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
-        payload: Map<String, Any?>,
     ): Notification?
 
     /**
@@ -401,7 +342,6 @@ interface StreamNotificationUpdatesProviderWithPayload {
     suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification?
 }
 
@@ -643,7 +583,7 @@ open class StreamNotificationBuilderInterceptorsWithPayload {
 /**
  * Interceptor for notification updates.
  */
-open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterceptorsWithPayload() {
+open class StreamNotificationUpdateInterceptors {
 
     /**
      * Intercept the notification builder and modify it before it is posted.
@@ -652,11 +592,6 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
      * @param callDisplayName The name of the caller to display in the notification.
      * @param call the stream call
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     open suspend fun onUpdateOngoingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -672,11 +607,6 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
      * @param callDisplayName The name of the caller to display in the notification.
      * @param call the stream call
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     open suspend fun onUpdateOngoingCallMediaNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -692,11 +622,6 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
      * @param callDisplayName The name of the caller to display in the notification
      * @param call the stream call
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     open suspend fun onUpdateOutgoingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -712,11 +637,6 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
      * @param callDisplayName The name of the caller to display in the notification
      * @param call the stream call
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     open suspend fun onUpdateIncomingCallNotification(
         builder: NotificationCompat.Builder,
         callDisplayName: String? = null,
@@ -732,11 +652,6 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
      * @param call The Stream call object.
      * @param callDisplayName The name of the caller to display in the notification.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     open suspend fun onUpdateMediaNotificationMetadata(
         builder: MediaMetadataCompat.Builder,
         call: Call,
@@ -752,11 +667,6 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
      * @param call The Stream call object.
      * @param callDisplayName The name of the caller to display in the notification.
      */
-    @Deprecated(
-        "Use the one with payload: Map<String, Any?>",
-        replaceWith = ReplaceWith("Use the one with payload: Map<String, Any?>"),
-        level = DeprecationLevel.WARNING,
-    )
     open suspend fun onUpdateMediaNotificationPlaybackState(
         builder: PlaybackStateCompat.Builder,
         call: Call,
@@ -776,104 +686,5 @@ open class StreamNotificationUpdateInterceptors : StreamNotificationUpdateInterc
         channelId: String,
     ): MediaSessionCompat? {
         return null
-    }
-}
-
-open class StreamNotificationUpdateInterceptorsWithPayload {
-
-    /**
-     * Intercept the notification builder and modify it before it is posted.
-     *
-     * @param builder The notification builder.
-     * @param callDisplayName The name of the caller to display in the notification.
-     * @param call the stream call
-     */
-    open suspend fun onUpdateOngoingCallNotification(
-        builder: NotificationCompat.Builder,
-        callDisplayName: String? = null,
-        call: Call,
-        payload: Map<String, Any?>,
-    ): NotificationCompat.Builder {
-        return builder
-    }
-
-    /**
-     * Intercept the notification builder and modify it before it is posted.
-     *
-     * @param builder The notification builder.
-     * @param callDisplayName The name of the caller to display in the notification.
-     * @param call the stream call
-     */
-    open suspend fun onUpdateOngoingCallMediaNotification(
-        builder: NotificationCompat.Builder,
-        callDisplayName: String? = null,
-        call: Call,
-        payload: Map<String, Any?>,
-    ): NotificationCompat.Builder {
-        return builder
-    }
-
-    /**
-     * Intercept the notification builder and modify it before it is posted.
-     *
-     * @param builder The notification builder.
-     * @param callDisplayName The name of the caller to display in the notification
-     * @param call the stream call
-     */
-    open suspend fun onUpdateOutgoingCallNotification(
-        builder: NotificationCompat.Builder,
-        callDisplayName: String? = null,
-        call: Call,
-        payload: Map<String, Any?>,
-    ): NotificationCompat.Builder {
-        return builder
-    }
-
-    /**
-     * Intercept the notification builder and modify it before it is posted.
-     *
-     * @param builder The notification builder.
-     * @param callDisplayName The name of the caller to display in the notification
-     * @param call the stream call
-     */
-    open suspend fun onUpdateIncomingCallNotification(
-        builder: NotificationCompat.Builder,
-        callDisplayName: String? = null,
-        call: Call,
-        payload: Map<String, Any?>,
-    ): NotificationCompat.Builder {
-        return builder
-    }
-
-    /**
-     * Intercept the media notification metadata builder and modify it before it is posted for updating.
-     *
-     * @param builder The media metadata builder.
-     * @param call The Stream call object.
-     * @param callDisplayName The name of the caller to display in the notification.
-     */
-    open suspend fun onUpdateMediaNotificationMetadata(
-        builder: MediaMetadataCompat.Builder,
-        call: Call,
-        callDisplayName: String? = null,
-        payload: Map<String, Any?>,
-    ): MediaMetadataCompat.Builder {
-        return builder
-    }
-
-    /**
-     * Intercept the media notification playback state builder and modify it before it is posted for updating.
-     *
-     * @param builder The media playback state builder.
-     * @param call The Stream call object.
-     * @param callDisplayName The name of the caller to display in the notification.
-     */
-    open suspend fun onUpdateMediaNotificationPlaybackState(
-        builder: PlaybackStateCompat.Builder,
-        call: Call,
-        callDisplayName: String? = null,
-        payload: Map<String, Any?>,
-    ): PlaybackStateCompat.Builder {
-        return builder
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
@@ -84,19 +84,16 @@ internal object NoOpNotificationHandler : NotificationHandler {
     override suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
-        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
-        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getRingingCallNotification(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
@@ -30,19 +30,36 @@ import io.getstream.video.android.model.User
 import kotlinx.coroutines.CoroutineScope
 
 internal object NoOpNotificationHandler : NotificationHandler {
-    override fun onRingingCall(callId: StreamCallId, callDisplayName: String) {
+
+    override fun onRingingCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
-    override fun onMissedCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onMissedCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
-    override fun onNotification(callId: StreamCallId, callDisplayName: String) {
+    override fun onNotification(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
-    override fun onLiveCall(callId: StreamCallId, callDisplayName: String) {
+    override fun onLiveCall(
+        callId: StreamCallId,
+        callDisplayName: String,
+        payload: Map<String, Any?>,
+    ) {
         /* NoOp */
     }
 
@@ -52,6 +69,7 @@ internal object NoOpNotificationHandler : NotificationHandler {
         rejectCallPendingIntent: PendingIntent,
         callerName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getOngoingCallNotification(
@@ -59,22 +77,26 @@ internal object NoOpNotificationHandler : NotificationHandler {
         callDisplayName: String?,
         isOutgoingCall: Boolean,
         remoteParticipantCount: Int,
+        payload: Map<String, Any?>,
     ): Notification? = null
-
     override suspend fun onCallNotificationUpdate(call: Call): Notification? = null
+
     override suspend fun updateOngoingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateOutgoingCallNotification(
         call: Call,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override suspend fun updateIncomingCallNotification(
         call: Call,
         callDisplayName: String,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getRingingCallNotification(
@@ -82,11 +104,13 @@ internal object NoOpNotificationHandler : NotificationHandler {
         callId: StreamCallId,
         callDisplayName: String?,
         shouldHaveContentIntent: Boolean,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getMissedCallNotification(
         callId: StreamCallId,
         callDisplayName: String?,
+        payload: Map<String, Any?>,
     ): Notification? = null
 
     override fun getSettingUpCallNotification(): Notification? = null
@@ -124,6 +148,7 @@ internal object NoOpNotificationHandler : NotificationHandler {
         callId: StreamCallId,
         mediaNotificationConfig: MediaNotificationConfig,
         remoteParticipantCount: Int,
+
     ): NotificationCompat.Builder? {
         return null
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -62,22 +62,22 @@ internal class VideoPushDelegate : PushDelegate() {
 
     private fun handleRingType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("ring-type-notification")?.onRingingCall(callId, callDisplayName)
+        getStreamVideo("ring-type-notification")?.onRingingCall(callId, callDisplayName, payload)
     }
 
     private fun handleMissedType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("missed-type-notification")?.onMissedCall(callId, callDisplayName)
+        getStreamVideo("missed-type-notification")?.onMissedCall(callId, callDisplayName, payload)
     }
 
     private fun handleNotificationType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("generic-notification")?.onNotification(callId, callDisplayName)
+        getStreamVideo("generic-notification")?.onNotification(callId, callDisplayName, payload)
     }
 
     private fun handleLiveStartedType(callId: StreamCallId, payload: Map<String, Any?>) {
         val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
-        getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName)
+        getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName, payload)
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/RejectCallBroadcastReceiver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/receivers/RejectCallBroadcastReceiver.kt
@@ -39,8 +39,17 @@ internal class RejectCallBroadcastReceiver : GenericCallActionBroadcastReceiver(
 
     override suspend fun onReceive(call: Call, context: Context, intent: Intent) {
         when (val rejectResult = call.reject(RejectReason.Decline)) {
-            is Result.Success -> logger.d { "[onReceive] rejectCall, Success: $rejectResult" }
-            is Result.Failure -> logger.d { "[onReceive] rejectCall, Failure: $rejectResult" }
+            is Result.Success -> {
+                val userId = StreamVideo.instanceOrNull()?.userId
+                userId?.let {
+                    val set = mutableSetOf(it)
+                    call.state.updateRejectedBy(set)
+                }
+                logger.d { "[onReceive] rejectCall, Success: $rejectResult" }
+            }
+            is Result.Failure -> {
+                logger.d { "[onReceive] rejectCall, Failure: $rejectResult" }
+            }
         }
         logger.d { "[onReceive] #ringing; callId: ${call.id}, action: ${intent.action}" }
         CallService.removeIncomingCall(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -417,6 +417,7 @@ internal open class CallService : Service() {
                     first = streamVideo.getOngoingCallNotification(
                         callId = streamCallId,
                         callDisplayName = intentCallDisplayName,
+                        payload = emptyMap(),
                     ),
                     second = streamCallId.hashCode(),
                 )
@@ -432,6 +433,7 @@ internal open class CallService : Service() {
                         callId = streamCallId,
                         callDisplayName = intentCallDisplayName,
                         shouldHaveContentIntent = shouldHaveContentIntent,
+                        payload = emptyMap(),
                     ),
                     second = INCOMING_CALL_NOTIFICATION_ID,
                 )
@@ -446,6 +448,7 @@ internal open class CallService : Service() {
                         callDisplayName = getString(
                             R.string.stream_video_outgoing_call_notification_title,
                         ),
+                        payload = emptyMap(),
                     ),
                     second = INCOMING_CALL_NOTIFICATION_ID, // Same for incoming and outgoing
                 )

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/service/CallServiceTest.kt
@@ -58,6 +58,9 @@ class CallServiceTest {
     @MockK
     lateinit var mockNotification: Notification
 
+    @MockK
+    lateinit var payload: Map<String, Any?>
+
     private lateinit var context: Context
     private lateinit var callService: CallService
     private lateinit var testCallId: StreamCallId
@@ -216,7 +219,9 @@ class CallServiceTest {
     @Test
     fun `getNotificationPair returns correct data for ongoing call`() {
         // Given
-        every { mockStreamVideoClient.getOngoingCallNotification(any(), any()) } returns mockNotification
+        every {
+            mockStreamVideoClient.getOngoingCallNotification(any(), any(), payload = any())
+        } returns mockNotification
 
         // When
         val result = callService.getNotificationPair(
@@ -240,7 +245,7 @@ class CallServiceTest {
             every { value } returns null
         }
         every {
-            mockStreamVideoClient.getRingingCallNotification(any(), any(), any(), any())
+            mockStreamVideoClient.getRingingCallNotification(any(), any(), any(), any(), any())
         } returns mockNotification
 
         // When

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -354,7 +354,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         granted: List<String>,
         notGranted: List<String>,
     ) {
-        if (!showRationale && configuration.canSkipPermissionRationale) {
+        if (!showRationale && configurationMap[call.cid]?.canSkipPermissionRationale == true) {
             logger.w { "Permissions were not granted, but rationale is required to be skipped." }
             safeFinish()
         } else {
@@ -375,7 +375,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         val connection by call.state.connection.collectAsStateWithLifecycle()
         when (connection) {
             RealtimeConnection.Disconnected -> {
-                if (!configuration.closeScreenOnCallEnded) {
+                if (configurationMap[call.cid]?.closeScreenOnCallEnded == false) {
                     CallDisconnectedContent(call)
                 } else {
                     // This is just for safety, will be called from other place as well.
@@ -384,7 +384,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
             }
 
             is RealtimeConnection.Failed -> {
-                if (!configuration.closeScreenOnError) {
+                if (configurationMap[call.cid]?.closeScreenOnError == false) {
                     val err = Exception("${(connection as? RealtimeConnection.Failed)?.error}")
                     CallFailedContent(call, err)
                 } else {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -327,8 +327,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                         val configuration = configurationMap[call.id]
                         if (configuration?.closeScreenOnCallEnded == true) {
                             safeFinish()
-                        }
-                        else {
+                        } else {
                             logger.d { "Don't close activity as some other call is active" }
                         }
                     }

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -94,6 +94,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	protected fun getCallTransitionTime ()J
 	protected final fun getConfig ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	public fun getConfiguration ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
+	public final fun getConfigurationMap ()Ljava/util/HashMap;
 	protected final fun getOnErrorFinish ()Lkotlin/jvm/functions/Function2;
 	protected final fun getOnSuccessFinish ()Lkotlin/jvm/functions/Function2;
 	public abstract fun getUiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -90,16 +90,16 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun end (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public final fun enterPictureInPicture ()V
 	public fun get (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
-	protected final fun getCallHandlerDelegate ()Lio/getstream/video/android/ui/common/IncomingCallHandlerDelegate;
-	protected final fun getCallTransitionTime ()J
+	protected fun getCallHandlerDelegate ()Lio/getstream/video/android/ui/common/IncomingCallHandlerDelegate;
+	protected fun getCallTransitionTime ()J
 	protected final fun getConfig ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	public fun getConfiguration ()Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;
 	protected final fun getOnErrorFinish ()Lkotlin/jvm/functions/Function2;
 	protected final fun getOnSuccessFinish ()Lkotlin/jvm/functions/Function2;
 	public abstract fun getUiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
-	protected final fun handleOnNewIncomingCallAcceptAction ()V
-	protected final fun handleOnNewIntentAction (Landroid/content/Intent;)V
-	protected final fun isCurrentAcceptedCall (Lio/getstream/video/android/core/Call;)Z
+	protected fun handleOnNewIncomingCallAcceptAction ()V
+	protected fun handleOnNewIntentAction (Landroid/content/Intent;)V
+	protected fun isCurrentAcceptedCall (Lio/getstream/video/android/core/Call;)Z
 	public fun isVideoCall (Lio/getstream/video/android/core/Call;)Z
 	public fun join (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public fun leave (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
@@ -129,12 +129,14 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun onUserLeaveHint (Lio/getstream/video/android/core/Call;)V
 	public fun reject (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/model/RejectReason;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public final fun safeFinish ()V
-	protected final fun setCallHandlerDelegate (Lio/getstream/video/android/ui/common/IncomingCallHandlerDelegate;)V
+	protected fun setCallHandlerDelegate (Lio/getstream/video/android/ui/common/IncomingCallHandlerDelegate;)V
 }
 
 public final class io/getstream/video/android/ui/common/StreamCallActivity$Companion {
 	public final fun callIntent (Landroid/content/Context;Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLjava/lang/String;Ljava/lang/Class;Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;Landroid/os/Bundle;)Landroid/content/Intent;
 	public static synthetic fun callIntent$default (Lio/getstream/video/android/ui/common/StreamCallActivity$Companion;Landroid/content/Context;Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLjava/lang/String;Ljava/lang/Class;Lio/getstream/video/android/ui/common/StreamCallActivityConfiguration;Landroid/os/Bundle;ILjava/lang/Object;)Landroid/content/Intent;
+	public final fun callIntentBundle (Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLio/getstream/video/android/ui/common/StreamCallActivityConfiguration;Landroid/os/Bundle;)Landroid/os/Bundle;
+	public static synthetic fun callIntentBundle$default (Lio/getstream/video/android/ui/common/StreamCallActivity$Companion;Lio/getstream/video/android/model/StreamCallId;Ljava/util/List;ZLio/getstream/video/android/ui/common/StreamCallActivityConfiguration;Landroid/os/Bundle;ILjava/lang/Object;)Landroid/os/Bundle;
 }
 
 public final class io/getstream/video/android/ui/common/StreamCallActivityConfiguration {

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -177,7 +177,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
      * You can get Call id via
      * `intent?.streamCallId(NotificationHandler.INTENT_EXTRA_CALL_CID)?.id`
      */
-    private val configurationMap: HashMap<String, StreamCallActivityConfiguration> =
+    public val configurationMap: HashMap<String, StreamCallActivityConfiguration> =
         HashMap()
 
     private var cachedCallEventJob: Job? = null
@@ -193,11 +193,13 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
             if (configuration?.closeScreenOnCallEnded == true) {
                 safeFinish()
             }
+        } else {
+            logger.d { "[onSuccessFinish] for non-active call" }
         }
     }
 
     /**
-     * The Exception is `StreamCallActivityException`. We will update the args in next major release
+     * The Exception is [StreamCallActivityException]. We will update the args in next major release
      */
     protected val onErrorFinish: suspend (Exception) -> Unit = { error ->
         logger.e(error) { "Something went wrong" }
@@ -213,6 +215,13 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
             }
         } else {
             // older version ~ this flow might never going to be execute (Need to check)
+            } else {
+                logger.e(error) { "[onErrorFinish] for non-active call" }
+            }
+        } else {
+            /**
+             * This will execute when we got a error before creating the call object
+             */
             if (config.closeScreenOnError) {
                 logger.e(error) { "Finishing the activity" }
                 safeFinish()

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -212,9 +212,6 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
                     logger.e(error) { "Finishing the activity" }
                     safeFinish()
                 }
-            }
-        } else {
-            // older version ~ this flow might never going to be execute (Need to check)
             } else {
                 logger.e(error) { "[onErrorFinish] for non-active call" }
             }


### PR DESCRIPTION
### 🎯 Goal

Improve call rejection from Notification Button

### 🛠 Implementation details

The UI will observe `Call.state.rejectedBy` if it is self then the code will try to close the activity if there is no active call

```kotlin
/**
           * Call can be rejected by [RejectCallBroadcastReceiver] so the activity
           * needs to observe [Call.state.rejectedBy]
           */
          val rejectedBy by call.state.rejectedBy.collectAsStateWithLifecycle()
          LaunchedEffect(rejectedBy) {
              val currentUserId = StreamVideo.instanceOrNull()?.userId
              if (rejectedBy.contains(currentUserId)) {
                  // check if there is no ongoing call then safely finish it else do nothing
                  val noActiveCall = (StreamVideo.instanceOrNull()?.state?.activeCall?.value == null)
                  if (noActiveCall) {
                      onEnded(call)
                      val configuration = configurationMap[call.id]
                      if (configuration?.closeScreenOnCallEnded == true) {
                          safeFinish()
                      } else {
                          logger.d { "Don't close activity as some other call is active" }
                      }
                  }
              }
          }
```

