### PR TITLE
Correctly update current call ringing state in case of group-calls

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1115,7 +1115,7 @@ public class CallState(
         )
 
         // no members - call is empty, we can join
-        val state: RingingState = if (hasActiveCall && client.state.activeCall.value?.id == call.id) {
+        val state: RingingState = if (hasActiveCall) {
             cancelTimeout()
             RingingState.Active
         } else if ((rejectedBy.isNotEmpty() && rejectedBy.size >= outgoingMembersCount) ||


### PR DESCRIPTION
### Goal

Correctly update current call ringing state in case of group-calls

### Implementation

Ensure we are correctly updating current call ringing state

### Testing

Smoke test group testing with at least 3 people, observe correct notifications are displayed

