### PR TITLE
Throw exception with message when we have non-ascii app name in headers

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
@@ -22,6 +22,7 @@ import io.getstream.video.android.core.BuildConfig
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.internal.InternalStreamVideoApi
+import io.getstream.video.android.core.utils.hasNonAsciiCharacters
 
 @InternalStreamVideoApi
 class HeadersUtil {
@@ -55,16 +56,25 @@ class HeadersUtil {
      *
      * @return The application name or `"UnknownApp"` if retrieval fails.
      */
+    @Throws(IllegalArgumentException::class)
     private fun getAppName(): String {
         val context = getContext() ?: return "UnknownApp"
         val applicationInfo = context.applicationInfo
         val stringId = applicationInfo.labelRes
 
-        return if (stringId != 0) {
+        val appName = if (stringId != 0) {
             context.getString(stringId)
         } else {
             applicationInfo.nonLocalizedLabel?.toString() ?: "UnknownApp"
         }
+
+        if (appName.hasNonAsciiCharacters()) {
+            throw IllegalArgumentException(
+                "The application name contains non-ASCII characters. " +
+                    "Please provide an ASCII-only appName (e.g., 'MyApp') when initializing StreamVideoBuilder.",
+            )
+        }
+        return appName
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/StringUtils.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/utils/StringUtils.kt
@@ -32,3 +32,7 @@ internal fun StreamPeerType.stringify() = when (this) {
 internal fun String?.isWhitespaceOnly(): Boolean {
     return !this.isNullOrEmpty() && this.all { it.isWhitespace() }
 }
+
+internal fun String.hasNonAsciiCharacters(): Boolean {
+    return !this.all { it.code <= 127 }
+}


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Describe the implementation_
