### PR TITLE
Prevent active call UI from switching to PiP on incoming call

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/MainActivity.kt
@@ -130,16 +130,18 @@ class MainActivity : ComponentActivity() {
                 }
                 .collectLatest { ringingState ->
                     val currentCall = StreamVideo.instanceState.value?.state?.ringingCall?.value
-
-                    /**
-                     * This activity is re-launched once StreamCallActivity is finished
-                     * So we just need to check if the call is rejected by self previously
-                     */
-                    val self = StreamVideo.instanceOrNull()?.userId
-                    val rejectedBySelf = currentCall?.state?.rejectedBy?.value?.contains(self) == true
-                    if (ringingState is RingingState.Incoming && !rejectedBySelf) {
-                        currentCall?.let {
-                            startIncomingCallActivity(it)
+                    val activeCall = StreamVideo.instanceState.value?.state?.activeCall?.value
+                    if (activeCall == null) {
+                        /**
+                         * This activity is re-launched once StreamCallActivity is finished
+                         * So we just need to check if the call is rejected by self previously
+                         */
+                        val self = StreamVideo.instanceOrNull()?.userId
+                        val rejectedBySelf = currentCall?.state?.rejectedBy?.value?.contains(self) == true
+                        if (ringingState is RingingState.Incoming && !rejectedBySelf) {
+                            currentCall?.let {
+                                startIncomingCallActivity(it)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
### Goal

Prevent active call UI from switching to PiP on incoming call

### Implementation

Previously, when an active call was in progress and a new incoming call arrived, the current calling activity automatically entered PiP mode.

Now, the UI remains unchanged, and the ongoing call continues without interruption.

### Testing

Get a incoming video-call while already on a ongoing video-call