### PR TITLE
Stop the ringing timeout when a call is marked as ended

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -762,6 +762,7 @@ public class CallState(
             }
 
             is CallEndedEvent -> {
+                call.state.cancelTimeout()
                 updateFromResponse(event.call)
                 _endedAt.value = OffsetDateTime.now(Clock.systemUTC())
                 _endedByUser.value = event.user?.toUser()


### PR DESCRIPTION
### Goal

Stop the ringing timeout when a call is marked as ended

### Implementation

Cancel ringing timeout when call is marked ended

### Testing

Smoke test this by invokin `call.end()` from UI