### PR TITLE
Restore call event subscriptions on socket reconnect

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocketConnection.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocketConnection.kt
@@ -46,6 +46,7 @@ import io.getstream.video.android.model.User
 import io.getstream.video.android.model.User.Companion.isAnonymous
 import io.getstream.video.android.model.UserToken
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -109,7 +110,7 @@ public open class CoordinatorSocketConnection(
             parser,
             httpClient,
         ),
-        scope as? UserScope ?: UserScope(ClientScope()),
+        scope as? UserScope ?: UserScope(ClientScope(), Dispatchers.IO.limitedParallelism(1)),
         StreamLifecycleObserver(scope, lifecycle),
         networkStateProvider,
     ).also {
@@ -155,6 +156,7 @@ public open class CoordinatorSocketConnection(
 
     override fun onConnecting() {
         super.onConnecting()
+        connectionId.value = null
         logger.d { "[onConnecting] Socket is connecting" }
     }
 
@@ -186,6 +188,7 @@ public open class CoordinatorSocketConnection(
 
     override fun onDisconnected(cause: DisconnectCause) {
         super.onDisconnected(cause)
+        connectionId.value = null
         logger.d { "[onDisconnected] Socket disconnected. Cause: $cause" }
     }
 


### PR DESCRIPTION
### Goal

Fix the resubscription logic so that after the coordinator socket reconnects, active calls are correctly resubscribed and coordinator events are received again.

### Implementation

1. Reset the `connectionId` whenever the connection is either disconnected or transitioning to a connecting state.
2. Ensure the coordinator socket processes all tasks serially by using `Dispatchers.limitedParallelism(1)`.

### Testing

1. Open the demo app.
2. Start a new call.
3. Toggle the internet on and off.
4. Send a reaction — it should appear as expected.
5. Repeat steps 3 and 4; the behavior should remain consistent.