### PR TITLE
Add ASCII sanitization utility for HTTP header compatibility

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
@@ -33,6 +33,7 @@ class HeadersUtil {
         @InternalStreamVideoApi
         @JvmStatic
         public var VERSION_PREFIX_HEADER: VersionPrefixHeader = VersionPrefixHeader.Default
+        private val NON_ASCII_REGEX = "[^\\p{ASCII}]".toRegex()
     }
 
     /**
@@ -98,8 +99,17 @@ class HeadersUtil {
         return StreamVideo.instanceOrNull()?.context
     }
 
+    /**
+     * Sanitizes a string to contain only ASCII characters.
+     *
+     * Uses Unicode NFD (canonical decomposition) to decompose accented characters
+     * into base characters and combining marks, then strips all non-ASCII characters.
+     * For example, "café" becomes "cafe", "Müller" becomes "Muller".
+     *
+     * @return ASCII-only version of the string.
+     */
     private fun String.sanitize(): String {
         return Normalizer.normalize(this, Normalizer.Form.NFD)
-            .replace("[^\\p{ASCII}]".toRegex(), "")
+            .replace(NON_ASCII_REGEX, "")
     }
 }


### PR DESCRIPTION
### Goal

Ensure HTTP headers are ASCII-safe by normalizing and stripping non-ASCII characters to prevent OkHttp header validation issues and align with Chat product behavior.

### Implementation

Ensure HTTP headers are ASCII-safe by normalizing and stripping non-ASCII characters to prevent OkHttp header validation issues and align with Chat product behavior.

### 🎨 UI Changes

None

### Testing

Pass special character in `appName` in StringBuilder and sdk should work as usual




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header handling with enhanced sanitization to properly process and normalize special characters, ensuring better compatibility across different character encodings and system configurations while maintaining stability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->