### PR TITLE
Fix Paparazzi flakiness execution

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,9 +76,6 @@ jobs:
 
       - uses: GetStream/android-ci-actions/actions/gradle-cache@main
 
-      - name: Run snapshot tests
-        run: ./gradlew verifyPaparazziDebug --scan --stacktrace
-
       - name: Run unit tests
         run: ./gradlew :testCoverage --scan --stacktrace
 

--- a/scripts/coverage.gradle
+++ b/scripts/coverage.gradle
@@ -52,6 +52,7 @@ subprojects {
 
         afterEvaluate {
             def isAndroidModule = plugins.hasPlugin("com.android.library") || plugins.hasPlugin("com.android.application")
+            def hasPaparazziPlugin = plugins.hasPlugin("app.cash.paparazzi")
 
             if (isAndroidModule) {
                 android {
@@ -62,6 +63,17 @@ subprojects {
                         }
                     }
                 }
+            }
+
+            // Determine the appropriate test task name based on module type and plugins
+            def testTaskName = isAndroidModule
+                    ? (hasPaparazziPlugin ? "verifyPaparazziDebug" : "testDebugUnitTest")
+                    : "test"
+
+            tasks.register("testCoverage") {
+                group = "verification"
+                description = "Run module-specific tests"
+                dependsOn(testTaskName)
             }
 
             kover {
@@ -91,6 +103,9 @@ coverageModulesWithTests.each { project -> dependencies { kover(project) } }
 tasks.register("testCoverage") {
     group = "verification"
     description = "Run all tests in all modules and generate merged coverage report"
+
+    dependsOn coverageModulesWithTests.collect { ":${it.name}:testCoverage" }
+
     finalizedBy("koverXmlReportCoverage", "koverHtmlReportCoverage")
 }
 


### PR DESCRIPTION
### Goal

Fix the Paparazzi flakiness execution

### Implementation

After testing a few different approaches. It seems using `ubuntu-22.04` has more stable runs than `ubuntu-latest` (as of October 9, 2025, is 24.04) for unit tests with Paparazzi.

22.04 version is the one used in the chat project, and it defaults Java to OpenJDK 11, whereas 24.04 is OpenJDK 17

### Testing

The `Android CI / Unit Tests` CI job should pass
