### PR TITLE
Add local coordinator support for dev/testing

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
@@ -67,6 +67,58 @@ public enum class InitializedState {
     NOT_STARTED, RUNNING, FINISHED, FAILED
 }
 
+/**
+ * Configuration for connecting to a local dev environment instead of the cloud.
+ * Set [StreamVideoInitHelper.localDevConfig] before calling [StreamVideoInitHelper.loadSdk].
+ *
+ * Provide either [token] directly or [secret] to auto-generate a signed JWT.
+ * The SFU address is resolved automatically by the local coordinator's join response.
+ *
+ * @property coordinatorAddress Local coordinator IP:port (e.g. "192.168.1.2:3030").
+ * @property apiKey API key from the local coordinator database.
+ * @property secret API secret from the local coordinator — used to sign a JWT for [userId].
+ * @property userId User ID to connect as.
+ * @property token Pre-generated JWT token. If null, one is generated from [secret].
+ */
+data class LocalDevConfig(
+    val coordinatorAddress: String,
+    val apiKey: String,
+    val userId: String,
+    val secret: String? = null,
+    val token: String? = null,
+) {
+    init {
+        require(secret != null || token != null) {
+            "LocalDevConfig requires either 'secret' (to generate a token) or a pre-generated 'token'."
+        }
+    }
+
+    fun resolveToken(): String = token ?: generateSignedToken()
+
+    private fun generateSignedToken(): String {
+        val secret = requireNotNull(secret)
+        fun base64Url(data: ByteArray): String =
+            android.util.Base64.encodeToString(
+                data,
+                android.util.Base64.URL_SAFE or android.util.Base64.NO_WRAP or android.util.Base64.NO_PADDING,
+            )
+
+        val header = base64Url(
+            "{\"alg\":\"HS256\",\"typ\":\"JWT\"}".toByteArray(Charsets.UTF_8),
+        )
+        val now = System.currentTimeMillis() / 1000
+        val payload = base64Url(
+            "{\"user_id\":\"$userId\",\"iat\":$now,\"exp\":${now + 86_400}}"
+                .toByteArray(Charsets.UTF_8),
+        )
+        val signingInput = "$header.$payload"
+        val mac = javax.crypto.Mac.getInstance("HmacSHA256")
+        mac.init(javax.crypto.spec.SecretKeySpec(secret.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        val signature = base64Url(mac.doFinal(signingInput.toByteArray(Charsets.UTF_8)))
+        return "$signingInput.$signature"
+    }
+}
+
 @SuppressLint("StaticFieldLeak")
 object StreamVideoInitHelper {
 
@@ -84,19 +136,22 @@ object StreamVideoInitHelper {
     suspend fun reloadSdk(
         dataStore: StreamUserDataStore,
         useRandomUserAsFallback: Boolean = true,
+        localDevConfig: LocalDevConfig? = null,
     ) {
         StreamVideo.removeClient()
-        loadSdk(dataStore, useRandomUserAsFallback)
+        loadSdk(dataStore, useRandomUserAsFallback, localDevConfig)
     }
 
     /**
      * A helper function that will initialise the [StreamVideo] SDK and also the [ChatClient].
      * Set [useRandomUserAsFallback] to true if you want to use a guest fallback if the user is not
      * logged in.
+     * Pass [localDevConfig] to bypass cloud auth and connect to a local coordinator instead.
      */
     suspend fun loadSdk(
         dataStore: StreamUserDataStore,
         useRandomUserAsFallback: Boolean = true,
+        localDevConfig: LocalDevConfig? = null,
     ) = AppConfig.load(context) {
         if (StreamVideo.isInstalled) {
             _initState.value = InitializedState.FINISHED
@@ -114,52 +169,74 @@ object StreamVideoInitHelper {
         _initState.value = InitializedState.RUNNING
 
         try {
-            // Load the signed-in user (can be null)
-            var loggedInUser = dataStore.data.firstOrNull()?.user
-            var authData: GetAuthDataResponse? = null
-
-            // Create and login a random new user if user is null and we allow a random user login
-            if (loggedInUser == null && useRandomUserAsFallback) {
-                val userId = UserHelper.generateRandomString()
-
-                authData = StreamService.instance.getAuthData(
-                    environment = AppConfig.currentEnvironment.value!!.env,
-                    userId = userId,
-                    StreamService.TOKEN_EXPIRY_TIME,
-                )
-
-                loggedInUser = User(id = authData.userId, role = "admin")
-
-                // Store the data (note that this datastore belongs to the client - it's not
-                // used by the SDK directly in any way)
+            if (localDevConfig != null) {
+                val localCfg = localDevConfig
+                val loggedInUser = User(id = localCfg.userId, role = "admin")
                 dataStore.updateUser(loggedInUser)
-            }
 
-            // If we have a logged in user (from the data store or randomly created above)
-            // then we can initialise the SDK
-            if (loggedInUser != null) {
-                if (authData == null) {
-                    authData = StreamService.instance.getAuthData(
-                        environment = AppConfig.currentEnvironment.value!!.env,
-                        userId = loggedInUser.id,
-                        StreamService.TOKEN_EXPIRY_TIME,
-                    )
-                }
-
-                initializeStreamChat(
-                    context = context,
-                    apiKey = authData.apiKey,
-                    user = loggedInUser,
-                    token = authData.token,
-                )
+                ChatClient.Builder(localCfg.apiKey, context)
+                    .logLevel(if (BuildConfig.DEBUG) ChatLogLevel.ALL else ChatLogLevel.NOTHING)
+                    .build()
 
                 initializeStreamVideo(
                     context = context,
-                    apiKey = authData.apiKey,
+                    apiKey = localCfg.apiKey,
                     user = loggedInUser,
-                    token = authData.token,
+                    token = localCfg.resolveToken(),
                     loggingLevel = LoggingLevel(priority = Priority.VERBOSE),
+                    localCoordinatorAddress = localCfg.coordinatorAddress,
+                    localTokenProvider = object : TokenProvider {
+                        override suspend fun loadToken(): String = localCfg.resolveToken()
+                    },
                 )
+            } else {
+                // Load the signed-in user (can be null)
+                var loggedInUser = dataStore.data.firstOrNull()?.user
+                var authData: GetAuthDataResponse? = null
+
+                // Create and login a random new user if user is null and we allow a random user login
+                if (loggedInUser == null && useRandomUserAsFallback) {
+                    val userId = UserHelper.generateRandomString()
+
+                    authData = StreamService.instance.getAuthData(
+                        environment = AppConfig.currentEnvironment.value!!.env,
+                        userId = userId,
+                        StreamService.TOKEN_EXPIRY_TIME,
+                    )
+
+                    loggedInUser = User(id = authData.userId, role = "admin")
+
+                    // Store the data (note that this datastore belongs to the client - it's not
+                    // used by the SDK directly in any way)
+                    dataStore.updateUser(loggedInUser)
+                }
+
+                // If we have a logged in user (from the data store or randomly created above)
+                // then we can initialise the SDK
+                if (loggedInUser != null) {
+                    if (authData == null) {
+                        authData = StreamService.instance.getAuthData(
+                            environment = AppConfig.currentEnvironment.value!!.env,
+                            userId = loggedInUser.id,
+                            StreamService.TOKEN_EXPIRY_TIME,
+                        )
+                    }
+
+                    initializeStreamChat(
+                        context = context,
+                        apiKey = authData.apiKey,
+                        user = loggedInUser,
+                        token = authData.token,
+                    )
+
+                    initializeStreamVideo(
+                        context = context,
+                        apiKey = authData.apiKey,
+                        user = loggedInUser,
+                        token = authData.token,
+                        loggingLevel = LoggingLevel(priority = Priority.VERBOSE),
+                    )
+                }
             }
             /**
              * The `connectOnInit` flag in `StreamVideoInitHelper` is set to `false` to give us
@@ -233,6 +310,8 @@ object StreamVideoInitHelper {
         user: User,
         token: String,
         loggingLevel: LoggingLevel,
+        localCoordinatorAddress: String? = null,
+        localTokenProvider: TokenProvider? = null,
     ): StreamVideo {
         val callServiceConfigRegistry = CallServiceConfigRegistry()
         callServiceConfigRegistry.apply {
@@ -265,6 +344,7 @@ object StreamVideoInitHelper {
             connectionTimeoutInMs = 12_000L,
             loggingLevel = loggingLevel,
             ensureSingleInstance = false,
+            localCoordinatorAddress = localCoordinatorAddress,
             callServiceConfigRegistry = callServiceConfigRegistry,
             vibrationConfig = enableRingingCallVibrationConfig(),
             notificationConfig = testNotificationConfig ?: NotificationConfig(
@@ -328,7 +408,7 @@ object StreamVideoInitHelper {
                     ),
                 ),
             ),
-            tokenProvider = object : TokenProvider {
+            tokenProvider = localTokenProvider ?: object : TokenProvider {
                 override suspend fun loadToken(): String {
                     val userEmail = user.custom?.get("email")
                     val userId = user.id

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -87,7 +87,7 @@ import java.net.ConnectException
  * @property ensureSingleInstance Verify that only 1 version of the video client exists. Prevents integration mistakes.
  * @property videoDomain URL overwrite to allow for testing against a local instance of video.
  * @property callServiceConfig Configuration for the call foreground service. See [CallServiceConfig]. (Deprecated) Use `callServiceConfigRegistry` instead.
- * @property localSfuAddress Local SFU address (IP:port) to be used for testing. Leave null if not needed.
+ * @property localCoordinatorAddress Local coordinator address (IP:port) to be used for testing. Leave null if not needed.
  * @property sounds Overwrite the default SDK sounds. See [io.getstream.video.android.core.sounds.RingingConfig].
  * @property permissionCheck Used to check for system permission based on call capabilities. See [StreamPermissionCheck].
  * @property crashOnMissingPermission Throw an exception or just log an error if [permissionCheck] fails.
@@ -142,7 +142,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
     )
     private val callServiceConfig: CallServiceConfig? = null,
     private val callServiceConfigRegistry: CallServiceConfigRegistry? = null,
-    private val localSfuAddress: String? = null,
+    private val localCoordinatorAddress: String? = null,
     private val sounds: Sounds = defaultResourcesRingingConfig(context).toSounds(),
     private val vibrationConfig: RingingCallVibrationConfig = disableVibrationConfig(),
     private val crashOnMissingPermission: Boolean = false,
@@ -234,11 +234,18 @@ public class StreamVideoBuilder @JvmOverloads constructor(
         AndroidThreeTen.init(context)
         tokenRepository.updateToken(token)
         // This connection module class exposes the connections to the various retrofit APIs.
+        val resolvedApiUrl = localCoordinatorAddress?.let {
+            "http://${it.trimEnd('/')}"
+        } ?: apiUrl ?: "https:///$videoDomain"
+        val resolvedWssUrl = localCoordinatorAddress?.let {
+            "ws://${it.trimEnd('/')}/video/connect"
+        } ?: wssUrl ?: "wss://$videoDomain/video/connect"
+
         val coordinatorConnectionModule = CoordinatorConnectionModule(
             context = context,
             scope = scope,
-            apiUrl = apiUrl ?: "https:///$videoDomain",
-            wssUrl = wssUrl ?: "wss://$videoDomain/video/connect",
+            apiUrl = resolvedApiUrl,
+            wssUrl = resolvedWssUrl,
             connectionTimeoutInMs = connectionTimeoutInMs,
             loggingLevel = loggingLevel,
             user = user,
@@ -278,7 +285,6 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             streamNotificationManager = streamNotificationManager,
             enableCallNotificationUpdates = notificationConfig.enableCallNotificationUpdates,
             callServiceConfigRegistry = callConfigRegistry,
-            testSfuAddress = localSfuAddress,
             sounds = sounds,
             permissionCheck = permissionCheck,
             crashOnMissingPermission = crashOnMissingPermission,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -171,7 +171,6 @@ internal class StreamVideoClient internal constructor(
     internal val streamNotificationManager: StreamNotificationManager,
     internal val enableCallNotificationUpdates: Boolean,
     internal val callServiceConfigRegistry: CallServiceConfigRegistry = CallServiceConfigRegistry(),
-    internal val testSfuAddress: String? = null,
     internal val sounds: Sounds,
     internal val vibrationConfig: RingingCallVibrationConfig,
     internal val permissionCheck: StreamPermissionCheck = DefaultStreamPermissionCheck(),


### PR DESCRIPTION
### Goal

Adds support for connecting the demo app to a local coordinator for development and testing. This is useful for testing SFU migration, reconnection flows, and other server-side behaviors against a local environment.

### Implementation

- Added LocalDevConfig data class in StreamVideoInitHelper that holds local coordinator address, API key, user ID, and secret. Generates HS256-signed JWT tokens from the secret automatically.

- Added localCoordinatorAddress parameter to StreamVideoBuilder that overrides the coordinator HTTP (http://) and WebSocket (ws://) URLs when set.

- Removed unused testSfuAddress / localSfuAddress from StreamVideoBuilder and StreamVideoClient — SFU addresses come from the coordinator's join response, so a separate override is unnecessary.

- When LocalDevConfig is passed to loadSdk(), the demo app bypasses cloud auth, uses a local token provider for refreshes, and initializes a minimal ChatClient to prevent UI crashes.

### Usage
```
StreamVideoInitHelper.loadSdk(
  dataStore = StreamUserDataStore.instance(),
  useRandomUserAsFallback = false,
  localDevConfig = LocalDevConfig(
      coordinatorAddress = "192.168.1.2:3030",
      apiKey = "qk4nn7rpcn75",
      secret = "vz4yhgcwums5h64uh8xbx58c9yfgtkjneab5ch9skds93xzqd8mv6dc824dusnvt",
      userId = "test-user",
  ),
)
```

To revert to cloud, simply remove the localDevConfig parameter.

### Testing
Prerequisites: Local coordinator running at <IP>:3030 with 2 SFU instances registered.
[ ] Basic connection — App connects to local coordinator, joins a call, audio/video works
[ ] Token refresh — Kill the WebSocket, verify the SDK regenerates a local JWT (not a cloud token) and reconnects
[ ] SFU migration (GoAway) — Drain/stop SFU1 while in a call; verify the client migrates to SFU2 via the coordinator
[ ] SFU migration (connection exhaustion) — Kill SFU1 process; verify after 2 failed retries the SDK auto-escalates to migrate() and gets SFU2
[ ] No regression (cloud) — Remove localDevConfig, rebuild; verify the demo app connects to the cloud coordinator as before
[ ] Graceful failure — With only 1 SFU running, trigger migration; verify the app doesn't crash (falls back to reconnect)

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved configuration infrastructure for local development and testing scenarios.
  * Refined initialization parameters to streamline setup flow for local development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->