### PR TITLE
Improve call display name resolution in PN handling

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.video.android.core.notifications.internal
 
+import androidx.annotation.VisibleForTesting
 import io.getstream.android.push.PushDevice
 import io.getstream.android.push.delegate.AndroidPushDelegateProvider
 import io.getstream.android.push.delegate.PushDelegate
@@ -34,7 +35,6 @@ import kotlinx.coroutines.launch
  */
 internal class VideoPushDelegate : PushDelegate() {
     private val logger by taggedLogger("Call:PushDelegate")
-    private val DEFAULT_CALL_TEXT = "Unknown caller"
 
     /**
      * Handle a push message.
@@ -61,23 +61,30 @@ internal class VideoPushDelegate : PushDelegate() {
     }
 
     private fun handleRingType(callId: StreamCallId, payload: Map<String, Any?>) {
-        val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
+        val callDisplayName = getCallDisplayName(payload)
         getStreamVideo("ring-type-notification")?.onRingingCall(callId, callDisplayName, payload)
     }
 
     private fun handleMissedType(callId: StreamCallId, payload: Map<String, Any?>) {
-        val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
+        val callDisplayName = getCallDisplayName(payload)
         getStreamVideo("missed-type-notification")?.onMissedCall(callId, callDisplayName, payload)
     }
 
     private fun handleNotificationType(callId: StreamCallId, payload: Map<String, Any?>) {
-        val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
+        val callDisplayName = getCallDisplayName(payload)
         getStreamVideo("generic-notification")?.onNotification(callId, callDisplayName, payload)
     }
 
     private fun handleLiveStartedType(callId: StreamCallId, payload: Map<String, Any?>) {
-        val callDisplayName = (payload[KEY_CREATED_BY_DISPLAY_NAME] as String).ifEmpty { DEFAULT_CALL_TEXT }
+        val callDisplayName = getCallDisplayName(payload)
         getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName, payload)
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    internal fun getCallDisplayName(payload: Map<String, Any?>): String {
+        return payload.getStringValue(KEY_CALL_DISPLAY_NAME)
+            ?: payload.getStringValue(KEY_CREATED_BY_DISPLAY_NAME)
+            ?: DEFAULT_CALL_TEXT
     }
 
     /**
@@ -101,6 +108,20 @@ internal class VideoPushDelegate : PushDelegate() {
                 }
             }
         }
+
+    /**
+     * Return if the map contains string value for the given key.
+     *
+     * @param key The key to be checked.
+     * @return the string value for the given key, null otherwise.
+     */
+    private fun <K> Map<out K, *>.getStringValue(key: K): String? {
+        return if ((this as Map<K, *>).containsKey(key) && this[key] != null) {
+            this[key] as? String
+        } else {
+            null
+        }
+    }
 
     /**
      * Return if the map is valid.
@@ -184,7 +205,8 @@ internal class VideoPushDelegate : PushDelegate() {
     private fun Map<String, Any?>.isValidIncomingCall(): Boolean =
         !(this[KEY_TYPE] as? String).isNullOrBlank() && !(this[KEY_CALL_CID] as? String).isNullOrBlank()
 
-    private companion object {
+    internal companion object {
+        internal val DEFAULT_CALL_TEXT = "Unknown caller"
         private const val KEY_SENDER = "sender"
         private const val KEY_TYPE = "type"
         private const val KEY_TYPE_RING = "call.ring"
@@ -192,8 +214,8 @@ internal class VideoPushDelegate : PushDelegate() {
         private const val KEY_TYPE_NOTIFICATION = "call.notification"
         private const val KEY_TYPE_LIVE_STARTED = "call.live_started"
         private const val KEY_CALL_CID = "call_cid"
-        private const val KEY_CALL_DISPLAY_NAME = "call_display_name"
-        private const val KEY_CREATED_BY_DISPLAY_NAME = "created_by_display_name"
+        internal const val KEY_CALL_DISPLAY_NAME = "call_display_name"
+        internal const val KEY_CREATED_BY_DISPLAY_NAME = "created_by_display_name"
         private const val VALUE_STREAM_SENDER = "stream.video"
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegateTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegateTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications.internal
+
+import io.getstream.video.android.core.notifications.internal.VideoPushDelegate.Companion.KEY_CALL_DISPLAY_NAME
+import io.getstream.video.android.core.notifications.internal.VideoPushDelegate.Companion.KEY_CREATED_BY_DISPLAY_NAME
+import org.junit.Test
+import kotlin.test.assertEquals
+
+class VideoPushDelegateTest {
+
+    private val delegate = VideoPushDelegate()
+
+    @Test
+    fun `check getCallDisplayName() with empty payload`() {
+        assertEquals(VideoPushDelegate.DEFAULT_CALL_TEXT, delegate.getCallDisplayName(emptyMap()))
+    }
+
+    @Test
+    fun `check getCallDisplayName() with non-String value`() {
+        assertEquals(
+            VideoPushDelegate.DEFAULT_CALL_TEXT,
+            delegate.getCallDisplayName(mapOf(KEY_CALL_DISPLAY_NAME to 1)),
+        )
+    }
+
+    @Test
+    fun `check getCallDisplayName() with String value`() {
+        val createdBy = "createdBy"
+        assertEquals(
+            createdBy,
+            delegate.getCallDisplayName(mapOf(KEY_CREATED_BY_DISPLAY_NAME to createdBy)),
+        )
+    }
+
+    @Test
+    fun `check getCallDisplayName() pick KEY_CALL_DISPLAY_NAME`() {
+        val callDisplayName = "callDisplayName"
+        val createdBy = "createdBy"
+        assertEquals(
+            callDisplayName,
+            delegate.getCallDisplayName(
+                mapOf(
+                    KEY_CALL_DISPLAY_NAME to callDisplayName,
+                    KEY_CREATED_BY_DISPLAY_NAME to createdBy,
+                ),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Use `call_display_name` from the PN as first option when choosing Notification title

### 🛠 Implementation details

Add a consolidated private fun to get a `callDisplayName` for all call types