### PR TITLE
Update build conventions to v0.10.0

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   base-android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.10.0
     secrets: inherit

--- a/.github/workflows/pr-clean-old-drafts.yaml
+++ b/.github/workflows/pr-clean-old-drafts.yaml
@@ -13,5 +13,5 @@ permissions:
 
 jobs:
   pr-clean-stale:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.10.0
     secrets: inherit

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -15,5 +15,5 @@ concurrency:
 
 jobs:
   pr-checklist:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.10.0
     secrets: inherit

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.10.0
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -9,7 +9,7 @@ concurrency:
 
 jobs:
   compare-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-checks.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-checks.yml@v0.10.0
     with:
       modules: "stream-video-android-core stream-video-android-ui-xml stream-video-android-ui-compose"
       metrics-project: "stream-video-android-metrics"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.9.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.10.0
     with:
       modules: "stream-video-android-core stream-video-android-ui-xml stream-video-android-ui-compose"
       metrics-project: "stream-video-android-metrics"


### PR DESCRIPTION
### Goal

Update `stream-build-conventions-android` workflow references to the latest version (v0.10.0).

### Implementation

Bumped the `@v0.9.0` tag to `@v0.10.0` in all CI workflow files that reference `stream-build-conventions-android`:

- `android.yml` — android-ci
- `pr-quality.yml` — PR checklist
- `pr-clean-old-drafts.yaml` — stale PR cleanup
- `publish-new-version.yml` — release publishing
- `sdk-size-checks.yml` — SDK size checks
- `sdk-size-updates.yml` — SDK size updates

### Testing

CI workflows will validate themselves — this PR's checks run on the updated conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal CI/CD pipeline infrastructure versions to the latest stable release for improved build reliability and performance across Android development, pull request validation, version publishing, and SDK size tracking workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->