### PR TITLE
Clean old draft PRs from the repo

### DIFF
--- a/.github/workflows/pr-clean-old-drafts.yaml
+++ b/.github/workflows/pr-clean-old-drafts.yaml
@@ -1,0 +1,18 @@
+# .github/workflows/pr-quality-check.yml (caller)
+name: PR checklist
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"  # every Monday 09:00 CEST (UTC+2)
+  workflow_dispatch:
+
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  pr-checklist:
+    uses: GetStream/android-ci-actions/.github/workflows/pr-clean-stale.yaml@main
+    secrets: inherit


### PR DESCRIPTION
### Goal

Automatically keep the PR queue tidy.

### Implementation

Added a workflow in the shared repo that we invoke here once a week. This workflow will close any DRAFT PRs that have not had activity for more than 30 day.s

### Testing
Create a draft PR and see it auto-closed in 30 days