### PR TITLE
Allow for ringing call to be rejected if the caller does not join the call

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -5495,8 +5495,8 @@ public final class io/getstream/video/android/core/Call {
 	public final fun isPinnedParticipant (Ljava/lang/String;)Z
 	public final fun isServerPin (Ljava/lang/String;)Z
 	public final fun isVideoEnabled ()Z
-	public final fun join (ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun join$default (Lio/getstream/video/android/core/Call;ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun join (ZLio/getstream/video/android/core/CreateCallOptions;ZZLio/getstream/video/android/core/call/JoinCallConfig;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun join$default (Lio/getstream/video/android/core/Call;ZLio/getstream/video/android/core/CreateCallOptions;ZZLio/getstream/video/android/core/call/JoinCallConfig;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun leave ()V
 	public final fun listRecordings (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun listRecordings$default (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -6490,6 +6490,21 @@ public final class io/getstream/video/android/core/call/CallType$Default : io/ge
 
 public final class io/getstream/video/android/core/call/CallType$Livestream : io/getstream/video/android/core/call/CallType {
 	public static final field INSTANCE Lio/getstream/video/android/core/call/CallType$Livestream;
+}
+
+public final class io/getstream/video/android/core/call/JoinCallConfig {
+	public fun <init> ()V
+	public fun <init> (ZI)V
+	public synthetic fun <init> (ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()I
+	public final fun copy (ZI)Lio/getstream/video/android/core/call/JoinCallConfig;
+	public static synthetic fun copy$default (Lio/getstream/video/android/core/call/JoinCallConfig;ZIILjava/lang/Object;)Lio/getstream/video/android/core/call/JoinCallConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxRetries ()I
+	public final fun getRejectRingingCallOnFailure ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/getstream/video/android/core/call/RtcSession {
@@ -8538,6 +8553,12 @@ public final class io/getstream/video/android/core/errors/RtcException : java/la
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ZZLstream/video/sfu/models/Error;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ZZLstream/video/sfu/models/Error;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class io/getstream/video/android/core/errors/SfuJoinException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public fun getCause ()Ljava/lang/Throwable;
+	public fun getMessage ()Ljava/lang/String;
 }
 
 public final class io/getstream/video/android/core/errors/VideoErrorCode : java/lang/Enum {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/JoinCallConfig.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/JoinCallConfig.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call
+
+import io.getstream.video.android.core.Call
+
+/**
+ * Configuration knobs for the [Call.join] flow.
+ *
+ * @property rejectRingingCallOnFailure Remove the call from the local ringing list if the join attempt fails.
+ * @property maxRetries Number of retry attempts for transient join errors before surfacing failure.
+ */
+data class JoinCallConfig(
+    val rejectRingingCallOnFailure: Boolean = false,
+    val maxRetries: Int = 3,
+)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/errors/SfuJoinException.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/errors/SfuJoinException.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.errors
+
+/**
+ * Exception thrown when the SFU join fails.
+ *
+ * @param message The detail message of the exception.
+ * @param cause The cause of the exception, if any.
+ */
+class SfuJoinException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallJoinConfigTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallJoinConfigTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core
+
+import com.google.common.truth.Truth.assertThat
+import io.getstream.android.video.generated.models.RejectCallResponse
+import io.getstream.result.Error
+import io.getstream.result.Result.Failure
+import io.getstream.result.Result.Success
+import io.getstream.video.android.core.base.IntegrationTestBase
+import io.getstream.video.android.core.call.JoinCallConfig
+import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.errors.SfuJoinException
+import io.getstream.video.android.core.model.RejectReason
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.spyk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertEquals
+
+@RunWith(RobolectricTestRunner::class)
+internal class CallJoinConfigTest : IntegrationTestBase() {
+
+    @Test
+    fun `rejects ringing call when SFU join fails and auto reject is enabled`() = runTest {
+        val call = spyk(client.call("default", randomUUID()), recordPrivateCalls = true)
+
+        every { call.clientImpl.permissionCheck.checkAndroidPermissions(any(), any()) } returns true
+
+        val joinFailure = Failure(
+            Error.ThrowableError(
+                message = "sfu join failed",
+                cause = SfuJoinException("failed to connect", RuntimeException("boom")),
+            ),
+        )
+
+        coEvery { call._join(any(), any(), any(), any()) } returns joinFailure
+        coEvery { call.reject(RejectReason.Cancel) } returns Success(RejectCallResponse(duration = "0"))
+
+        val result = call.join(
+            ring = true,
+            joinCallConfig = JoinCallConfig(
+                rejectRingingCallOnFailure = true,
+                maxRetries = 1,
+            ),
+        )
+
+        assertThat(result.isFailure).isTrue()
+        coVerify(exactly = 1) { call.isSFuJoinError(any()) }
+        coVerify(exactly = 1) { call.reject(RejectReason.Cancel) }
+        assertThat(call.state.connection.value).isInstanceOf(RealtimeConnection.Failed::class.java)
+    }
+
+    @Test
+    fun `join surfaces reject error if it has to reject ringing call when sfu join fails`() = runTest {
+        val call = spyk(client.call("default", randomUUID()), recordPrivateCalls = true)
+
+        every { call.clientImpl.permissionCheck.checkAndroidPermissions(any(), any()) } returns true
+
+        val joinFailure = Failure(
+            Error.ThrowableError(
+                message = "sfu join failed",
+                cause = SfuJoinException("failed to connect", RuntimeException("boom")),
+            ),
+        )
+
+        coEvery { call._join(any(), any(), any(), any()) } returns joinFailure
+        val failure = Failure(Error.GenericError("reject failed"))
+        coEvery { call.reject(RejectReason.Cancel) } returns failure
+
+        val result = call.join(
+            ring = true,
+            joinCallConfig = JoinCallConfig(
+                rejectRingingCallOnFailure = true,
+                maxRetries = 1,
+            ),
+        )
+
+        assertThat(result.isFailure).isTrue()
+        coVerify(exactly = 1) { call.isSFuJoinError(any()) }
+        coVerify(exactly = 1) { call.reject(RejectReason.Cancel) }
+        assertThat(call.state.connection.value).isInstanceOf(RealtimeConnection.Failed::class.java)
+        assertEquals(failure, result)
+    }
+
+    @Test
+    fun `join retries until success respecting the configured max retries`() = runTest {
+        val call = spyk(client.call("default", randomUUID()), recordPrivateCalls = true)
+
+        every { call.clientImpl.permissionCheck.checkAndroidPermissions(any(), any()) } returns true
+
+        val rtcSession = mockk<RtcSession>(relaxed = true)
+        val transientFailure =
+            Failure(Error.ThrowableError("Unable to resolve host", RuntimeException("boom")))
+        coEvery { call._join(any(), any(), any(), any()) } returnsMany listOf(
+            transientFailure,
+            Success(rtcSession),
+        )
+
+        val result = call.join(joinCallConfig = JoinCallConfig(maxRetries = 2))
+
+        println(result)
+        assertThat(result.isSuccess).isTrue()
+        coVerify(exactly = 2) { call._join(any(), any(), any(), any()) }
+    }
+}


### PR DESCRIPTION
### Goal

Allow an option to `reject()` a call with `join(ring=true)` in case the SFU connection fails.

### Implementation

Add a new class / struct `JoinCallConfig` which is a standalone class supplied to the `join()` method, with two fields that enable automatic rejection when a `ring = true` join attempt cannot reach the SFU.

```kotlin
data class JoinCallConfig(    
	val rejectRingingCallOnFailure: Boolean = false,    
	val maxRetries: Int = 3,
)
```

- `rejectRingingCallOnFailure`: If set to `true` will automatically reject the call if the current user fails to join the SFU while ringing.
- `maxRetries`: the number of total retry attempts before the SDK surfaces a failure. This was not configurable on Android so we are adding it here.

### Signature of `join()`

Old

```kotlin
suspend fun join(
	create: Boolean = false,
	createOptions: CreateCallOptions? = null,
	ring: Boolean = false,
	notify: Boolean = false,
): Result<RtcSession>
```

New

```kotlin
suspend fun join(
	create: Boolean = false,
	createOptions: CreateCallOptions? = null,
	ring: Boolean = false,
	notify: Boolean = false,
	joinCallConfig: JoinCallConfig = JoinCallConfig(),
): Result<RtcSession>
```

### If case `reject()` fails

When we fail to connect to the SFU (if configured) we will call `reject()` on the `Call` object. This request can fail in this case we are going to surface the reject error, otherwise we are going to surface the original error for which we failed to connect to the SFU.

### Testing

Covered by unit tests. If you want to test it manually, throw an exception in `session.connect()` and see that the call is rejected on the receiver side.