### PR TITLE
Early promote to FG service for active calls

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -655,22 +655,13 @@ internal open class CallService : Service() {
         notificationId: Int,
         trigger: String,
     ) {
-        val hasActiveCall = videoClient.state.activeCall.value != null
-        val not = if (hasActiveCall) " not" else ""
-
-        logger.d {
-            "[promoteToFgServiceIfNoActiveCall] hasActiveCall: $hasActiveCall. Will$not call startForeground early."
-        }
-
-        if (!hasActiveCall) {
-            videoClient.getSettingUpCallNotification()?.let { notification ->
-                startForegroundWithServiceType(
-                    notificationId,
-                    notification,
-                    trigger,
-                    permissionManager.getServiceType(baseContext, trigger),
-                )
-            }
+        videoClient.getSettingUpCallNotification()?.let { notification ->
+            startForegroundWithServiceType(
+                notificationId,
+                notification,
+                trigger,
+                permissionManager.getServiceType(baseContext, trigger),
+            )
         }
     }
 


### PR DESCRIPTION
### Goal

Resolve `ForegroundServiceDidNotStartInTimeException` for ongoing calls

### Implementation

Early promote to FG service for active calls

### 🎨 UI Changes

None

### Testing

Simple call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call notification reliability by ensuring foreground service properly initiates whenever a notification is available, regardless of current call status. This resolves inconsistent notification delivery during calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->