### PR TITLE
Add missing permissions message in Video SDK

### DIFF
--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -88,6 +88,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import java.util.Locale
 
 @OptIn(StreamCallActivityDelicateApi::class)
 public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOperations {
@@ -885,6 +886,20 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
                     call,
                 )
                 if (!permissionsNowGranted) {
+                    val missingPermissions = PermissionManager.getMissingPermission(
+                        this@StreamCallActivity,
+                        call,
+                    )
+                    val exceptionText =
+                        missingPermissions.map { it.capitalize(Locale.getDefault()) }
+                            .joinToString(separator = ",") { it }
+                    onError?.invoke(
+                        StreamCallActivityException(
+                            call,
+                            "$exceptionText Permission(s) not granted.",
+                            null,
+                        ),
+                    )
                     return@launch
                 }
                 create(call, ring, members, onSuccess, onError)

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/permission/PermissionManager.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/permission/PermissionManager.kt
@@ -128,6 +128,27 @@ public interface PermissionManager {
             return true
         }
 
+        internal fun getMissingPermission(context: Context, call: Call): List<String> {
+            val list = ArrayList<String>()
+            val capabilities = call.state.ownCapabilities.value
+            if (capabilities.isEmpty()) return list
+            if (capabilities.contains(OwnCapability.SendAudio)) {
+                if (ContextCompat.checkSelfPermission(context, Manifest.permission.RECORD_AUDIO)
+                    != PackageManager.PERMISSION_GRANTED
+                ) {
+                    list.add(Manifest.permission.RECORD_AUDIO)
+                }
+            }
+            if (capabilities.contains(OwnCapability.SendVideo)) {
+                if (ContextCompat.checkSelfPermission(context, Manifest.permission.CAMERA)
+                    != PackageManager.PERMISSION_GRANTED
+                ) {
+                    list.add(Manifest.permission.CAMERA)
+                }
+            }
+            return list
+        }
+
         internal fun hasNotificationPermission(context: Context): Boolean =
             ContextCompat.checkSelfPermission(
                 context,


### PR DESCRIPTION
### Goal

Add Missing commit for https://github.com/GetStream/stream-video-android/pull/1627

### Implementation

Add missing permission message

### 🎨 UI Changes

Refer https://github.com/GetStream/stream-video-android/pull/1627


### Testing

Refer https://github.com/GetStream/stream-video-android/pull/1627

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for call permission denials. When required permissions remain ungranted after the permission request flow, the app now generates and displays a detailed error message identifying the specific permissions missing instead of failing silently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->