### PR TITLE
Improve Foreground Service orchestration when transitioning from outgoing call to active call

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
@@ -298,6 +298,20 @@ object StreamVideoInitHelper {
                                 )
                             }
 
+                            override fun getOngoingCallBundle(
+                                callId: StreamCallId,
+                                notificationId: Int,
+                                payload: Map<String, Any?>,
+                            ): Bundle {
+                                return StreamCallActivity.callIntentBundle(
+                                    callId,
+                                    configuration = StreamCallActivityConfiguration(
+                                        closeScreenOnCallEnded = true,
+                                    ),
+                                    leaveWhenLastInCall = true,
+                                )
+                            }
+
                             override fun getAcceptCallBundle(
                                 callId: StreamCallId,
                                 notificationId: Int,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1781,6 +1781,11 @@ public class CallState(
         this.atomicNotification.set(notification)
     }
 
+    @InternalStreamVideoApi
+    fun setOwnCapabilities(ownCapability: List<OwnCapability>) {
+        this._ownCapabilities.value = ownCapability
+    }
+
     /**
      * [RingingState.Incoming] and [RingingState.Outgoing] are intentionally not observed.
      * In Android Telecom, hold states are only applicable once a call is active (answered).

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
@@ -190,7 +190,7 @@ class ClientState(private val client: StreamVideo) {
                 val callServiceConfig = callConfigRegistry.get(call.type)
                 val serviceClass = callServiceConfig.serviceClass
                 val isServiceRunning = ServiceIntentBuilder()
-                    .isServiceRunning(this.client.context, serviceClass::class.java)
+                    .isServiceRunning(this.client.context, serviceClass)
                 if (callServiceConfig.runCallServiceInForeground) {
                     if (!isServiceRunning) {
                         logger.e { "Outgoing call service should already be running" }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
@@ -25,6 +25,7 @@ import io.getstream.log.taggedLogger
 import io.getstream.result.Error
 import io.getstream.video.android.core.internal.InternalStreamVideoApi
 import io.getstream.video.android.core.notifications.internal.service.CallService
+import io.getstream.video.android.core.notifications.internal.service.ServiceIntentBuilder
 import io.getstream.video.android.core.notifications.internal.service.ServiceLauncher
 import io.getstream.video.android.core.notifications.internal.telecom.TelecomIntegrationType
 import io.getstream.video.android.core.socket.coordinator.state.VideoSocketState
@@ -184,9 +185,16 @@ class ClientState(private val client: StreamVideo) {
                 if (!call.state.isJoinAndRingInProgress.get()) {
                     transitionToAcceptCall(call)
                 }
-                call.scope.launch {
-                    delay(serviceTransitionDelayMs)
-                    maybeStartForegroundService(call, CallService.TRIGGER_ONGOING_CALL)
+                // Intentionally skipping maybeStartForegroundService because service should already be started
+                // when initiating outgoing-call
+                val callServiceConfig = callConfigRegistry.get(call.type)
+                val serviceClass = callServiceConfig.serviceClass
+                val isServiceRunning = ServiceIntentBuilder()
+                    .isServiceRunning(this.client.context, serviceClass::class.java)
+                if (callServiceConfig.runCallServiceInForeground) {
+                    if (!isServiceRunning) {
+                        logger.e { "Outgoing call service should already be running" }
+                    }
                 }
             }
             else -> {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/StreamForegroundPermissionUtil.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/StreamForegroundPermissionUtil.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications.internal.service
+
+import io.getstream.video.android.core.StreamVideo
+import io.getstream.video.android.core.StreamVideoClient
+import io.getstream.video.android.core.internal.InternalStreamVideoApi
+import io.getstream.video.android.core.notifications.internal.service.permissions.AudioCallPermissionManager
+import io.getstream.video.android.core.notifications.internal.service.permissions.ForegroundServicePermissionManager
+import kotlin.jvm.java
+
+@InternalStreamVideoApi
+public object StreamForegroundPermissionUtil {
+
+    public fun getForegroundPermissionsForCallType(callType: String): Set<Int> {
+        val client = StreamVideo.instanceOrNull() as? StreamVideoClient
+        if (client != null) {
+            val config = client.callServiceConfigRegistry.get(callType)
+            return when (config.serviceClass) {
+                CallService::class.java -> ForegroundServicePermissionManager().requiredForegroundTypes
+                AudioCallService::class.java -> AudioCallPermissionManager().requiredForegroundTypes
+                else -> setOf(-1)
+            }
+        }
+        return setOf(-1)
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/StreamForegroundPermissionUtil.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/StreamForegroundPermissionUtil.kt
@@ -33,9 +33,9 @@ public object StreamForegroundPermissionUtil {
             return when (config.serviceClass) {
                 CallService::class.java -> ForegroundServicePermissionManager().requiredForegroundTypes
                 AudioCallService::class.java -> AudioCallPermissionManager().requiredForegroundTypes
-                else -> setOf(-1)
+                else -> emptySet()
             }
         }
-        return setOf(-1)
+        return emptySet()
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/observers/CallServiceNotificationUpdateObserver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/observers/CallServiceNotificationUpdateObserver.kt
@@ -21,7 +21,6 @@ import android.content.Context
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.RingingState
-import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.internal.ExperimentalStreamVideoApi
 import io.getstream.video.android.core.notifications.NotificationType
@@ -119,7 +118,7 @@ internal class CallServiceNotificationUpdateObserver(
 
         when (ringingState) {
             is RingingState.Active -> {
-                showActiveCallNotification(context, callId, notification)
+                showActiveCallNotification(callId, notification)
             }
             is RingingState.Outgoing -> {
                 showOutgoingCallNotification(context, callId, notification)
@@ -134,7 +133,6 @@ internal class CallServiceNotificationUpdateObserver(
     }
 
     private fun showActiveCallNotification(
-        context: Context,
         callId: StreamCallId,
         notification: Notification,
     ) {
@@ -142,9 +140,9 @@ internal class CallServiceNotificationUpdateObserver(
         val notificationId =
             call.state.notificationIdFlow.value ?: callId.getNotificationId(NotificationType.Ongoing)
 
-        StreamVideo.instanceOrNull()
-            ?.getStreamNotificationDispatcher()
-            ?.notify(
+        streamVideo
+            .getStreamNotificationDispatcher()
+            .notify(
                 callId,
                 notificationId,
                 notification,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/observers/CallServiceNotificationUpdateObserver.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/observers/CallServiceNotificationUpdateObserver.kt
@@ -21,6 +21,7 @@ import android.content.Context
 import io.getstream.log.taggedLogger
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.RingingState
+import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.internal.ExperimentalStreamVideoApi
 import io.getstream.video.android.core.notifications.NotificationType
@@ -140,12 +141,14 @@ internal class CallServiceNotificationUpdateObserver(
         logger.d { "[showActiveCallNotification] Showing active call notification" }
         val notificationId =
             call.state.notificationIdFlow.value ?: callId.getNotificationId(NotificationType.Ongoing)
-        startForegroundWithServiceType(
-            notificationId,
-            notification,
-            CallService.Companion.TRIGGER_ONGOING_CALL,
-            permissionManager.getServiceType(context, CallService.Companion.TRIGGER_ONGOING_CALL),
-        )
+
+        StreamVideo.instanceOrNull()
+            ?.getStreamNotificationDispatcher()
+            ?.notify(
+                callId,
+                notificationId,
+                notification,
+            )
     }
 
     private fun showOutgoingCallNotification(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/permissions/ForegroundServicePermissionManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/permissions/ForegroundServicePermissionManager.kt
@@ -53,7 +53,9 @@ internal open class ForegroundServicePermissionManager {
 
     fun getServiceType(context: Context, trigger: String): Int {
         return when (trigger) {
-            CallService.Companion.TRIGGER_ONGOING_CALL -> calculateServiceType(context)
+            CallService.Companion.TRIGGER_ONGOING_CALL,
+            CallService.Companion.TRIGGER_OUTGOING_CALL,
+            -> calculateServiceType(context)
             else -> noPermissionServiceType()
         }
     }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/service/observers/CallServiceNotificationUpdateObserverTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/service/observers/CallServiceNotificationUpdateObserverTest.kt
@@ -26,12 +26,14 @@ import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.core.RingingState
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.notifications.NotificationType
+import io.getstream.video.android.core.notifications.dispatchers.DefaultNotificationDispatcher
 import io.getstream.video.android.core.notifications.internal.service.CallService
 import io.getstream.video.android.core.notifications.internal.service.permissions.ForegroundServicePermissionManager
 import io.getstream.video.android.model.StreamCallId
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -135,7 +137,6 @@ class CallServiceNotificationUpdateObserverTest {
     @Test
     fun `incoming ringing state starts incoming foreground notification`() = runTest {
         observer.observe(context)
-//        advanceUntilIdle()
 
         ringingStateFlow.value = RingingState.Incoming()
         advanceUntilIdle()
@@ -171,21 +172,31 @@ class CallServiceNotificationUpdateObserverTest {
     }
 
     @Test
-    fun `active ringing state starts ongoing foreground notification`() = runTest {
+    fun `active ringing state dispatches ongoing call notification`() = runTest {
+        val notificationDispatcher = mockk<DefaultNotificationDispatcher>(relaxed = true)
+        val mockNotification = mockk<Notification>()
+
+        every { streamVideo.getStreamNotificationDispatcher() } returns notificationDispatcher
+        coEvery { streamVideo.onCallNotificationUpdate(call) } returns mockNotification
+
         observer.observe(context)
+
         advanceUntilIdle()
 
         ringingStateFlow.value = RingingState.Active
-        advanceUntilIdle()
-        advanceTimeBy(100L)
 
-        val args = startArgs!!
-        assertEquals(
-            StreamCallId("default", "call-1")
-                .getNotificationId(NotificationType.Ongoing),
-            args.first,
-        )
-        assertEquals(CallService.TRIGGER_ONGOING_CALL, args.third)
+        advanceUntilIdle()
+        advanceTimeBy(100)
+
+        val streamCallId = StreamCallId("default", "call-1")
+
+        verify {
+            notificationDispatcher.notify(
+                streamCallId,
+                streamCallId.getNotificationId(NotificationType.Ongoing),
+                mockNotification,
+            )
+        }
     }
 
     @Test

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -124,9 +124,38 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                             .systemBarsPadding(),
                     ) {
                         logger.d { "[setContent] with RootContent" }
-                        activity.RootContent(call = call)
+
+                        val renderPermissionUi by activity.renderPermissionUi.collectAsStateWithLifecycle()
+                        if (renderPermissionUi) {
+                            NoPermissionUi(activity, call) {
+                                activity.updateRenderPermissionUi(false)
+                            }
+                        } else {
+                            activity.RootContent(call = call)
+                        }
                     }
                 }
+            }
+        }
+    }
+
+    @Composable
+    private fun NoPermissionUi(
+        activity: StreamCallActivity,
+        call: Call,
+        onAllPermissionGranted: () -> Unit,
+    ) {
+        LaunchPermissionRequest(getRequiredPermissions(call)) {
+            AllPermissionsGranted {
+                onAllPermissionGranted()
+            }
+
+            SomeGranted { granted, notGranted, showRationale ->
+                activity.InternalPermissionContent(showRationale, call, granted, notGranted)
+            }
+
+            NoneGranted {
+                activity.InternalPermissionContent(it, call, emptyList(), emptyList())
             }
         }
     }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/StreamCallActivityComposeDelegate.kt
@@ -398,6 +398,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
     ) {
         if (!showRationale && configurationMap[call.id]?.canSkipPermissionRationale == true) {
             logger.w { "Permissions were not granted, but rationale is required to be skipped." }
+            updateRenderPermissionUi(false)
             safeFinish()
         } else {
             PermissionsRationaleContent(call, granted, notGranted)
@@ -628,6 +629,7 @@ public open class StreamCallActivityComposeDelegate : StreamCallActivityComposeU
                     ButtonStyles.tertiaryButtonStyle(StyleSize.S),
                 ) {
                     // No permissions, leave the call
+                    updateRenderPermissionUi(false)
                     onCallAction(call, LeaveCall)
                 },
             )

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -99,6 +99,7 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	protected final fun getOnErrorFinish ()Lkotlin/jvm/functions/Function2;
 	protected final fun getOnSuccessFinish ()Lkotlin/jvm/functions/Function2;
 	public fun getParticipantUpdateDebounce (Lio/getstream/video/android/core/Call;)J
+	public final fun getRenderPermissionUi ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getUiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
 	protected fun handleOnNewIncomingCallAcceptAction ()V
 	protected fun handleOnNewIncomingCallAction ()V
@@ -134,6 +135,8 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun reject (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/model/RejectReason;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public final fun safeFinish ()V
 	protected fun setCallHandlerDelegate (Lio/getstream/video/android/ui/common/IncomingCallHandlerDelegate;)V
+	public final fun setRenderPermissionUi (Lkotlinx/coroutines/flow/StateFlow;)V
+	public final fun updateRenderPermissionUi (Z)V
 }
 
 public final class io/getstream/video/android/ui/common/StreamCallActivity$Companion {

--- a/stream-video-android-ui-core/api/stream-video-android-ui-core.api
+++ b/stream-video-android-ui-core/api/stream-video-android-ui-core.api
@@ -99,7 +99,6 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	protected final fun getOnErrorFinish ()Lkotlin/jvm/functions/Function2;
 	protected final fun getOnSuccessFinish ()Lkotlin/jvm/functions/Function2;
 	public fun getParticipantUpdateDebounce (Lio/getstream/video/android/core/Call;)J
-	public final fun getRenderPermissionUi ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getUiDelegate ()Lio/getstream/video/android/ui/common/StreamActivityUiDelegate;
 	protected fun handleOnNewIncomingCallAcceptAction ()V
 	protected fun handleOnNewIncomingCallAction ()V
@@ -135,8 +134,6 @@ public abstract class io/getstream/video/android/ui/common/StreamCallActivity : 
 	public fun reject (Lio/getstream/video/android/core/Call;Lio/getstream/video/android/core/model/RejectReason;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;)V
 	public final fun safeFinish ()V
 	protected fun setCallHandlerDelegate (Lio/getstream/video/android/ui/common/IncomingCallHandlerDelegate;)V
-	public final fun setRenderPermissionUi (Lkotlinx/coroutines/flow/StateFlow;)V
-	public final fun updateRenderPermissionUi (Z)V
 }
 
 public final class io/getstream/video/android/ui/common/StreamCallActivity$Companion {
@@ -233,8 +230,6 @@ public final class io/getstream/video/android/ui/common/util/ColorUtilsKt {
 
 public final class io/getstream/video/android/ui/common/util/ParticipantsTextKt {
 	public static final fun buildLargeCallText (Landroid/content/Context;Ljava/util/List;)Ljava/lang/String;
-	public static final fun buildSmallCallText (Landroid/content/Context;Ljava/util/List;IZ)Ljava/lang/String;
-	public static synthetic fun buildSmallCallText$default (Landroid/content/Context;Ljava/util/List;IZILjava/lang/Object;)Ljava/lang/String;
 }
 
 public final class io/getstream/video/android/ui/common/util/ResourcesKt {

--- a/stream-video-android-ui-core/build.gradle.kts
+++ b/stream-video-android-ui-core/build.gradle.kts
@@ -17,6 +17,9 @@
 plugins {
     id("io.getstream.video.android.library")
 }
+apiValidation {
+    nonPublicMarkers.add("io.getstream.video.android.core.internal.InternalStreamVideoApi")
+}
 
 android {
     namespace = "io.getstream.video.android.ui.common"

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -874,7 +874,9 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
                 result.onOutcome(call, onSuccess, onError)
             } else {
                 _renderPermissionUi.value = true
-                uiDelegate.setContent(activity = this@StreamCallActivity, call)
+                withContext(Dispatchers.Main) {
+                    uiDelegate.setContent(activity = this@StreamCallActivity, call)
+                }
                 renderPermissionUi.first { !it }
                 create(call, ring, members, onSuccess, onError)
             }

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -22,6 +22,8 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_CAMERA
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_MICROPHONE
 import android.os.Build
 import android.os.Bundle
 import android.os.PersistableBundle
@@ -59,9 +61,11 @@ import io.getstream.video.android.core.call.state.ToggleMicrophone
 import io.getstream.video.android.core.call.state.ToggleSpeakerphone
 import io.getstream.video.android.core.events.CallEndedSfuEvent
 import io.getstream.video.android.core.events.ParticipantLeftEvent
+import io.getstream.video.android.core.internal.InternalStreamVideoApi
 import io.getstream.video.android.core.model.RejectReason
 import io.getstream.video.android.core.notifications.NotificationHandler
 import io.getstream.video.android.core.notifications.dispatchers.DefaultNotificationDispatcher
+import io.getstream.video.android.core.notifications.internal.service.StreamForegroundPermissionUtil
 import io.getstream.video.android.core.notifications.internal.telecom.TelecomCallController
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.streamCallId
@@ -76,8 +80,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -174,6 +181,16 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
     // Internal state
     private var callSocketConnectionMonitor: Job? = null
     private lateinit var cachedCall: Call
+
+    private val _renderPermissionUi = MutableStateFlow(false)
+
+    @InternalStreamVideoApi
+    public var renderPermissionUi: StateFlow<Boolean> = _renderPermissionUi
+
+    @InternalStreamVideoApi
+    public fun updateRenderPermissionUi(render: Boolean) {
+        _renderPermissionUi.value = render
+    }
 
     @Deprecated(
         "Use configurationMap instead",
@@ -840,16 +857,50 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
         onSuccess: (suspend (Call) -> Unit)?,
         onError: (suspend (Exception) -> Unit)?,
     ) {
+        setCallCapabilitiesIfNotPresent(call)
         lifecycleScope.launch(Dispatchers.IO) {
-            val instance = StreamVideo.instance()
-            val result = call.create(
-                // List of all users, containing the caller also
-                memberIds = members + instance.userId,
-                // If other users will get push notification.
-                ring = ring,
+            val hasCallPermission = PermissionManager.hasRequiredCallPermissions(
+                this@StreamCallActivity,
+                call,
             )
-            result.onOutcome(call, onSuccess, onError)
+            if (hasCallPermission) {
+                val instance = StreamVideo.instance()
+                val result = call.create(
+                    // List of all users, containing the caller also
+                    memberIds = members + instance.userId,
+                    // If other users will get push notification.
+                    ring = ring,
+                )
+                result.onOutcome(call, onSuccess, onError)
+            } else {
+                _renderPermissionUi.value = true
+                uiDelegate.setContent(activity = this@StreamCallActivity, call)
+                renderPermissionUi.first { !it }
+                create(call, ring, members, onSuccess, onError)
+            }
         }
+    }
+
+    private fun setCallCapabilitiesIfNotPresent(call: Call) {
+        if (call.state.ownCapabilities.value.isNotEmpty()) return
+
+        val outgoingCallCapabilities = ArrayList<OwnCapability>()
+        if (intent.action == NotificationHandler.ACTION_OUTGOING_CALL) {
+            val permissionTypes = StreamForegroundPermissionUtil.getForegroundPermissionsForCallType(
+                call.type,
+            )
+            for (permission in permissionTypes) {
+                when (permission) {
+                    FOREGROUND_SERVICE_TYPE_CAMERA -> outgoingCallCapabilities.add(
+                        OwnCapability.SendVideo,
+                    )
+                    FOREGROUND_SERVICE_TYPE_MICROPHONE -> outgoingCallCapabilities.add(
+                        OwnCapability.SendAudio,
+                    )
+                }
+            }
+        }
+        call.state.setOwnCapabilities(outgoingCallCapabilities)
     }
 
     /**

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -878,6 +878,15 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
                     uiDelegate.setContent(activity = this@StreamCallActivity, call)
                 }
                 renderPermissionUi.first { !it }
+
+                // check if permissions were actually granted or denied
+                val permissionsNowGranted = PermissionManager.hasRequiredCallPermissions(
+                    this@StreamCallActivity,
+                    call,
+                )
+                if (!permissionsNowGranted) {
+                    return@launch
+                }
                 create(call, ring, members, onSuccess, onError)
             }
         }


### PR DESCRIPTION
### Goal

1. Transition from Outgoing call to active call should not crash when launching FG Service
2. Render no permission when permissions are missing in making outgoing call 

### Implementation

1. Transition from Outgoing call to active call should not crash when launching FG Service

Root Cause - Launching FG Service even when the application is in background and ringing state transitions from outgoing to active

Proposed Solution
1. Launch only FG Serive once with trigger type as outgoing-call

Because of this we need to correctly handle the following
2. Correctly update the notification transition from outgoing to active

### 🎨 UI Changes

Just a no permission ui in outgoing-call flow

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_



### Testing

Scenario: Outgoing call → background → call accepted
	1.	Make an outgoing call to another user.
	2.	While the call is still in the outgoing state, press the Home button to send the app to the background.
	3.	Accept the call on the other device.

Expected behavior
	•	The caller should transition smoothly from outgoing → active state.
	•	PiP should not be rendered, since it was never shown before the app went to the background.
	•	The Call Service should continue running without interruption.
	•	The notification should update from outgoing → active.

End condition
	•	If either the caller or callee declines/ends the call, the other participant should also leave the call and the session should terminate correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a permission request UI for foreground service permissions during call setup.
  * Enhanced capability management to properly reflect available permissions for outgoing calls.

* **Bug Fixes**
  * Improved foreground service handling to prevent unnecessary service starts and log errors when required services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->