### PR TITLE
Prevent ringing state updates after `RingingState.Timeout`

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1259,8 +1259,12 @@ public class CallState(
     }
 
     private fun updateRingingState(rejectReason: RejectReason? = null) {
-        if (ringingState.value == RingingState.RejectedByAll) {
-            return
+        when (ringingState.value) {
+            RingingState.TimeoutNoAnswer, RingingState.RejectedByAll -> {
+                return
+            }
+
+            else -> {}
         }
 
         // this is only true when we are in the session (we have accepted/joined the call)


### PR DESCRIPTION
### Goal

Prevent updating ringing state after reaching `RingingState.Timeout`

### Implementation

Prevent updating ringing state after reaching `RingingState.Timeout`

### 🎨 UI Changes

None

### Testing

1. Login with User A on both web and Android.
2. Initiate a call from User B to User A.
3. Accept the call on the web platform — Android should transition Ringing state  `RingingState.Timeout` to and render the main screen.
4. Check for logs with tag RingingState to verify Ringing state transitions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call state handling for timeout and rejection scenarios to prevent unnecessary state recalculations, ensuring more reliable call management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->