### PR TITLE
Fixed incoming call notification not waking the device on locked screen

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -13189,6 +13189,7 @@ public class io/getstream/video/android/core/notifications/DefaultNotificationHa
 	public fun getRejectAction (Landroid/app/PendingIntent;)Landroidx/core/app/NotificationCompat$Action;
 	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public fun getSettingUpCallNotification ()Landroid/app/Notification;
+	public fun getSettingUpCallNotification (Ljava/lang/String;Lio/getstream/video/android/model/StreamCallId;)Landroid/app/Notification;
 	public fun getStreamNotificationDispatcher ()Lio/getstream/video/android/core/notifications/dispatchers/NotificationDispatcher;
 	public fun isInForeground ()Z
 	public fun maybeCreateChannel (Ljava/lang/String;Landroid/content/Context;Lkotlin/jvm/functions/Function1;)V
@@ -13441,6 +13442,7 @@ public class io/getstream/video/android/core/notifications/handlers/StreamDefaul
 	public fun getOngoingCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/util/Map;)Landroid/app/Notification;
 	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZLjava/util/Map;)Landroid/app/Notification;
 	public fun getSettingUpCallNotification ()Landroid/app/Notification;
+	public fun getSettingUpCallNotification (Ljava/lang/String;Lio/getstream/video/android/model/StreamCallId;)Landroid/app/Notification;
 	public fun onCallNotificationUpdate (Lio/getstream/video/android/core/Call;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun onLiveCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 	public fun onMissedCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
@@ -13544,7 +13546,7 @@ public abstract interface class io/getstream/video/android/core/notifications/ha
 	public abstract fun onRingingCall (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Ljava/util/Map;)V
 }
 
