### PR TITLE
Ensure non-empty call display name is passed to notification flow

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/VideoPushDelegate.kt
@@ -80,10 +80,13 @@ internal class VideoPushDelegate : PushDelegate() {
         getStreamVideo("live-started-notification")?.onLiveCall(callId, callDisplayName, payload)
     }
 
+    /**
+     * It should return non-empty string otherwise notification apis will cause crash
+     */
     @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
     internal fun getCallDisplayName(payload: Map<String, Any?>): String {
-        return payload.getStringValue(KEY_CALL_DISPLAY_NAME)
-            ?: payload.getStringValue(KEY_CREATED_BY_DISPLAY_NAME)
+        return payload.getStringValue(KEY_CALL_DISPLAY_NAME)?.takeIf { it.isNotBlank() }
+            ?: payload.getStringValue(KEY_CREATED_BY_DISPLAY_NAME)?.takeIf { it.isNotBlank() }
             ?: DEFAULT_CALL_TEXT
     }
 


### PR DESCRIPTION
### 🎯 Goal

Ensure a valid (non-empty) call display name is always used in the notification flow.

### 🛠 Reason

An empty call display name can lead to failures in the Android Notification API, so we apply fallback logic to guarantee a meaningful, non-empty value is always provided.