### PR TITLE
Fixes issue where activity was closing unexpectedly 

### DIFF
--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -40,6 +40,7 @@ import androidx.compose.material.icons.filled.SignalWifiBad
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -113,16 +114,18 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
      * @param call the call
      */
     override fun setContent(activity: StreamCallActivity, call: Call) {
-        logger.d { "[setContent(activity, call)] invoked from compose delegate." }
+        logger.d { "[setContent(activity, call)] invoked from compose delegate, call_id:${call.id}" }
         activity.setContent {
-            VideoTheme {
-                Box(
-                    modifier = Modifier
-                        .background(VideoTheme.colors.baseSheetPrimary)
-                        .systemBarsPadding(),
-                ) {
-                    logger.d { "[setContent] with RootContent" }
-                    activity.RootContent(call = call)
+            key(call.id) {
+                VideoTheme {
+                    Box(
+                        modifier = Modifier
+                            .background(VideoTheme.colors.baseSheetPrimary)
+                            .systemBarsPadding(),
+                    ) {
+                        logger.d { "[setContent] with RootContent" }
+                        activity.RootContent(call = call)
+                    }
                 }
             }
         }
@@ -385,8 +388,16 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
     ) {
         val connection by call.state.connection.collectAsStateWithLifecycle()
         logger.d {
-            "[ConnectionAvailable], connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
+            "[ConnectionAvailable], Noob connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
         }
+        LaunchedEffect(call.id) {
+            val activeCall = StreamVideo.instanceOrNull()?.state?.activeCall?.value
+            val activeCallConnection = activeCall?.state?.connection?.value
+            logger.d {
+                "[ConnectionAvailable], LaunchedEffect, Noob connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, activeCall = ${activeCall?.id}, activeCallConnection=$activeCallConnection"
+            }
+        }
+
         when (connection) {
             RealtimeConnection.Disconnected -> {
                 if (isCurrentAcceptedCall(call)) {
@@ -394,7 +405,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     if (configuration?.closeScreenOnCallEnded == false) {
                         CallDisconnectedContent(call)
                     } else {
-                        logger.d { "[RealtimeConnection.Disconnected], call_id = ${call.id}" }
+                        logger.d { "[RealtimeConnection.Disconnected], Noob call_id = ${call.id}" }
                         safeFinish()
                     }
                 } else {
@@ -415,7 +426,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     }
                 } else {
                     // Do nothing, this block belongs to in-active call
-                    logger.d { "[RealtimeConnection.Failed] for in-active call, call_id = ${call.id}" }
+                    logger.d { "[RealtimeConnection.Failed] Noob for in-active call, call_id = ${call.id}" }
                 }
             }
 

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -388,13 +388,13 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
     ) {
         val connection by call.state.connection.collectAsStateWithLifecycle()
         logger.d {
-            "[ConnectionAvailable], Noob connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
+            "[ConnectionAvailable], connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
         }
         LaunchedEffect(call.id) {
             val activeCall = StreamVideo.instanceOrNull()?.state?.activeCall?.value
             val activeCallConnection = activeCall?.state?.connection?.value
             logger.d {
-                "[ConnectionAvailable], LaunchedEffect, Noob connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, activeCall = ${activeCall?.id}, activeCallConnection=$activeCallConnection"
+                "[ConnectionAvailable], LaunchedEffect, connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, activeCall = ${activeCall?.id}, activeCallConnection=$activeCallConnection"
             }
         }
 
@@ -405,7 +405,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     if (configuration?.closeScreenOnCallEnded == false) {
                         CallDisconnectedContent(call)
                     } else {
-                        logger.d { "[RealtimeConnection.Disconnected], Noob call_id = ${call.id}" }
+                        logger.d { "[RealtimeConnection.Disconnected], call_id = ${call.id}" }
                         safeFinish()
                     }
                 } else {
@@ -426,7 +426,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     }
                 } else {
                     // Do nothing, this block belongs to in-active call
-                    logger.d { "[RealtimeConnection.Failed] Noob for in-active call, call_id = ${call.id}" }
+                    logger.d { "[RealtimeConnection.Failed] for in-active call, call_id = ${call.id}" }
                 }
             }
 

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -390,6 +390,12 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         logger.d {
             "[ConnectionAvailable], connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
         }
