### PR TITLE
Open UserDevice APIs and add more logs

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 
 internal class StreamNotificationManager private constructor(
-    private val context: Context,
     private var scope: CoroutineScope,
     internal val notificationConfig: NotificationConfig,
     private var api: ProductvideoApi,
@@ -61,7 +60,7 @@ internal class StreamNotificationManager private constructor(
             ?.let { generator ->
                 generator.onPushDeviceGeneratorSelected()
                 generator.asyncGeneratePushDevice { generatedDevice ->
-                    logger.d { "[registerPushDevice] pushDevice gnerated: $generatedDevice" }
+                    logger.d { "[registerPushDevice] pushDevice generated: $generatedDevice" }
                     scope.launch { createDevice(generatedDevice) }
                 }
                 if (notificationConfig.requestPermissionOnDeviceRegistration()) {
@@ -74,12 +73,16 @@ internal class StreamNotificationManager private constructor(
         logger.d { "[createDevice] pushDevice: $pushDevice" }
         val newDevice = pushDevice.toDevice()
         return pushDevice
-            .takeUnless { newDevice == deviceTokenStorage.userDevice.firstOrNull() }
+            .takeUnless {
+                val equal = newDevice == getDevice()
+                logger.d { "[createDevice] Device equal to stored: $equal" }
+                equal
+            }
             ?.toCreateDeviceRequest()
             ?.flatMapSuspend { createDeviceRequest ->
                 try {
                     api.createDevice(createDeviceRequest)
-                    deviceTokenStorage.updateUserDevice(pushDevice.toDevice())
+                    updateDevice(pushDevice.toDevice())
                     Result.Success(newDevice)
                 } catch (e: Exception) {
                     logger.e(e) {
@@ -95,9 +98,20 @@ internal class StreamNotificationManager private constructor(
 
     private suspend fun removeStoredDevice(device: Device) {
         logger.d { "[removeStoredDevice] device: device" }
-        deviceTokenStorage.userDevice.firstOrNull()
-            .takeIf { it == device }
-            ?.let { deviceTokenStorage.updateUserDevice(null) }
+        getDevice()
+            .takeIf {
+                val equal = it == device
+                logger.d { "[removeStoredDevice] Device equal to stored: $equal" }
+                equal
+            }
+            ?.let { updateDevice(null) }
+    }
+
+    suspend fun getDevice(): Device? = deviceTokenStorage.userDevice.firstOrNull()
+
+    suspend fun updateDevice(device: Device?) {
+        logger.d { "[updateUserDevice] device: $device" }
+        deviceTokenStorage.updateUserDevice(device)
     }
 
     /**
@@ -105,7 +119,6 @@ internal class StreamNotificationManager private constructor(
      */
     suspend fun deleteDevice(device: Device): Result<Unit> {
         logger.d { "[deleteDevice] device: $device" }
-        val userId = StreamVideo.instanceOrNull()?.user?.id
         return try {
             api.deleteDevice(device.id)
             removeStoredDevice(device)
@@ -119,7 +132,7 @@ internal class StreamNotificationManager private constructor(
         Device(
             id = this.token,
             pushProvider = this.pushProvider.key,
-            pushProviderName = this.providerName ?: "",
+            pushProviderName = this.providerName,
         )
 
     private fun PushDevice.toCreateDeviceRequest(): Result<CreateDeviceRequest> =
@@ -179,7 +192,6 @@ internal class StreamNotificationManager private constructor(
                         )
                     }
                     internalStreamNotificationManager = StreamNotificationManager(
-                        context,
                         scope,
                         updatedNotificationConfig,
                         api,


### PR DESCRIPTION
### 🎯 Goal

Make available to access `UserDevice` functions by API

### 🛠 Implementation details

- Adding `getDevice()` and `updateDevice()` API
- Adding more log in `createDevice()`, `updateDevice()` and `removeStoredDevice()`