### PR TITLE
Enhance retry handling for failed call joins.

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -445,10 +445,18 @@ public class Call(
             }
             delay(retryCount - 1 * 1000L)
         }
-        return Failure(value = Error.GenericError("Join failed after 3 retries"))
+        session = null
+        val errorMessage = "Join failed after 3 retries"
+        state._connection.value = RealtimeConnection.Failed(errorMessage)
+        return Failure(value = Error.GenericError(errorMessage))
     }
 
     internal fun isPermanentError(error: Any): Boolean {
+        if (error is Error.ThrowableError) {
+            if (error.message.contains("Unable to resolve host")) {
+                return false
+            }
+        }
         return true
     }
 


### PR DESCRIPTION
### Goal

Enhance retry handling for failed call joins.

### Implementation

1. Treat no internet available as a non-permanent error in `isPermanentError` and allow retries.
2. Observe `RealtimeConnection.Failed` to clear the ringing call notification.

### Testing

1. Add a breakpoint on where we invoke `coordinatorConnectionModule.api.joinCall` in StreamVideoClient class
2. Toggle off internet
3. Resume the breakpoint