-public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider : io/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload {
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProvider : io/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload, io/getstream/video/android/core/notifications/handlers/StreamSettingUpCallNotificationProvider {
 	public fun getIncomingCallNotification (Landroid/app/PendingIntent;Landroid/app/PendingIntent;Landroid/app/PendingIntent;Ljava/lang/String;Z)Landroid/app/Notification;
 	public fun getMissedCallNotification (Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;)Landroid/app/Notification;
 	public static synthetic fun getMissedCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ILjava/lang/Object;)Landroid/app/Notification;
@@ -13587,6 +13589,10 @@ public abstract interface class io/getstream/video/android/core/notifications/ha
 	public abstract fun updateIncomingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun updateOngoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun updateOutgoingCallNotification (Lio/getstream/video/android/core/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamSettingUpCallNotificationProvider {
+	public abstract fun getSettingUpCallNotification (Ljava/lang/String;Lio/getstream/video/android/model/StreamCallId;)Landroid/app/Notification;
 }
 
 public final class io/getstream/video/android/core/notifications/internal/receivers/ToggleCameraBroadcastReceiver : android/content/BroadcastReceiver {

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -13554,7 +13554,8 @@ public abstract interface class io/getstream/video/android/core/notifications/ha
 	public static synthetic fun getOngoingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZIILjava/lang/Object;)Landroid/app/Notification;
 	public fun getRingingCallNotification (Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;Z)Landroid/app/Notification;
 	public static synthetic fun getRingingCallNotification$default (Lio/getstream/video/android/core/notifications/handlers/StreamNotificationProvider;Lio/getstream/video/android/core/RingingState;Lio/getstream/video/android/model/StreamCallId;Ljava/lang/String;ZILjava/lang/Object;)Landroid/app/Notification;
-	public abstract fun getSettingUpCallNotification ()Landroid/app/Notification;
+	public fun getSettingUpCallNotification ()Landroid/app/Notification;
+	public fun getSettingUpCallNotification (Ljava/lang/String;Lio/getstream/video/android/model/StreamCallId;)Landroid/app/Notification;
 }
 
 public abstract interface class io/getstream/video/android/core/notifications/handlers/StreamNotificationProviderWithPayload {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/DefaultNotificationHandler.kt
@@ -244,6 +244,13 @@ public open class DefaultNotificationHandler(
             .build()
     }
 
+    @Deprecated(
+        "Use StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        replaceWith = ReplaceWith(
+            "StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     override fun getSettingUpCallNotification(): Notification? {
         val channelId = application.getString(
             R.string.stream_video_call_setup_notification_channel_id,
@@ -276,6 +283,11 @@ public open class DefaultNotificationHandler(
             setOngoing(true)
         }
     }
+
+    override fun getSettingUpCallNotification(
+        trigger: String,
+        callId: StreamCallId,
+    ): Notification? = getSettingUpCallNotification()
 
     override suspend fun onCallNotificationUpdate(call: Call): Notification? {
         coroutineScope {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -575,7 +575,6 @@ constructor(
                     callId,
                     payload = emptyMap(),
                 )
-                val shouldHaveContentIntent = true
 
                 return ensureChannelAndBuildNotification(notificationChannel) {
                     priority = if (hideRingingNotificationInForeground) {
@@ -590,18 +589,7 @@ constructor(
                     setOngoing(true)
                     setCategory(NotificationCompat.CATEGORY_CALL)
                     setFullScreenIntent(fullScreenPendingIntent, true)
-                    if (shouldHaveContentIntent) {
-                        setContentIntent(fullScreenPendingIntent)
-                    } else {
-                        val emptyIntent = PendingIntent.getActivity(
-                            application,
-                            0,
-                            Intent(),
-                            PendingIntent.FLAG_IMMUTABLE,
-                        )
-                        setContentIntent(emptyIntent)
-                        setAutoCancel(false)
-                    }
+                    setContentIntent(fullScreenPendingIntent)
                 }
             }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -580,7 +580,6 @@ constructor(
                     logger.w {
                         "[getSettingUpCallNotification] fullScreenPendingIntent is null; lock-screen wake-up may not work."
                     }
-                    return getSettingUpCallNotification()
                 }
                 return ensureChannelAndBuildNotification(notificationChannel) {
                     priority = if (hideRingingNotificationInForeground) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -59,6 +59,7 @@ import io.getstream.video.android.core.notifications.StreamIntentResolver
 import io.getstream.video.android.core.notifications.dispatchers.DefaultNotificationDispatcher
 import io.getstream.video.android.core.notifications.dispatchers.NotificationDispatcher
 import io.getstream.video.android.core.notifications.extractor.DefaultNotificationContentExtractor
+import io.getstream.video.android.core.notifications.internal.service.CallService.Companion.TRIGGER_INCOMING_CALL
 import io.getstream.video.android.core.notifications.internal.service.ServiceLauncher
 import io.getstream.video.android.core.utils.isAppInForeground
 import io.getstream.video.android.core.utils.safeCall
@@ -528,6 +529,13 @@ constructor(
         }
     }
 
+    @Deprecated(
+        "Use StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        replaceWith = ReplaceWith(
+            "StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     override fun getSettingUpCallNotification(): Notification? {
         logger.d { "[getSettingUpCallNotification]" }
         val channelId = notificationChannels.outgoingCallChannel.id
@@ -540,6 +548,64 @@ constructor(
             setChannelId(channelId)
             setCategory(NotificationCompat.CATEGORY_CALL)
             setOngoing(true)
+        }
+    }
+
+    override fun getSettingUpCallNotification(trigger: String, callId: StreamCallId): Notification? {
+        return when (trigger) {
+            /**
+             * TODO: This logic is duplicated with getIncomingCallNotificationInternal.
+             * Update it soon
+             */
+
+            TRIGGER_INCOMING_CALL -> {
+                val title = application.getString(
+                    R.string.stream_video_call_setup_notification_title,
+                )
+                val description =
+                    application.getString(R.string.stream_video_call_setup_notification_description)
+
+                val notificationChannel = when {
+                    isAppInForeground() && hideRingingNotificationInForeground ->
+                        notificationChannels.incomingCallLowImportanceChannel
+                    else -> notificationChannels.incomingCallChannel
+                }
+
+                val fullScreenPendingIntent = intentResolver.searchIncomingCallPendingIntent(
+                    callId,
+                    payload = emptyMap(),
+                )
+                val shouldHaveContentIntent = true
+
+                return ensureChannelAndBuildNotification(notificationChannel) {
+                    priority = if (hideRingingNotificationInForeground) {
+                        NotificationCompat.PRIORITY_LOW
+                    } else {
+                        NotificationCompat.PRIORITY_MAX
+                    }
+                    setContentTitle(title)
+                    setContentText(description)
+                    setSmallIcon(R.drawable.stream_video_ic_call)
+                    setChannelId(notificationChannel.id)
+                    setOngoing(true)
+                    setCategory(NotificationCompat.CATEGORY_CALL)
+                    setFullScreenIntent(fullScreenPendingIntent, true)
+                    if (shouldHaveContentIntent) {
+                        setContentIntent(fullScreenPendingIntent)
+                    } else {
+                        val emptyIntent = PendingIntent.getActivity(
+                            application,
+                            0,
+                            Intent(),
+                            PendingIntent.FLAG_IMMUTABLE,
+                        )
+                        setContentIntent(emptyIntent)
+                        setAutoCancel(false)
+                    }
+                }
+            }
+
+            else -> getSettingUpCallNotification()
         }
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -576,6 +576,12 @@ constructor(
                     payload = emptyMap(),
                 )
 
+                if (fullScreenPendingIntent == null) {
+                    logger.w {
+                        "[getSettingUpCallNotification] fullScreenPendingIntent is null; lock-screen wake-up may not work."
+                    }
+                    return getSettingUpCallNotification()
+                }
                 return ensureChannelAndBuildNotification(notificationChannel) {
                     priority = if (hideRingingNotificationInForeground) {
                         NotificationCompat.PRIORITY_LOW

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -183,6 +183,10 @@ interface StreamNotificationProviderWithPayload {
     ): Notification?
 }
 
+interface StreamSettingUpCallNotificationProvider {
+    fun getSettingUpCallNotification(trigger: String, callId: StreamCallId): Notification?
+}
+
 interface StreamNotificationUpdatesProvider {
 
     /**
@@ -228,7 +232,7 @@ interface StreamNotificationUpdatesProvider {
     ): Notification?
 }
 
-interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
+interface StreamNotificationProvider : StreamNotificationProviderWithPayload, StreamSettingUpCallNotificationProvider {
 
     /**
      * Customize the notification when you receive a push notification for ringing call with type [RingingState.Incoming]
@@ -348,6 +352,13 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload {
      *
      * @return A [Notification] object.
      */
+    @Deprecated(
+        "Use StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        replaceWith = ReplaceWith(
+            "StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     fun getSettingUpCallNotification(): Notification?
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamNotificationHandler.kt
@@ -359,7 +359,15 @@ interface StreamNotificationProvider : StreamNotificationProviderWithPayload, St
         ),
         level = DeprecationLevel.WARNING,
     )
-    fun getSettingUpCallNotification(): Notification?
+    fun getSettingUpCallNotification(): Notification? = null
+
+    // Inside StreamNotificationProvider interface, add:
+    override fun getSettingUpCallNotification(
+        trigger: String,
+        callId: StreamCallId,
+    ): Notification? {
+        return getSettingUpCallNotification()
+    }
 }
 
 /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/NoOpNotificationHandler.kt
@@ -115,7 +115,18 @@ internal object NoOpNotificationHandler : NotificationHandler {
         payload: Map<String, Any?>,
     ): Notification? = null
 
+    @Deprecated(
+        "Use StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        replaceWith = ReplaceWith(
+            "StreamSettingUpCallNotificationProvider.getSettingUpCallNotification(trigger,callId)",
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     override fun getSettingUpCallNotification(): Notification? = null
+    override fun getSettingUpCallNotification(
+        trigger: String,
+        callId: StreamCallId,
+    ): Notification? = null
 
     @Deprecated(
         level = DeprecationLevel.ERROR,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/service/CallService.kt
@@ -216,7 +216,12 @@ internal open class CallService : Service() {
          * Mandatory, if not called then it will throw exception if we directly decide to stop the service.
          * For example: it will stop the service if [verifyPermissions] is false
          */
-        promoteToFgServiceIfNoActiveCall(params.streamVideo, notificationId, params.trigger)
+        promoteToFgServiceIfNoActiveCall(
+            params.streamVideo,
+            notificationId,
+            params.trigger,
+            params.callId,
+        )
         val call = params.streamVideo.call(params.callId.type, params.callId.id)
 
         // Rendering incoming call does not need audio/video permissions
@@ -654,8 +659,9 @@ internal open class CallService : Service() {
         videoClient: StreamVideoClient,
         notificationId: Int,
         trigger: String,
+        callId: StreamCallId,
     ) {
-        videoClient.getSettingUpCallNotification()?.let { notification ->
+        videoClient.getSettingUpCallNotification(trigger, callId)?.let { notification ->
             startForegroundWithServiceType(
                 notificationId,
                 notification,


### PR DESCRIPTION
### Goal

Fix locked screen incoming-call wake up notification behaviour

### Implementation

When we launch a temporary notification for an incoming call, it should include all the properties of the standard incoming call notification.

### 🎨 UI Changes

None

### Testing

1. Open demo-app
2. Login with any user
3. Lock the screen
4. Get an incoming call
5. The incoming call should wake up the device


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced call setup notifications with improved context awareness, now providing customized notification handling based on call type and trigger for better user experience during call initialization.

* **Deprecations**
  * Legacy call setup notification method deprecated in favor of enhanced variant with improved customization capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->