### PR TITLE
Fix Sonar showing 0% coverage

### DIFF
--- a/scripts/coverage.gradle
+++ b/scripts/coverage.gradle
@@ -119,5 +119,18 @@ kover {
 sonar {
     properties {
         property "sonar.coverage.jacoco.xmlReportPaths", "${buildDir}/reports/kover/reportCoverage.xml"
+
+        def sources = coverageModulesWithTests.collect { project ->
+            "${project.projectDir}/src/main/kotlin"
+        }.join(",")
+        property "sonar.sources", sources
+
+        def tests = coverageModulesWithTests.collect { project ->
+            [
+                    "${project.projectDir}/src/androidTest/kotlin",
+                    "${project.projectDir}/src/test/kotlin"
+            ]
+        }.flatten().join(",")
+        property "sonar.tests", tests
     }
 }

--- a/scripts/sonar.gradle
+++ b/scripts/sonar.gradle
@@ -16,7 +16,7 @@ ext.sonar = [
     ]
 ]
 
-sonarqube {
+sonar {
     properties {
         property("sonar.host.url", "https://sonarcloud.io")
         property("sonar.token", "${System.getenv("SONAR_TOKEN")}")


### PR DESCRIPTION
### Goal

Fix Sonar coverage

### Implementation

This project uses custom plugins such as `id("io.getstream.android.library")`, which prevents the Sonar plugin from automatically filling the `sonar.sources` and `sonar.tests`  properties.
The fix manually adds those properties to the Sonar configuration.

### Testing

The Sonar dashboard should show coverage