### PR TITLE
Restore timestamp in snapshot version name

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,8 @@
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import io.getstream.video.android.Configuration
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
 apply(from = "${rootDir}/scripts/open-api-code-gen.gradle.kts")
 
@@ -71,7 +74,16 @@ tasks.register("clean")
   }
 
 private val isSnapshot = System.getenv("SNAPSHOT")?.toBoolean() == true
-version = if (isSnapshot) Configuration.snapshotVersionName else Configuration.versionName
+
+version = if (isSnapshot) {
+    val timestamp = SimpleDateFormat("yyyyMMddHHmm").run {
+        timeZone = TimeZone.getTimeZone("UTC")
+        format(Date())
+    }
+    "${Configuration.snapshotBasedVersionName}-${timestamp}-SNAPSHOT"
+} else {
+    Configuration.versionName
+}
 
 subprojects {
   plugins.withId("com.vanniktech.maven.publish") {


### PR DESCRIPTION
### Goal

When migrating to Central Portal, I mistakenly lost the logic adding the timestamp to the snapshot. Readding it.

### Implementation

Add the timestamp to snapshot versions

### 🎨 UI Changes

None

### Testing

Run `SNAPSHOT=true ./gradlew publishToMavenLocal` and verify that the version is correct under `~/.m2`

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_