### PR TITLE
Fixed an issue where the `foreground` service may not be canceled

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
@@ -30,8 +30,10 @@ import io.getstream.video.android.core.socket.coordinator.state.VideoSocketState
 import io.getstream.video.android.core.utils.safeCallWithDefault
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.User
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 // These are UI states, need to move out.
 @Stable
@@ -150,7 +152,13 @@ class ClientState(private val client: StreamVideo) {
     fun setActiveCall(call: Call) {
         this._activeCall.value = call
         removeRingingCall(call)
-        maybeStartForegroundService(call, CallService.TRIGGER_ONGOING_CALL)
+        call.scope.launch {
+            /**
+             * Temporary fix: `maybeStartForegroundService` is called just before this code, which can stop the service
+             */
+            delay(500L)
+            maybeStartForegroundService(call, CallService.TRIGGER_ONGOING_CALL)
+        }
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -343,6 +343,7 @@ internal open class CallService : Service() {
         // STOP SERVICE LOGIC STARTS
         if (shouldStopServiceFromIntent(intent)) {
             stopService()
+            return START_NOT_STICKY
         }
         // STOP SERVICE LOGIC ENDS
 


### PR DESCRIPTION
### Goal

Fix foreground service cancellation issue

### Implementation
Resolve race condition by adding a delay in maybeStartForegroundService that causes service to stop. 

### Testing

Smoke test audio/video calling. Check if you see all the notifications, incoming, in progress .