### PR TITLE
Fix microphone muting immediately after joining a call

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -1285,7 +1285,7 @@ public class RtcSession internal constructor(
                                 // Reconcile any orphaned tracks that arrived before this event
                                 reconcileOrphanedTracks(event.sessionId)
                             }
-
+                            val isMicEnabled = call.mediaManager.microphone.isEnabled.value
                             updatePublishState(
                                 userId = event.userId,
                                 sessionId = event.sessionId,
@@ -1294,6 +1294,13 @@ public class RtcSession internal constructor(
                                 audioEnabled = true,
                                 paused = false,
                             )
+
+                            if (event.trackType == TrackType.TRACK_TYPE_AUDIO) {
+                                if (!isMicEnabled) {
+                                    setMuteState(isEnabled = false, event.trackType)
+                                    publisher?.unpublishStream(event.trackType)
+                                }
+                            }
 
                             // Reconcile orphaned tracks for this participant
                             // The track might have arrived before the participant was created

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -1285,7 +1285,7 @@ public class RtcSession internal constructor(
                                 // Reconcile any orphaned tracks that arrived before this event
                                 reconcileOrphanedTracks(event.sessionId)
                             }
-                            val isMicEnabled = call.mediaManager.microphone.isEnabled.value
+
                             updatePublishState(
                                 userId = event.userId,
                                 sessionId = event.sessionId,
@@ -1296,9 +1296,12 @@ public class RtcSession internal constructor(
                             )
 
                             if (event.trackType == TrackType.TRACK_TYPE_AUDIO) {
-                                if (!isMicEnabled) {
-                                    setMuteState(isEnabled = false, event.trackType)
-                                    publisher?.unpublishStream(event.trackType)
+                                if (event.sessionId == sessionId) {
+                                    val isMicEnabled = call.mediaManager.microphone.isEnabled.value
+                                    if (isMicEnabled) {
+                                        setMuteState(isEnabled = false, event.trackType)
+                                        publisher?.unpublishStream(event.trackType)
+                                    }
                                 }
                             }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -1297,8 +1297,8 @@ public class RtcSession internal constructor(
 
                             if (event.trackType == TrackType.TRACK_TYPE_AUDIO) {
                                 if (event.sessionId == sessionId) {
-                                    val isMicEnabled = call.mediaManager.microphone.isEnabled.value
-                                    if (isMicEnabled) {
+                                    val isMicDisabled = !call.mediaManager.microphone.isEnabled.value
+                                    if (isMicDisabled) {
                                         setMuteState(isEnabled = false, event.trackType)
                                         publisher?.unpublishStream(event.trackType)
                                     }


### PR DESCRIPTION
### Goal

Fix: Microphone audio leaks to remote participants after muting on call join

Problem: When a user joins a call and turns off their microphone immediately, other participants can still hear them despite the mic being toggled off.

### Implementation

**Investigation**

If the microphone is toggled between `JoinCallResponseEvent` and `TrackPublishedEvent`, the mute state is not correctly reflected to other participants.

Microphone toggling works as expected after `TrackPublishedEvent` is received, where a subsequent mute action results in a `TrackUnpublishedEvent` being emitted.

**Proposal** - 
After getting `TrackPublishedEvent` in `RtcSession`, we should check if mic is toggled off-or not. If set to off then set it to mute via


```kotlin 
if (event.trackType == TrackType.TRACK_TYPE_AUDIO) {
    if (!isMicEnabled) {
        setMuteState(isEnabled = false, event.trackType) 
        publisher?.unpublishStream(event.trackType)
     }
 }
```


### 🎨 UI Changes

None


### Testing

1.	Join a video room with User A and User B. User B will act as the remote participant to verify whether any audio leaks while User A is muted.
2.	Pass the lobby and enter the call.
3.	As soon as `StreamCallActivity` appears and the microphone is visible as enabled, immediately toggle the mic off.
4.	Wait for ~3–4 seconds until the `TrackPublishedEvent` is received.
5.	Speak into the microphone and confirm that no audio is heard by User B, ensuring that audio is not leaking despite the mic being muted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed audio track handling when the microphone is disabled. Audio streams now properly unpublish and track state is correctly updated when microphone is turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->