### PR TITLE
Configure publishing through convention plugins and migrate to common workflow

### DIFF
--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -4,12 +4,18 @@ on:
   workflow_dispatch:
     inputs:
       bump:
+        required: true
         type: choice
         description: "Type of version bump to perform"
         options:
           - patch
           - minor
           - major
+        default: minor
+
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
   pre_release_check:
@@ -21,20 +27,16 @@ jobs:
         id: pre_release_check_step
         run: echo "Pre release check"
   publish:
+    permissions:
+      contents: write
     needs: pre_release_check
-    uses: GetStream/android-ci-actions/.github/workflows/release-new-version.yml@main
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.5.0
     with:
-      ref: "develop"
       bump: ${{ inputs.bump }}
-      file-path: ./buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
-      excluded-modules: "demo-app,tutorials:tutorial-video,tutorials:tutorial-audio"
-      use-official-plugin: false
-      # Disable explicit documentation tasks as they are already included while publishing
-      documentation-tasks: tasks
     secrets:
-      OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-      OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-      SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-      SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-      SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-      STREAM_PUBLIC_BOT_TOKEN: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}
+      github-token: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}
+      maven-central-username: ${{ secrets.OSSRH_USERNAME }}
+      maven-central-password: ${{ secrets.OSSRH_PASSWORD }}
+      signing-key: ${{ secrets.SIGNING_KEY }}
+      signing-key-id: ${{ secrets.SIGNING_KEY_ID }}
+      signing-key-password: ${{ secrets.SIGNING_PASSWORD }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,3 @@
-import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import io.getstream.video.android.Configuration
-import java.text.SimpleDateFormat
-import java.util.Date
-import java.util.TimeZone
-
 apply(from = "${rootDir}/scripts/open-api-code-gen.gradle.kts")
 
 buildscript {
@@ -27,6 +21,8 @@ plugins {
   alias(libs.plugins.stream.android.application) apply false
   alias(libs.plugins.stream.android.library) apply false
   alias(libs.plugins.stream.android.test) apply false
+  alias(libs.plugins.stream.java.library) apply false
+  alias(libs.plugins.stream.java.platform) apply false
   alias(libs.plugins.android.application) apply false
   alias(libs.plugins.kotlin.android) apply false
   // alias(libs.plugins.compose.compiler) apply false -> Enable with Kotlin 2.0+
@@ -34,7 +30,6 @@ plugins {
   alias(libs.plugins.kotlin.compatibility.validator) apply false
   alias(libs.plugins.ksp) apply false
   alias(libs.plugins.wire) apply false
-  alias(libs.plugins.maven.publish)
   alias(libs.plugins.google.gms) apply false
   alias(libs.plugins.dokka)
   alias(libs.plugins.spotless) apply false
@@ -66,6 +61,13 @@ streamProject {
             "io.getstream.video.android.core.model.*"
         )
     }
+
+    publishing {
+        description = "Stream Video official Android SDK"
+        moduleArtifactIdOverrides = mapOf(
+            "stream-video-android-ui-xml" to "stream-video-android-xml"
+        )
+    }
 }
 
 subprojects {
@@ -86,94 +88,6 @@ subprojects {
       kotlinOptions.freeCompilerArgs += listOf(
         "-Xexplicit-api=strict"
       )
-    }
-  }
-}
-
-private val isSnapshot = System.getenv("SNAPSHOT")?.toBoolean() == true
-
-version = if (isSnapshot) {
-    val timestamp = SimpleDateFormat("yyyyMMddHHmm").run {
-        timeZone = TimeZone.getTimeZone("UTC")
-        format(Date())
-    }
-    "${Configuration.snapshotBasedVersionName}-${timestamp}-SNAPSHOT"
-} else {
-    Configuration.versionName
-}
-
-subprojects {
-  plugins.withId("com.vanniktech.maven.publish") {
-    extensions.configure<MavenPublishBaseExtension> {
-      publishToMavenCentral(automaticRelease = true)
-
-      pom {
-        name.set(project.name)
-        description.set("Stream Video official Android SDK")
-        url.set("https://github.com/getstream/stream-video-android")
-
-        licenses {
-          license {
-            name.set("Stream License")
-            url.set("https://github.com/GetStream/stream-video-android/blob/main/LICENSE")
-          }
-        }
-
-        developers {
-          developer {
-            id = "aleksandar-apostolov"
-            name = "Aleksandar Apostolov"
-            email = "aleksandar.apostolov@getstream.io"
-          }
-          developer {
-            id = "VelikovPetar"
-            name = "Petar Velikov"
-            email = "petar.velikov@getstream.io"
-          }
-          developer {
-            id = "andremion"
-            name = "André Mion"
-            email = "andre.rego@getstream.io"
-          }
-          developer {
-            id = "rahul-lohra"
-            name = "Rahul Kumar Lohra"
-            email = "rahul.lohra@getstream.io"
-          }
-          developer {
-            id = "PratimMallick"
-            name = "Pratim Mallick"
-            email = "pratim.mallick@getstream.io"
-          }
-          developer {
-            id = "gpunto"
-            name = "Gianmarco David"
-            email = "gianmarco.david@getstream.io"
-          }
-        }
-
-        scm {
-          connection.set("scm:git:github.com/getstream/stream-video-android.git")
-          developerConnection.set("scm:git:ssh://github.com/getstream/stream-video-android.git")
-          url.set("https://github.com/getstream/stream-video-android/tree/main")
-        }
-      }
-    }
-  }
-}
-
-tasks.register("printAllArtifacts") {
-  group = "publishing"
-  description = "Prints all artifacts that will be published"
-
-  doLast {
-    subprojects.forEach { subproject ->
-      subproject.plugins.withId("com.vanniktech.maven.publish") {
-        subproject.extensions.findByType(PublishingExtension::class.java)
-          ?.publications
-          ?.filterIsInstance<MavenPublication>()
-          ?.forEach { println("${it.groupId}:${it.artifactId}:${it.version}") }
-      }
     }
   }
 }

--- a/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/video/android/Configuration.kt
@@ -1,14 +1,5 @@
 package io.getstream.video.android
 
 object Configuration {
-    const val majorVersion = 1
-    const val minorVersion = 18
-    const val patchVersion = 3
-    const val versionName = "$majorVersion.$minorVersion.$patchVersion"
-    const val versionCode = 57
-    const val snapshotBasedVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}"
-    const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
-    const val artifactGroup = "io.getstream"
-    const val streamVideoCallGooglePlayVersion = versionName
     const val streamWebRtcVersionName = "1.3.6"
 }