+        /**
+         * We need [StreamCallActivity.isTransitioningToAnotherCall] because we leave a call first then join another
+         * withing the same Activity Lifecycle
+         * Now leaving a call can lead to emit [RealtimeConnection.Disconnected] which we don't want to observe when
+         * we know we are in transitioning to anotherCall
+         */
         val isTransitioningToAnotherCall by isTransitioningToAnotherCall.collectAsStateWithLifecycle()
         if (!isTransitioningToAnotherCall) {
             when (connection) {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -390,13 +390,6 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
         logger.d {
             "[ConnectionAvailable], connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
         }
-        LaunchedEffect(call.id) {
-            val activeCall = StreamVideo.instanceOrNull()?.state?.activeCall?.value
-            val activeCallConnection = activeCall?.state?.connection?.value
-            logger.d {
-                "[ConnectionAvailable], LaunchedEffect, connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, activeCall = ${activeCall?.id}, activeCallConnection=$activeCallConnection"
-            }
-        }
 
         when (connection) {
             RealtimeConnection.Disconnected -> {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -388,13 +388,13 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
     ) {
         val connection by call.state.connection.collectAsStateWithLifecycle()
         logger.d {
-            "[ConnectionAvailable], connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
+            "[ConnectionAvailable], Noob connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, this=$this"
         }
         LaunchedEffect(call.id) {
             val activeCall = StreamVideo.instanceOrNull()?.state?.activeCall?.value
             val activeCallConnection = activeCall?.state?.connection?.value
             logger.d {
-                "[ConnectionAvailable], LaunchedEffect, connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, activeCall = ${activeCall?.id}, activeCallConnection=$activeCallConnection"
+                "[ConnectionAvailable], LaunchedEffect, Noob connection: $connection call_id = ${call.id}, activity hashcode=${this.hashCode()}, activeCall = ${activeCall?.id}, activeCallConnection=$activeCallConnection"
             }
         }
 
@@ -405,7 +405,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     if (configuration?.closeScreenOnCallEnded == false) {
                         CallDisconnectedContent(call)
                     } else {
-                        logger.d { "[RealtimeConnection.Disconnected], call_id = ${call.id}" }
+                        logger.d { "[RealtimeConnection.Disconnected], Noob call_id = ${call.id}" }
                         safeFinish()
                     }
                 } else {
@@ -426,7 +426,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     }
                 } else {
                     // Do nothing, this block belongs to in-active call
-                    logger.d { "[RealtimeConnection.Failed] for in-active call, call_id = ${call.id}" }
+                    logger.d { "[RealtimeConnection.Failed] Noob for in-active call, call_id = ${call.id}" }
                 }
             }
 

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -101,6 +101,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	protected fun handleOnNewIncomingCallAcceptAction ()V
 	protected fun handleOnNewIntentAction (Landroid/content/Intent;)V
 	public fun isCurrentAcceptedCall (Lio/getstream/video/android/core/Call;)Z
+	public final fun isTransitioningToAnotherCall ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun isVideoCall (Lio/getstream/video/android/core/Call;)Z
 	public fun join (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public fun leave (Lio/getstream/video/android/core/Call;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -205,7 +205,6 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
                 logger.d { "[onSuccessFinish] for non-active call" }
             }
         }
-
     }
 
     /**
@@ -235,7 +234,6 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
                 }
             }
         }
-
     }
 
     /**

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -544,7 +544,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
 
         val streamCallId = intent?.streamCallId(NotificationHandler.INTENT_EXTRA_CALL_CID)
         streamCallId?.let {
-            logger.d { "[initializeConfig], call_id: ${it.id}, activity hashcode=${this.hashCode()}" }
+            logger.d { "[initializeConfig], Noob call_id: ${it.id}, activity hashcode=${this.hashCode()}" }
             configurationMap[it.id] = config
         }
     }
@@ -561,7 +561,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
         call: Call,
     ) {
         logger.d {
-            "[onCreate(Bundle,PersistableBundle,Call)], call_id:${call.id}, setting up compose delegate."
+            "[onCreate(Bundle,PersistableBundle,Call)] Noob, call_id:${call.id}, setting up compose delegate."
         }
         uiDelegate.setContent(this, call)
     }
@@ -807,7 +807,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
         onSuccess: (suspend (Call) -> Unit)?,
         onError: (suspend (Exception) -> Unit)?,
     ) {
-        logger.d { "[reject] #ringing; rejectReason: $reason, call_id: ${call.id}" }
+        logger.d { "[reject] Noob #ringing; rejectReason: $reason, call_id: ${call.id}" }
         val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         call.state.cancelTimeout()
         call.state.updateRejectedBy(mutableSetOf(StreamVideo.instance().userId))
@@ -1187,7 +1187,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
     public fun safeFinish() {
         if (!this.isFinishing && !isFinishingSafely) {
             isFinishingSafely = true
-            logger.d { "[safeFinish] call_id:${cachedCall.cid}" }
+            logger.d { "[safeFinish] Noob call_id:${cachedCall.cid}" }
             finish()
         }
     }

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -299,12 +299,12 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
                 null,
                 intent,
                 onSuccess = { instanceState, persistentState, call, action ->
+                    _isTransitioningToAnotherCall.value = false
                     logger.d { "Calling [onNewIntent(intent)], because call is initialized $call, action=$action" }
                     onIntentAction(call, action, onError = onErrorFinish) { successCall ->
                         applyDashboardSettings(successCall)
                         onCreate(instanceState, persistentState, successCall)
                     }
-                    _isTransitioningToAnotherCall.value = false
                 },
                 onError = {
                     // We are not calling onErrorFinish here on purpose

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -544,7 +544,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
 
         val streamCallId = intent?.streamCallId(NotificationHandler.INTENT_EXTRA_CALL_CID)
         streamCallId?.let {
-            logger.d { "[initializeConfig], Noob call_id: ${it.id}, activity hashcode=${this.hashCode()}" }
+            logger.d { "[initializeConfig], call_id: ${it.id}, activity hashcode=${this.hashCode()}" }
             configurationMap[it.id] = config
         }
     }
@@ -561,7 +561,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
         call: Call,
     ) {
         logger.d {
-            "[onCreate(Bundle,PersistableBundle,Call)] Noob, call_id:${call.id}, setting up compose delegate."
+            "[onCreate(Bundle,PersistableBundle,Call)], call_id:${call.id}, setting up compose delegate."
         }
         uiDelegate.setContent(this, call)
     }
@@ -807,7 +807,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
         onSuccess: (suspend (Call) -> Unit)?,
         onError: (suspend (Exception) -> Unit)?,
     ) {
-        logger.d { "[reject] Noob #ringing; rejectReason: $reason, call_id: ${call.id}" }
+        logger.d { "[reject] #ringing; rejectReason: $reason, call_id: ${call.id}" }
         val appScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
         call.state.cancelTimeout()
         call.state.updateRejectedBy(mutableSetOf(StreamVideo.instance().userId))
@@ -1187,7 +1187,7 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
     public fun safeFinish() {
         if (!this.isFinishing && !isFinishingSafely) {
             isFinishingSafely = true
-            logger.d { "[safeFinish] Noob call_id:${cachedCall.cid}" }
+            logger.d { "[safeFinish] call_id:${cachedCall.cid}" }
             finish()
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Fixes an issue where the activity was closing unexpectedly.

### 🛠 Implementation Details

* Reverted the logic of finishing and restarting the activity, as it can lead to unpredictable behavior on certain OEMs.

* Introduced `key(call.id)` in Jetpack Compose to correctly recompose the `RootContent` when a new `Call` object is received.

* Ensured the Compose UI recomposes when transitioning to a new call instance.

* Added a new state in `StreamCallActivity` named `_isTransitioningToAnotherCall`:

  ```kotlin
  private val _isTransitioningToAnotherCall: MutableStateFlow<Boolean> = MutableStateFlow(false)
  ```

  This flag helps prevent automated actions (like leaving the activity) during a call transition.

* **Why it's needed**:
  When transitioning between calls, we first leave the existing call and then join the new one. The act of leaving can emit `RealtimeConnection.Disconnect`, which previously triggered the activity to close.
  By checking `_isTransitioningToAnotherCall`, we can suppress this behavior and keep the activity alive while the transition is in progress.

