### PR TITLE
Bump stream-push version to 1.3.4

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -54,7 +54,7 @@ streamNoiseCancellation = "1.0.4"
 streamResult = "1.3.0"
 streamChat = "6.10.0"
 streamLog = "1.3.2"
-streamPush = "1.3.1"
+streamPush = "1.3.4"
 streamRenderscript = "0.0.1"
 
 androidxTestRunner = "1.6.2"


### PR DESCRIPTION
### Goal

Update the `stream-android-push` library from `1.3.1` to `1.3.4`.

### Implementation

Bumped `streamPush` version in `gradle/libs.versions.toml`. This updates all push-related dependencies:
- `stream-android-push`
- `stream-android-push-delegate`
- `stream-android-push-firebase`
- `stream-android-push-permissions`

### Testing

- [ ] Verify push notifications work on a real device (Firebase)
- [ ] Verify ringing calls trigger push correctly
- [ ] Verify the app builds and all existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated streamPush library dependency to version 1.3.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->