--- a/demo-app/build.gradle.kts
+++ b/demo-app/build.gradle.kts
@@ -20,7 +20,6 @@ import com.android.build.api.variant.ResValue
 import com.github.triplet.gradle.androidpublisher.ResolutionStrategy
 import io.getstream.video.FlavorDimension
 import io.getstream.video.VideoDemoFlavor
-import io.getstream.video.android.Configuration
 import java.io.FileInputStream
 import java.util.Properties
 
@@ -45,7 +44,7 @@ android {
         minSdk = libs.versions.minSdk.get().toInt()
         targetSdk = libs.versions.targetSdk.get().toInt()
         versionCode = 1
-        versionName = Configuration.streamVideoCallGooglePlayVersion
+        versionName = rootProject.version.toString()
         testInstrumentationRunner = "io.qameta.allure.android.runners.AllureAndroidJUnitRunner"
         testInstrumentationRunnerArguments["clearPackageData"] = "true"
         missingDimensionStrategy(FlavorDimension.contentType.name, VideoDemoFlavor.development.name)
@@ -197,7 +196,7 @@ androidComponents {
             applicationVariant.outputs.forEach {
                 it.versionName.set(
                     it.versionCode.map { playVersionCode ->
-                        "${Configuration.streamVideoCallGooglePlayVersion} ($playVersionCode)"
+                        "${rootProject.version} ($playVersionCode)"
                     },
                 )
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -44,3 +44,6 @@ android.suppressUnsupportedCompileSdk=34
 # Build Compose Compiler metrics
 enableComposeCompilerMetrics=true
 enableComposeCompilerReports=true
+
+# Project version
+version=1.18.3

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,7 @@ allureKotlin = "2.4.0"
 androidGradlePlugin = "8.5.2"
 cameraCamera2 = "1.3.4"
 spotless = "6.21.0"
-streamConventions = "0.4.0"
-mavenPublish = "0.34.0"
+streamConventions = "0.5.0"
 kotlin = "1.9.25"
 ksp = "1.9.25-1.0.20"
 kotlinSerialization = "1.6.3"
@@ -247,7 +246,8 @@ stream-project = { id = "io.getstream.project", version.ref = "streamConventions
 stream-android-application = { id = "io.getstream.android.application", version.ref = "streamConventions" }
 stream-android-library = { id = "io.getstream.android.library", version.ref = "streamConventions" }
 stream-android-test = { id = "io.getstream.android.test", version.ref = "streamConventions" }
-maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish"}
+stream-java-library = { id = "io.getstream.java.library", version.ref = "streamConventions" }
+stream-java-platform = { id = "io.getstream.java.platform", version.ref = "streamConventions" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "kotlinDokka" }
 google-gms = { id = "com.google.gms.google-services", version.ref = "googleService" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }

--- a/stream-video-android-bom/build.gradle.kts
+++ b/stream-video-android-bom/build.gradle.kts
@@ -1,34 +1,25 @@
-import com.vanniktech.maven.publish.JavadocJar
-import com.vanniktech.maven.publish.KotlinJvm
-import io.getstream.video.android.Configuration
-
 plugins {
-    alias(libs.plugins.maven.publish)
     alias(libs.plugins.dokka)
-    kotlin("jvm")
+    alias(libs.plugins.stream.java.platform)
+}
+
+spotless {
+    // Point to non-existent file pattern because this module has no source files
+    java {
+        target("no-files-to-format")
+    }
+    kotlin {
+        target("no-files-to-format")
+    }
 }
 
 dependencies {
-  constraints {
-    api(project(":stream-video-android-core"))
-    api(project(":stream-video-android-ui-core"))
-    api(project(":stream-video-android-ui-xml"))
-    api(project(":stream-video-android-ui-compose"))
-    api(project(":stream-video-android-filters-video"))
-    api(project(":stream-video-android-previewdata"))
-  }
-}
-
-mavenPublishing {
-    coordinates(
-        groupId = Configuration.artifactGroup,
-        artifactId = "stream-video-android-bom",
-        version = rootProject.version.toString(),
-    )
-    configure(
-        KotlinJvm(
-            javadocJar = JavadocJar.Dokka("dokkaJavadoc"),
-            sourcesJar = true,
-        ),
-    )
+    constraints {
+        api(project(":stream-video-android-core"))
+        api(project(":stream-video-android-ui-core"))
+        api(project(":stream-video-android-ui-xml"))
+        api(project(":stream-video-android-ui-compose"))
+        api(project(":stream-video-android-filters-video"))
+        api(project(":stream-video-android-previewdata"))
+    }
 }

--- a/stream-video-android-filters-video/build.gradle.kts
+++ b/stream-video-android-filters-video/build.gradle.kts
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import io.getstream.video.android.Configuration
 
 plugins {
-    alias(libs.plugins.maven.publish)
     id("io.getstream.video.android.library")
 }
 
@@ -43,19 +40,4 @@ dependencies {
 
     // renderscript-toolkit
     implementation(libs.stream.renderscript)
-}
-
-mavenPublishing {
-    coordinates(
-        groupId = Configuration.artifactGroup,
-        artifactId = "stream-video-android-filters-video",
-        version = rootProject.version.toString(),
-    )
-    configure(
-        AndroidSingleVariantLibrary(
-            variant = "release",
-            sourcesJar = true,
-            publishJavadocJar = true,
-        ),
-    )
 }

--- a/stream-video-android-previewdata/build.gradle.kts
+++ b/stream-video-android-previewdata/build.gradle.kts
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import io.getstream.video.android.Configuration
 
 plugins {
-    alias(libs.plugins.maven.publish)
     id("io.getstream.video.android.library")
 }
 
@@ -41,19 +38,4 @@ baselineProfile {
 
 dependencies {
     api(project(":stream-video-android-core"))
-}
-
-mavenPublishing {
-    coordinates(
-        groupId = Configuration.artifactGroup,
-        artifactId = "stream-video-android-previewdata",
-        version = rootProject.version.toString(),
-    )
-    configure(
-        AndroidSingleVariantLibrary(
-            variant = "release",
-            sourcesJar = true,
-            publishJavadocJar = true,
-        ),
-    )
 }

--- a/stream-video-android-ui-compose/build.gradle.kts
+++ b/stream-video-android-ui-compose/build.gradle.kts
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import io.getstream.video.android.Configuration
 
 plugins {
-    alias(libs.plugins.maven.publish)
     id("io.getstream.video.android.library.compose")
 }
 
@@ -77,19 +74,4 @@ dependencies {
     testImplementation(libs.turbine)
     testImplementation(libs.robolectric)
     testImplementation(libs.kotlin.test.junit)
-}
-
-mavenPublishing {
-    coordinates(
-        groupId = Configuration.artifactGroup,
-        artifactId = "stream-video-android-ui-compose",
-        version = rootProject.version.toString(),
-    )
-    configure(
-        AndroidSingleVariantLibrary(
-            variant = "release",
-            sourcesJar = true,
-            publishJavadocJar = true,
-        ),
-    )
 }

--- a/stream-video-android-ui-core/build.gradle.kts
+++ b/stream-video-android-ui-core/build.gradle.kts
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import io.getstream.video.android.Configuration
 
 plugins {
-    alias(libs.plugins.maven.publish)
     id("io.getstream.video.android.library")
 }
 
@@ -52,19 +49,4 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
 
     implementation(libs.stream.log)
-}
-
-mavenPublishing {
-    coordinates(
-        groupId = Configuration.artifactGroup,
-        artifactId = "stream-video-android-ui-core",
-        version = rootProject.version.toString(),
-    )
-    configure(
-        AndroidSingleVariantLibrary(
-            variant = "release",
-            sourcesJar = true,
-            publishJavadocJar = true,
-        ),
-    )
 }

--- a/stream-video-android-ui-xml/build.gradle.kts
+++ b/stream-video-android-ui-xml/build.gradle.kts
@@ -13,11 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
-import io.getstream.video.android.Configuration
 
 plugins {
-    alias(libs.plugins.maven.publish)
     id("io.getstream.video.android.library")
 }
 
@@ -59,19 +56,4 @@ dependencies {
     implementation(libs.landscapist.coil)
 
     implementation(libs.stream.log)
-}
-
-mavenPublishing {
-    coordinates(
-        groupId = Configuration.artifactGroup,
-        artifactId = "stream-video-android-xml",
-        version = rootProject.version.toString(),
-    )
-    configure(
-        AndroidSingleVariantLibrary(
-            variant = "release",
-            sourcesJar = true,
-            publishJavadocJar = true,
-        ),
-    )
 }


### PR DESCRIPTION
### Goal

[AND-881: Extract publishing configuration to the plugins](https://linear.app/stream/issue/AND-881/extract-publishing-configuration-to-the-plugins)
[AND-781: Unify CI Across SDKs](https://linear.app/stream/issue/AND-781/unify-ci-across-sdks)

We now have publishing configuration in the common plugins and a new release workflow to go with it. This PR migrates to those.

### Implementation

- Remove publishing configuration in favor of the common one
- Remove version in `Configuration.kt` in favor of setting it in `gradle.properties`
    This automatically sets the project version and allows us to override it as needed.
- Populate version-related build config fields based on `project.version`
- Update publish workflow to use the new one

### Testing

We'll see when we try to release 🤞 

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build and release configuration and CI workflow; bumped project version to 1.18.3.
  * Revised publishing pipeline and credential mappings.
  * Removed legacy Maven publishing setup from multiple modules.
  * Aligned project tooling and plugin conventions to the new platform version and added some developer tooling plugins.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->