### PR TITLE
Upgrade to v1.0.4 noise cancellation which supports 16kb page size

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,7 +48,7 @@ turbine = "0.13.0"
 itu = "1.7.3"
 
 streamWebRTC = "1.3.8"
-streamNoiseCancellation = "1.0.2"
+streamNoiseCancellation = "1.0.4"
 streamResult = "1.3.0"
 streamChat = "6.10.0"
 streamLog = "1.3.2"


### PR DESCRIPTION
### Goal

Upgrading to v1.0.4 of noise cancellation lib which has the latest version of krisp that supports 16kb page size alignment

### Implementation
Upgraded `io.getstream:stream-video-android-noise-cancellation` version to `1.0.4`

### Testing
Deploy the app on a device and join a room with noise cancellation enabled. See if background noise gets cancelled