### PR TITLE
Remove custom clean Gradle task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,11 +68,6 @@ subprojects {
   }
 }
 
-tasks.register("clean")
-  .configure {
-    delete(rootProject.buildDir)
-  }
-
 private val isSnapshot = System.getenv("SNAPSHOT")?.toBoolean() == true
 
 version = if (isSnapshot) {


### PR DESCRIPTION
### Goal

The Android Gradle Plugin already adds a clean task, so we should remove the custom one.

### Implementation

Remove the registration call for the "clean" task

### 🎨 UI Changes

None

### Testing

Run `./gradlew clean` and verify it still works.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_