### PR TITLE
Fix a rare crash when creating the publisher peer connection

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
-### 🎯 Goal
+### Goal
 
 _Describe why we are making this change_
 
-### 🛠 Implementation details
+### Implementation
 
 _Describe the implementation_
 
@@ -35,7 +35,7 @@ _Add relevant videos_
 </tbody>
 </table>
 
-### 🧪 Testing
+### Testing
 
 _Explain how this change can be tested (or why it can't be tested)_
 

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,16 @@
+# .github/workflows/pr-quality-check.yml (caller)
+name: PR checklist
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, labeled, unlabeled, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-checklist:
+    uses: GetStream/android-ci-actions/.github/workflows/pr-quality.yml@main
+    secrets: inherit

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -935,7 +935,6 @@ public class RtcSession internal constructor(
     internal fun createPublisher(publishOptions: List<PublishOption>): Publisher {
         return call.peerConnectionFactory.makePublisher(
             sessionId = sessionId,
-            me = call.state.me.value!!,
             sfuClient = sfuConnectionModule.api,
             mediaManager = call.mediaManager,
             configuration = connectionConfiguration,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
@@ -65,7 +65,6 @@ import stream.video.sfu.signal.SetPublisherRequest
 import java.util.UUID
 
 internal class Publisher(
-    private val localParticipant: ParticipantState,
     private val mediaManager: MediaManagerImpl,
     private val peerConnectionFactory: StreamPeerConnectionFactory,
     private val publishOptions: List<PublishOption>,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
@@ -19,7 +19,6 @@ package io.getstream.video.android.core.call.connection
 import androidx.annotation.VisibleForTesting
 import io.getstream.result.onErrorSuspend
 import io.getstream.video.android.core.MediaManagerImpl
-import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.core.api.SignalServerService
 import io.getstream.video.android.core.call.connection.job.RestartIceJobDelegate
 import io.getstream.video.android.core.call.connection.stats.ComputedStats

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
@@ -349,7 +349,6 @@ public class StreamPeerConnectionFactory(
     }
 
     internal fun makePublisher(
-        me: ParticipantState,
         mediaManager: MediaManagerImpl,
         publishOptions: List<PublishOption>,
         coroutineScope: CoroutineScope,
@@ -368,7 +367,6 @@ public class StreamPeerConnectionFactory(
             sessionId = sessionId,
             sfuClient = sfuClient,
             peerConnectionFactory = this,
-            localParticipant = me,
             mediaManager = mediaManager,
             publishOptions = publishOptions,
             coroutineScope = coroutineScope,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
@@ -21,7 +21,6 @@ import android.media.AudioAttributes
 import android.os.Build
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.MediaManagerImpl
-import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.core.api.SignalServerService
 import io.getstream.video.android.core.call.connection.coding.SelectiveVideoDecoderFactory
 import io.getstream.video.android.core.call.video.FilterVideoProcessor


### PR DESCRIPTION
### Goal
Fix the crash that sometimes occurs when creating a new publisher peer connection.

### Implementation

The `Publisher` depends on `localParticipant` but this is not used in later versions. Thus we can safely remove the dependency to `call.state.me` which can sometimes be `null`.

### Testing 
Regular smoke and sanity check. The removed code had no other implications.