### PR TITLE
Exclude non-user-facing cameras (e.g., Pixel 4XL IR Camera)

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/camera/CameraCharacteristicsValidator.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/camera/CameraCharacteristicsValidator.kt
@@ -21,6 +21,10 @@ import io.getstream.video.android.core.internal.InternalStreamVideoApi
 
 @InternalStreamVideoApi
 interface CameraCharacteristicsValidator {
-    fun isUsable(characteristics: CameraCharacteristics?): Boolean
+    fun isUsable(
+        characteristics: CameraCharacteristics?,
+        allowMono: Boolean = true,
+        allowNir: Boolean = false,
+    ): Boolean
     fun getLensFacing(characteristics: CameraCharacteristics?): Int?
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/camera/DefaultCameraCharacteristicsValidator.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/camera/DefaultCameraCharacteristicsValidator.kt
@@ -18,15 +18,56 @@ package io.getstream.video.android.core.camera
 
 import android.hardware.camera2.CameraCharacteristics
 import android.hardware.camera2.CameraMetadata
+import android.os.Build
+import androidx.annotation.RequiresApi
 
 internal class DefaultCameraCharacteristicsValidator : CameraCharacteristicsValidator {
-    override fun isUsable(characteristics: CameraCharacteristics?): Boolean {
-        val capabilities =
-            characteristics?.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES)
-        return capabilities?.contains(CameraMetadata.REQUEST_AVAILABLE_CAPABILITIES_BACKWARD_COMPATIBLE) == true
+    override fun isUsable(
+        characteristics: CameraCharacteristics?,
+        allowMono: Boolean,
+        allowNir: Boolean,
+    ): Boolean {
+        val caps = characteristics?.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES) ?: return false
+
+        // Must always support backward compatibility
+        if (!caps.contains(CameraMetadata.REQUEST_AVAILABLE_CAPABILITIES_BACKWARD_COMPATIBLE)) {
+            return false
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            // If camera is mono and not allowed → reject
+            if (isMono(characteristics) && !allowMono) return false
+
+            // If camera is IR and not allowed → reject
+            if (isNir(characteristics) && !allowNir) return false
+        }
+
+        return true
     }
 
     override fun getLensFacing(characteristics: CameraCharacteristics?): Int? {
         return characteristics?.get(CameraCharacteristics.LENS_FACING)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun isMono(characteristics: CameraCharacteristics): Boolean {
+        val caps = characteristics.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES) ?: return false
+        if (!caps.contains(CameraMetadata.REQUEST_AVAILABLE_CAPABILITIES_MONOCHROME)) return false
+
+        val arrangement = characteristics.get(
+            CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT,
+        )
+        return arrangement == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_MONO
+    }
+
+    @RequiresApi(Build.VERSION_CODES.Q)
+    private fun isNir(characteristics: CameraCharacteristics): Boolean {
+        val caps = characteristics.get(CameraCharacteristics.REQUEST_AVAILABLE_CAPABILITIES) ?: return false
+        if (!caps.contains(CameraMetadata.REQUEST_AVAILABLE_CAPABILITIES_MONOCHROME)) return false
+
+        val arrangement = characteristics.get(
+            CameraCharacteristics.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT,
+        )
+        return arrangement == CameraMetadata.SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR
     }
 }


### PR DESCRIPTION
### Goal

Exclude non-user-facing cameras (e.g., Pixel 4XL IR Camera)

### Implementation

IR Camera Capability Detection: 
(https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#SENSOR_INFO_COLOR_FILTER_ARRANGEMENT_NIR)

Monochrome Camera Capability Detection: https://developer.android.com/reference/android/hardware/camera2/CameraMetadata#REQUEST_AVAILABLE_CAPABILITIES_MONOCHROME

### Testing

Just smoke test video call