### PR TITLE
Update `ownCapabilities` for local user only

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -783,7 +783,9 @@ public class CallState(
             }
 
             is UpdatedCallPermissionsEvent -> {
-                _ownCapabilities.value = event.ownCapabilities
+                if (event.user.id == client.userId) {
+                    _ownCapabilities.value = event.ownCapabilities
+                }
             }
 
             is ConnectedEvent -> {


### PR DESCRIPTION
### Goal

`ownCapabilities` should be done for local user only.

### Implementation

When `UpdateCallPermissionsEvent` is received check the `event.user.id ==. client.userId` before processing the event.

### Testing

Change capabilities on a call for different user and verify that the current user has not changed its own capabilities.