### PR TITLE
Define StreamVideoClient and Call public interfaces

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9490,6 +9490,167 @@ public final class io/getstream/video/android/core/StreamVideoConfigDefault : io
 	public fun getJoinOnAcceptedByCallee ()Z
 }
 
+public abstract interface class io/getstream/video/android/core/api/Call {
+	public abstract fun accept (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun blockUser (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun cleanup ()V
+	public abstract fun collectUserFeedback (ILjava/lang/String;Ljava/util/Map;)V
+	public static synthetic fun collectUserFeedback$default (Lio/getstream/video/android/core/api/Call;ILjava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public abstract fun create (Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Ljava/lang/String;ZZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun create$default (Lio/getstream/video/android/core/api/Call;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Ljava/lang/String;ZZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun disableClientCapabilities (Ljava/util/List;)V
+	public abstract fun enableClientCapabilities (Ljava/util/List;)V
+	public abstract fun end (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun get (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAudioFilter ()Lio/getstream/video/android/core/call/audio/InputAudioFilter;
+	public abstract fun getCamera ()Lio/getstream/video/android/core/api/CameraManager;
+	public abstract fun getCid ()Ljava/lang/String;
+	public abstract fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
+	public abstract fun getId ()Ljava/lang/String;
+	public abstract fun getLocalMicrophoneAudioLevel ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getMicrophone ()Lio/getstream/video/android/core/api/MicrophoneManager;
+	public abstract fun getScreenShare ()Lio/getstream/video/android/core/api/ScreenShareManager;
+	public abstract fun getSessionId ()Ljava/lang/String;
+	public abstract fun getSpeaker ()Lio/getstream/video/android/core/api/SpeakerManager;
+	public abstract fun getStatLatencyHistory ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getState ()Lio/getstream/video/android/core/CallState;
+	public abstract fun getStatsReport ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getType ()Ljava/lang/String;
+	public abstract fun getUser ()Lio/getstream/video/android/model/User;
+	public abstract fun getVideoFilter ()Lio/getstream/video/android/core/call/video/VideoFilter;
+	public abstract fun goLive (ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun goLive$default (Lio/getstream/video/android/core/api/Call;ZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun grantPermissions (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun hasCapability ([Lio/getstream/android/video/generated/models/OwnCapability;)Z
+	public abstract fun initRenderer (Lio/getstream/webrtc/android/ui/VideoTextureViewRenderer;Ljava/lang/String;Lstream/video/sfu/models/TrackType;Lkotlin/jvm/functions/Function1;Ljava/lang/String;)V
+	public static synthetic fun initRenderer$default (Lio/getstream/video/android/core/api/Call;Lio/getstream/webrtc/android/ui/VideoTextureViewRenderer;Ljava/lang/String;Lstream/video/sfu/models/TrackType;Lkotlin/jvm/functions/Function1;Ljava/lang/String;ILjava/lang/Object;)V
+	public abstract fun isAudioProcessingEnabled ()Z
+	public abstract fun isLocalPin (Ljava/lang/String;)Z
+	public abstract fun isPinnedParticipant (Ljava/lang/String;)Z
+	public abstract fun isServerPin (Ljava/lang/String;)Z
+	public abstract fun isVideoEnabled ()Z
+	public abstract fun join (ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun join$default (Lio/getstream/video/android/core/api/Call;ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun kickUser (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun kickUser$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun leave (Ljava/lang/String;)V
+	public static synthetic fun leave$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/String;ILjava/lang/Object;)V
+	public abstract fun listRecordings (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listRecordings$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun listTranscription (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun muteAllUsers (ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun muteAllUsers$default (Lio/getstream/video/android/core/api/Call;ZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun muteUser (Ljava/lang/String;ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun muteUser$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/String;ZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun muteUsers (Ljava/util/List;ZZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun muteUsers$default (Lio/getstream/video/android/core/api/Call;Ljava/util/List;ZZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun notify (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun pinForEveryone (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun processAudioSample (Lio/getstream/webrtc/audio/JavaAudioDeviceModule$AudioSamples;)V
+	public abstract fun queryMembers (Ljava/util/Map;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMembers$default (Lio/getstream/video/android/core/api/Call;Ljava/util/Map;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun reject (Lio/getstream/video/android/core/model/RejectReason;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun reject$default (Lio/getstream/video/android/core/api/Call;Lio/getstream/video/android/core/model/RejectReason;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun removeMembers (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun requestPermissions ([Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun revokePermissions (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun ring (Lio/getstream/android/video/generated/models/RingCallRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun ring (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun sendCustomEvent (Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun sendReaction (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun sendReaction$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun setAudioFilter (Lio/getstream/video/android/core/call/audio/InputAudioFilter;)V
+	public abstract fun setAudioProcessingEnabled (Z)V
+	public abstract fun setIncomingAudioEnabled (ZLjava/util/List;)V
+	public static synthetic fun setIncomingAudioEnabled$default (Lio/getstream/video/android/core/api/Call;ZLjava/util/List;ILjava/lang/Object;)V
+	public abstract fun setIncomingVideoEnabled (Ljava/lang/Boolean;Ljava/util/List;)V
+	public static synthetic fun setIncomingVideoEnabled$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)V
+	public abstract fun setPreferredIncomingVideoResolution (Lio/getstream/video/android/core/model/PreferredVideoResolution;Ljava/util/List;)V
+	public static synthetic fun setPreferredIncomingVideoResolution$default (Lio/getstream/video/android/core/api/Call;Lio/getstream/video/android/core/model/PreferredVideoResolution;Ljava/util/List;ILjava/lang/Object;)V
+	public abstract fun setVideoFilter (Lio/getstream/video/android/core/call/video/VideoFilter;)V
+	public abstract fun setVisibility (Ljava/lang/String;Lstream/video/sfu/models/TrackType;ZLjava/lang/String;)V
+	public abstract fun setVisibility (Ljava/lang/String;Lstream/video/sfu/models/TrackType;ZLjava/lang/String;II)V
+	public static synthetic fun setVisibility$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/String;Lstream/video/sfu/models/TrackType;ZLjava/lang/String;IIILjava/lang/Object;)V
+	public static synthetic fun setVisibility$default (Lio/getstream/video/android/core/api/Call;Ljava/lang/String;Lstream/video/sfu/models/TrackType;ZLjava/lang/String;ILjava/lang/Object;)V
+	public abstract fun startClosedCaptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startHLS (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startRecording (Lio/getstream/video/android/core/recording/RecordingType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startRecording (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun startScreenSharing (Landroid/content/Intent;Z)V
+	public static synthetic fun startScreenSharing$default (Lio/getstream/video/android/core/api/Call;Landroid/content/Intent;ZILjava/lang/Object;)V
+	public abstract fun startTranscription (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopClosedCaptions (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopHLS (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopLive (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopRecording (Lio/getstream/video/android/core/recording/RecordingType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopRecording (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopScreenSharing ()V
+	public abstract fun stopTranscription (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun subscribeFor ([Ljava/lang/Class;Lio/getstream/video/android/core/events/VideoEventListener;)Lio/getstream/video/android/core/EventSubscription;
+	public abstract fun takeScreenshot (Lio/getstream/video/android/core/model/VideoTrack;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun toggleAudioProcessing ()Z
+	public abstract fun unpinForEveryone (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun update (Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun update$default (Lio/getstream/video/android/core/api/Call;Ljava/util/Map;Lio/getstream/android/video/generated/models/CallSettingsRequest;Lorg/threeten/bp/OffsetDateTime;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun updateClosedCaptionsSettings (Lio/getstream/video/android/core/closedcaptions/ClosedCaptionsSettings;)V
+	public abstract fun updateMembers (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/video/android/core/api/CameraManager {
+	public abstract fun disable (Z)V
+	public static synthetic fun disable$default (Lio/getstream/video/android/core/api/CameraManager;ZILjava/lang/Object;)V
+	public abstract fun enable (Z)V
+	public static synthetic fun enable$default (Lio/getstream/video/android/core/api/CameraManager;ZILjava/lang/Object;)V
+	public abstract fun flip ()V
+	public abstract fun getAvailableResolutions ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getDirection ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getResolution ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getSelectedDevice ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun listDevices ()Ljava/util/List;
+	public abstract fun pause (Z)V
+	public static synthetic fun pause$default (Lio/getstream/video/android/core/api/CameraManager;ZILjava/lang/Object;)V
+	public abstract fun resume (Z)V
+	public static synthetic fun resume$default (Lio/getstream/video/android/core/api/CameraManager;ZILjava/lang/Object;)V
+	public abstract fun select (Ljava/lang/String;Z)V
+	public static synthetic fun select$default (Lio/getstream/video/android/core/api/CameraManager;Ljava/lang/String;ZILjava/lang/Object;)V
+	public abstract fun setDirection (Lio/getstream/video/android/core/CameraDirection;)V
+	public abstract fun setEnabled (ZZ)V
+	public static synthetic fun setEnabled$default (Lio/getstream/video/android/core/api/CameraManager;ZZILjava/lang/Object;)V
+}
+
+public abstract interface class io/getstream/video/android/core/api/MicrophoneManager {
+	public abstract fun disable (Z)V
+	public static synthetic fun disable$default (Lio/getstream/video/android/core/api/MicrophoneManager;ZILjava/lang/Object;)V
+	public abstract fun enable (Z)V
+	public static synthetic fun enable$default (Lio/getstream/video/android/core/api/MicrophoneManager;ZILjava/lang/Object;)V
+	public abstract fun getAudioBitrateProfile ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getDevices ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getSelectedDevice ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun listDevices ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun pause (Z)V
+	public static synthetic fun pause$default (Lio/getstream/video/android/core/api/MicrophoneManager;ZILjava/lang/Object;)V
+	public abstract fun resume (Z)V
+	public static synthetic fun resume$default (Lio/getstream/video/android/core/api/MicrophoneManager;ZILjava/lang/Object;)V
+	public abstract fun select (Lio/getstream/video/android/core/audio/StreamAudioDevice;)V
+	public abstract fun setAudioBitrateProfile-gIAlu-s (Lstream/video/sfu/models/AudioBitrateProfile;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun setEnabled (ZZ)V
+	public static synthetic fun setEnabled$default (Lio/getstream/video/android/core/api/MicrophoneManager;ZZILjava/lang/Object;)V
+}
+
+public abstract interface class io/getstream/video/android/core/api/ScreenShareManager {
+	public abstract fun disable (Z)V
+	public static synthetic fun disable$default (Lio/getstream/video/android/core/api/ScreenShareManager;ZILjava/lang/Object;)V
+	public abstract fun enable (Landroid/content/Intent;ZZ)V
+	public static synthetic fun enable$default (Lio/getstream/video/android/core/api/ScreenShareManager;Landroid/content/Intent;ZZILjava/lang/Object;)V
+	public abstract fun getAudioEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
 public abstract interface class io/getstream/video/android/core/api/SignalServerService {
 	public abstract fun iceRestart (Lstream/video/sfu/signal/ICERestartRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun iceTrickle (Lstream/video/sfu/models/ICETrickle;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -9500,6 +9661,53 @@ public abstract interface class io/getstream/video/android/core/api/SignalServer
 	public abstract fun stopNoiseCancellation (Lstream/video/sfu/signal/StopNoiseCancellationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun updateMuteStates (Lstream/video/sfu/signal/UpdateMuteStatesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun updateSubscriptions (Lstream/video/sfu/signal/UpdateSubscriptionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/video/android/core/api/SpeakerManager {
+	public abstract fun disable (Z)V
+	public static synthetic fun disable$default (Lio/getstream/video/android/core/api/SpeakerManager;ZILjava/lang/Object;)V
+	public abstract fun enable (Z)V
+	public static synthetic fun enable$default (Lio/getstream/video/android/core/api/SpeakerManager;ZILjava/lang/Object;)V
+	public abstract fun getAudioUsage ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getDevices ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getSelectedDevice ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getSpeakerPhoneEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getVolume ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun pause ()V
+	public abstract fun resume ()V
+	public abstract fun setAudioUsage (I)Z
+	public abstract fun setEnabled (ZZ)V
+	public static synthetic fun setEnabled$default (Lio/getstream/video/android/core/api/SpeakerManager;ZZILjava/lang/Object;)V
+	public abstract fun setSpeakerPhone (ZLio/getstream/video/android/core/audio/StreamAudioDevice;)V
+	public static synthetic fun setSpeakerPhone$default (Lio/getstream/video/android/core/api/SpeakerManager;ZLio/getstream/video/android/core/audio/StreamAudioDevice;ILjava/lang/Object;)V
+	public abstract fun setVolume (I)V
+}
+
+public abstract interface class io/getstream/video/android/core/api/StreamVideoClient : io/getstream/video/android/core/notifications/NotificationHandler {
+	public abstract fun call (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/video/android/core/api/Call;
+	public static synthetic fun call$default (Lio/getstream/video/android/core/api/StreamVideoClient;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/video/android/core/api/Call;
+	public abstract fun cleanup ()V
+	public abstract fun connect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun connectAsync (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun connectIfNotAlreadyConnected (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createDevice (Lio/getstream/android/push/PushDevice;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteDevice (Lio/getstream/video/android/model/Device;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getContext ()Landroid/content/Context;
+	public abstract fun getDevice ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getEdges (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getState ()Lio/getstream/video/android/core/ClientState;
+	public abstract fun getUser ()Lio/getstream/video/android/model/User;
+	public abstract fun getUserId ()Ljava/lang/String;
+	public abstract fun logOut ()V
+	public abstract fun queryCalls (Ljava/util/Map;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryCalls$default (Lio/getstream/video/android/core/api/StreamVideoClient;Ljava/util/Map;Ljava/util/List;ILjava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun queryMembers (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMembers$default (Lio/getstream/video/android/core/api/StreamVideoClient;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun subscribe (Lio/getstream/video/android/core/events/VideoEventListener;)Lio/getstream/video/android/core/EventSubscription;
+	public abstract fun subscribeFor ([Ljava/lang/Class;Lio/getstream/video/android/core/events/VideoEventListener;)Lio/getstream/video/android/core/EventSubscription;
+	public abstract fun updateDevice (Lio/getstream/video/android/model/Device;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/video/android/core/audio/AudioHandler {

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9630,7 +9630,6 @@ public abstract interface class io/getstream/video/android/core/api/MicrophoneMa
 	public abstract fun getSelectedDevice ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getStatus ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun isEnabled ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun listDevices ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun pause (Z)V
 	public static synthetic fun pause$default (Lio/getstream/video/android/core/api/MicrophoneManager;ZILjava/lang/Object;)V
 	public abstract fun resume (Z)V

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/Call.kt
@@ -1,0 +1,559 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.api
+
+import android.content.Intent
+import android.graphics.Bitmap
+import androidx.compose.runtime.Stable
+import io.getstream.android.video.generated.models.AcceptCallResponse
+import io.getstream.android.video.generated.models.BlockUserResponse
+import io.getstream.android.video.generated.models.CallSettingsRequest
+import io.getstream.android.video.generated.models.GetCallResponse
+import io.getstream.android.video.generated.models.GetOrCreateCallResponse
+import io.getstream.android.video.generated.models.GoLiveResponse
+import io.getstream.android.video.generated.models.KickUserResponse
+import io.getstream.android.video.generated.models.ListRecordingsResponse
+import io.getstream.android.video.generated.models.ListTranscriptionsResponse
+import io.getstream.android.video.generated.models.MemberRequest
+import io.getstream.android.video.generated.models.MuteUsersResponse
+import io.getstream.android.video.generated.models.OwnCapability
+import io.getstream.android.video.generated.models.PinResponse
+import io.getstream.android.video.generated.models.RejectCallResponse
+import io.getstream.android.video.generated.models.RingCallRequest
+import io.getstream.android.video.generated.models.RingCallResponse
+import io.getstream.android.video.generated.models.SendCallEventResponse
+import io.getstream.android.video.generated.models.SendReactionResponse
+import io.getstream.android.video.generated.models.StartClosedCaptionsResponse
+import io.getstream.android.video.generated.models.StartTranscriptionResponse
+import io.getstream.android.video.generated.models.StopClosedCaptionsResponse
+import io.getstream.android.video.generated.models.StopLiveResponse
+import io.getstream.android.video.generated.models.StopTranscriptionResponse
+import io.getstream.android.video.generated.models.UnpinResponse
+import io.getstream.android.video.generated.models.UpdateCallMembersResponse
+import io.getstream.android.video.generated.models.UpdateCallResponse
+import io.getstream.android.video.generated.models.UpdateUserPermissionsResponse
+import io.getstream.android.video.generated.models.VideoEvent
+import io.getstream.result.Result
+import io.getstream.video.android.core.CallState
+import io.getstream.video.android.core.CallStatsReport
+import io.getstream.video.android.core.CreateCallOptions
+import io.getstream.video.android.core.EventSubscription
+import io.getstream.video.android.core.call.audio.InputAudioFilter
+import io.getstream.video.android.core.call.video.VideoFilter
+import io.getstream.video.android.core.closedcaptions.ClosedCaptionsSettings
+import io.getstream.video.android.core.events.VideoEventListener
+import io.getstream.video.android.core.model.PreferredVideoResolution
+import io.getstream.video.android.core.model.QueriedMembers
+import io.getstream.video.android.core.model.RejectReason
+import io.getstream.video.android.core.model.SortField
+import io.getstream.video.android.core.model.VideoTrack
+import io.getstream.video.android.core.recording.RecordingType
+import io.getstream.video.android.model.User
+import io.getstream.webrtc.android.ui.VideoTextureViewRenderer
+import io.getstream.webrtc.audio.JavaAudioDeviceModule.AudioSamples
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import org.threeten.bp.OffsetDateTime
+import stream.video.sfu.models.ClientCapability
+import stream.video.sfu.models.TrackType
+
+/**
+ * The public interface for a video call.
+ *
+ * Provides access to call lifecycle, media controls, member management, recording,
+ * streaming, and event observation. Sub-interfaces [CameraManager], [MicrophoneManager],
+ * [SpeakerManager], and [ScreenShareManager] group related media functionality.
+ *
+ * Internal methods (fastReconnect, rejoin, migrate, handleEvent, fireEvent) and
+ * deprecated methods (subscribe, unsubscribe) are intentionally excluded.
+ */
+@Stable
+public interface Call {
+
+    // -- Identity --
+
+    /** The call type (e.g., "default", "livestream"). */
+    public val type: String
+
+    /** The call ID. */
+    public val id: String
+
+    /** The combined call identifier in "type:id" format. */
+    public val cid: String
+
+    /** The current user. */
+    public val user: User
+
+    /** The unique session ID for this call participant. */
+    public val sessionId: String
+
+    // -- State --
+
+    /** The call state containing participant list, connection status, settings, etc. */
+    public val state: CallState
+
+    // -- Events --
+
+    /**
+     * A shared flow of video events for this call.
+     * Consumers should collect this flow instead of using the deprecated subscribe/unsubscribe API.
+     */
+    public val events: SharedFlow<VideoEvent>
+
+    // -- Stats --
+
+    /** The latest call stats report. */
+    public val statsReport: StateFlow<CallStatsReport?>
+
+    /** History of latency measurements. */
+    public val statLatencyHistory: StateFlow<List<Int>>
+
+    // -- Audio level --
+
+    /**
+     * The local microphone audio level as a smoothed value between 0 (silent) and 1 (maximum).
+     * Does not return values until the session is established.
+     */
+    public val localMicrophoneAudioLevel: StateFlow<Float>
+
+    // -- Filters --
+
+    /** A custom video filter applied to the outgoing video stream. */
+    public var videoFilter: VideoFilter?
+
+    /** A custom audio filter applied to the outgoing audio stream. */
+    public var audioFilter: InputAudioFilter?
+
+    // -- Sub-interface accessors --
+
+    /** Camera controls for this call. */
+    public val camera: CameraManager
+
+    /** Microphone controls for this call. */
+    public val microphone: MicrophoneManager
+
+    /** Speaker controls for this call. */
+    public val speaker: SpeakerManager
+
+    /** Screen share controls for this call. */
+    public val screenShare: ScreenShareManager
+
+    // -- Lifecycle --
+
+    /**
+     * Creates a call on the server.
+     *
+     * @return Result containing the response with call details.
+     */
+    public suspend fun create(
+        memberIds: List<String>? = null,
+        members: List<MemberRequest>? = null,
+        custom: Map<String, Any>? = null,
+        settings: CallSettingsRequest? = null,
+        startsAt: OffsetDateTime? = null,
+        team: String? = null,
+        ring: Boolean = false,
+        notify: Boolean = false,
+        video: Boolean? = null,
+    ): Result<GetOrCreateCallResponse>
+
+    /**
+     * Fetches the call details from the server.
+     */
+    public suspend fun get(): Result<GetCallResponse>
+
+    /**
+     * Updates call properties on the server.
+     */
+    public suspend fun update(
+        custom: Map<String, Any>? = null,
+        settingsOverride: CallSettingsRequest? = null,
+        startsAt: OffsetDateTime? = null,
+    ): Result<UpdateCallResponse>
+
+    /**
+     * Joins the call, establishing a real-time audio/video session.
+     *
+     * @return Result<Unit> on success. Observe [state] for connection status.
+     */
+    public suspend fun join(
+        create: Boolean = false,
+        createOptions: CreateCallOptions? = null,
+        ring: Boolean = false,
+        notify: Boolean = false,
+    ): Result<Unit>
+
+    /**
+     * Leaves the call without ending it for other participants.
+     *
+     * @param reason The reason for leaving.
+     */
+    public fun leave(reason: String = "user")
+
+    /**
+     * Ends the call for all participants.
+     */
+    public suspend fun end(): Result<Unit>
+
+    /**
+     * Cleans up call resources.
+     */
+    public fun cleanup()
+
+    // -- Ringing --
+
+    /**
+     * Rings the call (simple form).
+     */
+    public suspend fun ring(): Result<GetCallResponse>
+
+    /**
+     * Rings the call with a specific request.
+     */
+    public suspend fun ring(ringCallRequest: RingCallRequest): Result<RingCallResponse>
+
+    /**
+     * Sends a notification for the call.
+     */
+    public suspend fun notify(): Result<GetCallResponse>
+
+    /**
+     * Accepts an incoming call.
+     */
+    public suspend fun accept(): Result<AcceptCallResponse>
+
+    /**
+     * Rejects an incoming call.
+     *
+     * @param reason The reason for rejecting.
+     */
+    public suspend fun reject(reason: RejectReason? = null): Result<RejectCallResponse>
+
+    // -- Members & Permissions --
+
+    /**
+     * Queries call members with filtering and pagination.
+     */
+    public suspend fun queryMembers(
+        filter: Map<String, Any>,
+        sort: List<SortField> = mutableListOf(SortField.Desc("created_at")),
+        limit: Int = 25,
+        prev: String? = null,
+        next: String? = null,
+    ): Result<QueriedMembers>
+
+    /**
+     * Updates call members.
+     */
+    public suspend fun updateMembers(
+        memberRequests: List<MemberRequest>,
+    ): Result<UpdateCallMembersResponse>
+
+    /**
+     * Removes members from the call.
+     */
+    public suspend fun removeMembers(userIds: List<String>): Result<UpdateCallMembersResponse>
+
+    /**
+     * Blocks a user from the call.
+     */
+    public suspend fun blockUser(userId: String): Result<BlockUserResponse>
+
+    /**
+     * Kicks a user from the call.
+     *
+     * @param userId The user to kick.
+     * @param block If true, the user will be blocked from rejoining.
+     */
+    public suspend fun kickUser(
+        userId: String,
+        block: Boolean = false,
+    ): Result<KickUserResponse>
+
+    /**
+     * Mutes a single user.
+     */
+    public suspend fun muteUser(
+        userId: String,
+        audio: Boolean = true,
+        video: Boolean = false,
+        screenShare: Boolean = false,
+    ): Result<MuteUsersResponse>
+
+    /**
+     * Mutes multiple users.
+     */
+    public suspend fun muteUsers(
+        userIds: List<String>,
+        audio: Boolean = true,
+        video: Boolean = false,
+        screenShare: Boolean = false,
+    ): Result<MuteUsersResponse>
+
+    /**
+     * Mutes all users in the call.
+     */
+    public suspend fun muteAllUsers(
+        audio: Boolean = true,
+        video: Boolean = false,
+        screenShare: Boolean = false,
+    ): Result<MuteUsersResponse>
+
+    /**
+     * Grants permissions to a user.
+     */
+    public suspend fun grantPermissions(
+        userId: String,
+        permissions: List<String>,
+    ): Result<UpdateUserPermissionsResponse>
+
+    /**
+     * Revokes permissions from a user.
+     */
+    public suspend fun revokePermissions(
+        userId: String,
+        permissions: List<String>,
+    ): Result<UpdateUserPermissionsResponse>
+
+    /**
+     * Requests permissions for the current user.
+     */
+    public suspend fun requestPermissions(vararg permission: String): Result<Unit>
+
+    // -- Media control --
+
+    /**
+     * Starts screen sharing.
+     *
+     * @param mediaProjectionPermissionResultData Intent data from screen capture permission.
+     * @param includeAudio Whether to include audio in the screen share.
+     */
+    public fun startScreenSharing(
+        mediaProjectionPermissionResultData: Intent,
+        includeAudio: Boolean = false,
+    )
+
+    /** Stops screen sharing. */
+    public fun stopScreenSharing()
+
+    /**
+     * Sets the preferred incoming video resolution for participants.
+     *
+     * @param resolution The preferred resolution, or null for auto.
+     * @param sessionIds Participant session IDs to apply to, or null for all.
+     */
+    public fun setPreferredIncomingVideoResolution(
+        resolution: PreferredVideoResolution?,
+        sessionIds: List<String>? = null,
+    )
+
+    /**
+     * Enables or disables incoming video.
+     *
+     * @param enabled Whether video should be enabled, or null for auto.
+     * @param sessionIds Participant session IDs to apply to, or null for all.
+     */
+    public fun setIncomingVideoEnabled(enabled: Boolean?, sessionIds: List<String>? = null)
+
+    /**
+     * Enables or disables incoming audio.
+     *
+     * @param enabled Whether audio should be enabled.
+     * @param sessionIds Participant session IDs to apply to, or null for all.
+     */
+    public fun setIncomingAudioEnabled(enabled: Boolean, sessionIds: List<String>? = null)
+
+    /**
+     * Sets the visibility of a participant's track.
+     */
+    public fun setVisibility(
+        sessionId: String,
+        trackType: TrackType,
+        visible: Boolean,
+        viewportId: String = sessionId,
+    )
+
+    /**
+     * Sets the visibility of a participant's track with specific dimensions.
+     */
+    public fun setVisibility(
+        sessionId: String,
+        trackType: TrackType,
+        visible: Boolean,
+        viewportId: String = sessionId,
+        width: Int,
+        height: Int,
+    )
+
+    /**
+     * Initializes a video renderer for a participant's track.
+     */
+    public fun initRenderer(
+        videoRenderer: VideoTextureViewRenderer,
+        sessionId: String,
+        trackType: TrackType,
+        onRendered: (VideoTextureViewRenderer) -> Unit = {},
+        viewportId: String = sessionId,
+    )
+
+    /**
+     * Processes an audio sample for speaking-while-muted detection.
+     */
+    public fun processAudioSample(audioSample: AudioSamples)
+
+    // -- Recording & Streaming --
+
+    /** Starts recording with the default (composite) type. */
+    public suspend fun startRecording(): Result<Any>
+
+    /** Starts recording with a specific type. */
+    public suspend fun startRecording(recordingType: RecordingType): Result<Any>
+
+    /** Stops recording with the default (composite) type. */
+    public suspend fun stopRecording(): Result<Any>
+
+    /** Stops recording with a specific type. */
+    public suspend fun stopRecording(recordingType: RecordingType): Result<Any>
+
+    /**
+     * Lists recordings for this call.
+     *
+     * @param sessionId If provided, only recordings for that session are returned.
+     */
+    public suspend fun listRecordings(sessionId: String? = null): Result<ListRecordingsResponse>
+
+    /** Starts HLS broadcasting. */
+    public suspend fun startHLS(): Result<Any>
+
+    /** Stops HLS broadcasting. */
+    public suspend fun stopHLS(): Result<Any>
+
+    /**
+     * Transitions the call to live mode.
+     */
+    public suspend fun goLive(
+        startHls: Boolean = false,
+        startRecording: Boolean = false,
+        startTranscription: Boolean = false,
+    ): Result<GoLiveResponse>
+
+    /** Stops live mode. */
+    public suspend fun stopLive(): Result<StopLiveResponse>
+
+    /** Starts transcription. */
+    public suspend fun startTranscription(): Result<StartTranscriptionResponse>
+
+    /** Stops transcription. */
+    public suspend fun stopTranscription(): Result<StopTranscriptionResponse>
+
+    /** Lists transcriptions for this call. */
+    public suspend fun listTranscription(): Result<ListTranscriptionsResponse>
+
+    /** Starts closed captions. */
+    public suspend fun startClosedCaptions(): Result<StartClosedCaptionsResponse>
+
+    /** Stops closed captions. */
+    public suspend fun stopClosedCaptions(): Result<StopClosedCaptionsResponse>
+
+    /** Updates closed captions settings. */
+    public fun updateClosedCaptionsSettings(closedCaptionsSettings: ClosedCaptionsSettings)
+
+    // -- Pinning --
+
+    /** Pins a participant for all users. */
+    public suspend fun pinForEveryone(sessionId: String, userId: String): Result<PinResponse>
+
+    /** Unpins a participant for all users. */
+    public suspend fun unpinForEveryone(sessionId: String, userId: String): Result<UnpinResponse>
+
+    /** Returns whether the participant is pinned (server or local). */
+    public fun isPinnedParticipant(sessionId: String): Boolean
+
+    /** Returns whether the participant has a server-side pin. */
+    public fun isServerPin(sessionId: String): Boolean
+
+    /** Returns whether the participant has a local pin. */
+    public fun isLocalPin(sessionId: String): Boolean
+
+    // -- Events --
+
+    /**
+     * Subscribes to specific event types on this call.
+     */
+    public fun subscribeFor(
+        vararg eventTypes: Class<out VideoEvent>,
+        listener: VideoEventListener<VideoEvent>,
+    ): EventSubscription
+
+    // -- Utility --
+
+    /** Returns whether the current user has all the specified capabilities. */
+    public fun hasCapability(vararg capability: OwnCapability): Boolean
+
+    /** Returns whether video is enabled in the call settings. */
+    public fun isVideoEnabled(): Boolean
+
+    /** Returns whether audio processing is currently enabled. */
+    public fun isAudioProcessingEnabled(): Boolean
+
+    /** Enables or disables audio processing. */
+    public fun setAudioProcessingEnabled(enabled: Boolean)
+
+    /** Toggles audio processing and returns the new state. */
+    public fun toggleAudioProcessing(): Boolean
+
+    /** Enables the provided client capabilities. */
+    public fun enableClientCapabilities(capabilities: List<ClientCapability>)
+
+    /** Disables the provided client capabilities. */
+    public fun disableClientCapabilities(capabilities: List<ClientCapability>)
+
+    /**
+     * Collects user feedback for the call.
+     *
+     * @param rating Rating value.
+     * @param reason Optional text reason.
+     * @param custom Optional custom data.
+     */
+    public fun collectUserFeedback(
+        rating: Int,
+        reason: String? = null,
+        custom: Map<String, Any>? = null,
+    )
+
+    /**
+     * Takes a screenshot of a video track.
+     *
+     * @param track The video track to capture.
+     * @return The captured bitmap, or null on failure.
+     */
+    public suspend fun takeScreenshot(track: VideoTrack): Bitmap?
+
+    /**
+     * Sends a reaction to the call.
+     */
+    public suspend fun sendReaction(
+        type: String,
+        emoji: String? = null,
+        custom: Map<String, Any>? = null,
+    ): Result<SendReactionResponse>
+
+    /**
+     * Sends a custom event to the call.
+     */
+    public suspend fun sendCustomEvent(data: Map<String, Any>): Result<SendCallEventResponse>
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/Call.kt
@@ -80,6 +80,9 @@ import stream.video.sfu.models.TrackType
  *
  * Internal methods (fastReconnect, rejoin, migrate, handleEvent, fireEvent) and
  * deprecated methods (subscribe, unsubscribe) are intentionally excluded.
+ *
+ * This interface is not intended for external implementation. The SDK provides
+ * the only supported implementation. New members may be added in minor releases.
  */
 @Stable
 public interface Call {
@@ -418,16 +421,16 @@ public interface Call {
     // -- Recording & Streaming --
 
     /** Starts recording with the default (composite) type. */
-    public suspend fun startRecording(): Result<Any>
+    public suspend fun startRecording(): Result<Unit>
 
     /** Starts recording with a specific type. */
-    public suspend fun startRecording(recordingType: RecordingType): Result<Any>
+    public suspend fun startRecording(recordingType: RecordingType): Result<Unit>
 
     /** Stops recording with the default (composite) type. */
-    public suspend fun stopRecording(): Result<Any>
+    public suspend fun stopRecording(): Result<Unit>
 
     /** Stops recording with a specific type. */
-    public suspend fun stopRecording(recordingType: RecordingType): Result<Any>
+    public suspend fun stopRecording(recordingType: RecordingType): Result<Unit>
 
     /**
      * Lists recordings for this call.
@@ -437,10 +440,10 @@ public interface Call {
     public suspend fun listRecordings(sessionId: String? = null): Result<ListRecordingsResponse>
 
     /** Starts HLS broadcasting. */
-    public suspend fun startHLS(): Result<Any>
+    public suspend fun startHLS(): Result<Unit>
 
     /** Stops HLS broadcasting. */
-    public suspend fun stopHLS(): Result<Any>
+    public suspend fun stopHLS(): Result<Unit>
 
     /**
      * Transitions the call to live mode.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/CameraManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/CameraManager.kt
@@ -28,6 +28,9 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * Provides controls for enabling/disabling the camera, flipping between front and back,
  * selecting specific devices, and observing camera state.
+ *
+ * This interface is not intended for external implementation. The SDK provides
+ * the only supported implementation. New members may be added in minor releases.
  */
 @Stable
 public interface CameraManager {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/CameraManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/CameraManager.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.api
+
+import androidx.compose.runtime.Stable
+import io.getstream.video.android.core.CameraDeviceWrapped
+import io.getstream.video.android.core.CameraDirection
+import io.getstream.video.android.core.DeviceStatus
+import io.getstream.webrtc.CameraEnumerationAndroid
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Manages the local camera for a video call.
+ *
+ * Provides controls for enabling/disabling the camera, flipping between front and back,
+ * selecting specific devices, and observing camera state.
+ */
+@Stable
+public interface CameraManager {
+
+    /** The status of the camera (enabled, disabled, or not selected). */
+    public val status: StateFlow<DeviceStatus>
+
+    /** Whether the camera is currently enabled. */
+    public val isEnabled: StateFlow<Boolean>
+
+    /** The current camera direction (front or back). */
+    public val direction: StateFlow<CameraDirection>
+
+    /** The currently selected camera device. */
+    public val selectedDevice: StateFlow<CameraDeviceWrapped?>
+
+    /** The currently selected camera resolution. */
+    public val resolution: StateFlow<CameraEnumerationAndroid.CaptureFormat?>
+
+    /** The available resolutions for the selected camera device. */
+    public val availableResolutions: StateFlow<List<CameraEnumerationAndroid.CaptureFormat>>
+
+    /** Flips the camera between front and back. */
+    public fun flip()
+
+    /** Enables the camera. */
+    public fun enable(fromUser: Boolean = true)
+
+    /** Disables the camera. */
+    public fun disable(fromUser: Boolean = true)
+
+    /** Enables or disables the camera. */
+    public fun setEnabled(enabled: Boolean, fromUser: Boolean = true)
+
+    /** Sets the camera direction (front or back). */
+    public fun setDirection(cameraDirection: CameraDirection)
+
+    /** Returns the list of available camera devices. */
+    public fun listDevices(): List<CameraDeviceWrapped>
+
+    /** Selects a specific camera device by ID. */
+    public fun select(deviceId: String, triggeredByFlip: Boolean = false)
+
+    /** Pauses the camera, remembering the prior state for resume. */
+    public fun pause(fromUser: Boolean = true)
+
+    /** Resumes the camera to the state before pause was called. */
+    public fun resume(fromUser: Boolean = true)
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/MicrophoneManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/MicrophoneManager.kt
@@ -27,6 +27,9 @@ import stream.video.sfu.models.AudioBitrateProfile
  *
  * Provides controls for enabling/disabling the microphone, selecting audio devices,
  * and observing microphone state.
+ *
+ * This interface is not intended for external implementation. The SDK provides
+ * the only supported implementation. New members may be added in minor releases.
  */
 @Stable
 public interface MicrophoneManager {
@@ -57,9 +60,6 @@ public interface MicrophoneManager {
 
     /** Selects a specific audio device. */
     public fun select(device: StreamAudioDevice?)
-
-    /** Returns a StateFlow of available audio devices. */
-    public fun listDevices(): StateFlow<List<StreamAudioDevice>>
 
     /**
      * Sets the audio bitrate profile. Can only be set before joining the call.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/MicrophoneManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/MicrophoneManager.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.api
+
+import androidx.compose.runtime.Stable
+import io.getstream.video.android.core.DeviceStatus
+import io.getstream.video.android.core.audio.StreamAudioDevice
+import kotlinx.coroutines.flow.StateFlow
+import stream.video.sfu.models.AudioBitrateProfile
+
+/**
+ * Manages the local microphone for a video call.
+ *
+ * Provides controls for enabling/disabling the microphone, selecting audio devices,
+ * and observing microphone state.
+ */
+@Stable
+public interface MicrophoneManager {
+
+    /** The status of the microphone (enabled, disabled, or not selected). */
+    public val status: StateFlow<DeviceStatus>
+
+    /** Whether the microphone is currently enabled. */
+    public val isEnabled: StateFlow<Boolean>
+
+    /** The currently selected audio device. */
+    public val selectedDevice: StateFlow<StreamAudioDevice?>
+
+    /** List of available audio devices. */
+    public val devices: StateFlow<List<StreamAudioDevice>>
+
+    /** The current audio bitrate profile. */
+    public val audioBitrateProfile: StateFlow<AudioBitrateProfile>
+
+    /** Enables the microphone. */
+    public fun enable(fromUser: Boolean = true)
+
+    /** Disables the microphone. */
+    public fun disable(fromUser: Boolean = true)
+
+    /** Enables or disables the microphone. */
+    public fun setEnabled(enabled: Boolean, fromUser: Boolean = true)
+
+    /** Selects a specific audio device. */
+    public fun select(device: StreamAudioDevice?)
+
+    /** Returns a StateFlow of available audio devices. */
+    public fun listDevices(): StateFlow<List<StreamAudioDevice>>
+
+    /**
+     * Sets the audio bitrate profile. Can only be set before joining the call.
+     *
+     * @param profile The audio bitrate profile to use.
+     * @return Result indicating success or failure.
+     */
+    public suspend fun setAudioBitrateProfile(profile: AudioBitrateProfile): Result<Unit>
+
+    /** Pauses the microphone, remembering the prior state for resume. */
+    public fun pause(fromUser: Boolean = true)
+
+    /** Resumes the microphone to the state before pause was called. */
+    public fun resume(fromUser: Boolean = true)
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/ScreenShareManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/ScreenShareManager.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.api
+
+import android.content.Intent
+import androidx.compose.runtime.Stable
+import io.getstream.video.android.core.DeviceStatus
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Manages screen sharing for a video call.
+ *
+ * Provides controls for enabling/disabling screen sharing and observing its state.
+ * This is a cross-cutting concern that requires access to the call session for
+ * track management.
+ */
+@Stable
+public interface ScreenShareManager {
+
+    /** The status of screen sharing (enabled, disabled, or not selected). */
+    public val status: StateFlow<DeviceStatus>
+
+    /** Whether screen sharing is currently enabled. */
+    public val isEnabled: StateFlow<Boolean>
+
+    /** Whether screen share audio capture is enabled. */
+    public val audioEnabled: StateFlow<Boolean>
+
+    /**
+     * Enables screen sharing.
+     *
+     * @param mediaProjectionPermissionResultData The intent data from the screen capture permission result.
+     * @param fromUser Whether this was triggered by a user action.
+     * @param includeAudio Whether to include audio in the screen share.
+     */
+    public fun enable(
+        mediaProjectionPermissionResultData: Intent,
+        fromUser: Boolean = true,
+        includeAudio: Boolean = false,
+    )
+
+    /**
+     * Disables screen sharing.
+     *
+     * @param fromUser Whether this was triggered by a user action.
+     */
+    public fun disable(fromUser: Boolean = true)
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/ScreenShareManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/ScreenShareManager.kt
@@ -27,6 +27,9 @@ import kotlinx.coroutines.flow.StateFlow
  * Provides controls for enabling/disabling screen sharing and observing its state.
  * This is a cross-cutting concern that requires access to the call session for
  * track management.
+ *
+ * This interface is not intended for external implementation. The SDK provides
+ * the only supported implementation. New members may be added in minor releases.
  */
 @Stable
 public interface ScreenShareManager {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/SpeakerManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/SpeakerManager.kt
@@ -26,6 +26,9 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * Provides controls for enabling/disabling the speaker, toggling speakerphone,
  * adjusting volume, and observing speaker state.
+ *
+ * This interface is not intended for external implementation. The SDK provides
+ * the only supported implementation. New members may be added in minor releases.
  */
 @Stable
 public interface SpeakerManager {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/SpeakerManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/SpeakerManager.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.api
+
+import androidx.compose.runtime.Stable
+import io.getstream.video.android.core.DeviceStatus
+import io.getstream.video.android.core.audio.StreamAudioDevice
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Manages the speaker output for a video call.
+ *
+ * Provides controls for enabling/disabling the speaker, toggling speakerphone,
+ * adjusting volume, and observing speaker state.
+ */
+@Stable
+public interface SpeakerManager {
+
+    /** The status of the speaker (enabled, disabled, or not selected). */
+    public val status: StateFlow<DeviceStatus>
+
+    /** Whether the speaker is currently enabled. */
+    public val isEnabled: StateFlow<Boolean>
+
+    /** The currently selected audio output device. */
+    public val selectedDevice: StateFlow<StreamAudioDevice?>
+
+    /** List of available audio output devices. */
+    public val devices: StateFlow<List<StreamAudioDevice>>
+
+    /** The current volume level (0-100), or null if not set. */
+    public val volume: StateFlow<Int?>
+
+    /** Whether the speakerphone mode is enabled. */
+    public val speakerPhoneEnabled: StateFlow<Boolean>
+
+    /** The current audio usage value. */
+    public val audioUsage: StateFlow<Int>
+
+    /** Enables the speaker. */
+    public fun enable(fromUser: Boolean = true)
+
+    /** Disables the speaker. */
+    public fun disable(fromUser: Boolean = true)
+
+    /** Enables or disables the speaker. */
+    public fun setEnabled(enabled: Boolean, fromUser: Boolean = true)
+
+    /**
+     * Enables or disables speakerphone mode.
+     *
+     * @param enable Whether to enable the speakerphone.
+     * @param defaultFallback The device to fall back to when disabling the speakerphone.
+     */
+    public fun setSpeakerPhone(enable: Boolean, defaultFallback: StreamAudioDevice? = null)
+
+    /**
+     * Sets the volume as a percentage.
+     *
+     * @param volumePercentage Volume level from 0 to 100.
+     */
+    public fun setVolume(volumePercentage: Int)
+
+    /**
+     * Sets the audio usage value (e.g., USAGE_MEDIA or USAGE_VOICE_COMMUNICATION).
+     *
+     * @param audioUsage The audio usage value to set.
+     * @return true if the update was successful, false otherwise.
+     */
+    public fun setAudioUsage(audioUsage: Int): Boolean
+
+    /** Pauses audio output, remembering the prior volume for resume. */
+    public fun pause()
+
+    /** Resumes audio output to the volume before pause was called. */
+    public fun resume()
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/StreamVideoClient.kt
@@ -46,6 +46,9 @@ import kotlinx.coroutines.flow.Flow
  *
  * Inherits [NotificationHandler] for push notification support. This coupling
  * is documented for future refactoring.
+ *
+ * This interface is not intended for external implementation. The SDK provides
+ * the only supported implementation. New members may be added in minor releases.
  */
 @Stable
 public interface StreamVideoClient : NotificationHandler {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/api/StreamVideoClient.kt
@@ -1,0 +1,201 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.api
+
+import android.content.Context
+import androidx.compose.runtime.Stable
+import io.getstream.android.push.PushDevice
+import io.getstream.android.video.generated.models.VideoEvent
+import io.getstream.result.Result
+import io.getstream.video.android.core.ClientState
+import io.getstream.video.android.core.EventSubscription
+import io.getstream.video.android.core.events.VideoEventListener
+import io.getstream.video.android.core.model.EdgeData
+import io.getstream.video.android.core.model.QueriedCalls
+import io.getstream.video.android.core.model.QueriedMembers
+import io.getstream.video.android.core.model.SortField
+import io.getstream.video.android.core.notifications.NotificationHandler
+import io.getstream.video.android.model.Device
+import io.getstream.video.android.model.User
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * The main interface to control Stream Video calls.
+ *
+ * Replaces the v1 [io.getstream.video.android.core.StreamVideo] interface with a cleaner
+ * contract. Provides call creation, querying, device management, event subscription,
+ * and connection lifecycle.
+ *
+ * Companion object methods (singleton management) are intentionally excluded --
+ * these move to VideoClientRegistry in a future phase.
+ *
+ * Inherits [NotificationHandler] for push notification support. This coupling
+ * is documented for future refactoring.
+ */
+@Stable
+public interface StreamVideoClient : NotificationHandler {
+
+    /** The application context. */
+    public val context: Context
+
+    /** The current authenticated user. */
+    public val user: User
+
+    /** The current user's ID. */
+    public val userId: String
+
+    /** The client-level state (active call, ringing call, connection status). */
+    public val state: ClientState
+
+    /**
+     * Creates or retrieves a call with the given type and ID.
+     *
+     * @param type The call type (e.g., "default", "livestream").
+     * @param id The call ID. If empty, a new ID will be generated.
+     * @return A [Call] instance for the given type and ID.
+     */
+    public fun call(type: String, id: String = ""): Call
+
+    /**
+     * Queries calls with filtering, sorting, and pagination.
+     *
+     * @param filters Filter predicates for the query.
+     * @param sort Sort fields and direction.
+     * @param limit Maximum number of results.
+     * @param prev Pagination cursor for previous page.
+     * @param next Pagination cursor for next page.
+     * @param watch Whether to watch for real-time updates.
+     * @return Result containing the queried calls.
+     */
+    public suspend fun queryCalls(
+        filters: Map<String, Any>,
+        sort: List<SortField> = listOf(SortField.Asc("cid")),
+        limit: Int = 25,
+        prev: String? = null,
+        next: String? = null,
+        watch: Boolean = false,
+    ): Result<QueriedCalls>
+
+    /**
+     * Queries members of a call with filtering, sorting, and pagination.
+     *
+     * @param type The call type.
+     * @param id The call ID.
+     * @param filter Filter predicates.
+     * @param sort Sort fields and direction.
+     * @param prev Pagination cursor for previous page.
+     * @param next Pagination cursor for next page.
+     * @param limit Maximum number of results.
+     * @return Result containing the queried members.
+     */
+    public suspend fun queryMembers(
+        type: String,
+        id: String,
+        filter: Map<String, Any>? = null,
+        sort: List<SortField> = mutableListOf(SortField.Desc("created_at")),
+        prev: String? = null,
+        next: String? = null,
+        limit: Int = 25,
+    ): Result<QueriedMembers>
+
+    /**
+     * Subscribes to specific event types.
+     *
+     * @param eventTypes The event types to subscribe to.
+     * @param listener The listener to invoke when matching events occur.
+     * @return An [EventSubscription] that can be disposed to stop receiving events.
+     */
+    public fun subscribeFor(
+        vararg eventTypes: Class<out VideoEvent>,
+        listener: VideoEventListener<VideoEvent>,
+    ): EventSubscription
+
+    /**
+     * Subscribes to all events.
+     *
+     * @param listener The listener to invoke for every event.
+     * @return An [EventSubscription] that can be disposed to stop receiving events.
+     */
+    public fun subscribe(
+        listener: VideoEventListener<VideoEvent>,
+    ): EventSubscription
+
+    /**
+     * Gets the cached push notification device.
+     *
+     * @return A flow emitting the current device, or null.
+     */
+    public fun getDevice(): Flow<Device?>
+
+    /**
+     * Registers a device for push notifications.
+     *
+     * @param pushDevice The push device from the selected push provider.
+     * @return Result containing the created device.
+     */
+    public suspend fun createDevice(pushDevice: PushDevice): Result<Device>
+
+    /**
+     * Updates a push notification device.
+     *
+     * @param device The device to update.
+     */
+    public suspend fun updateDevice(device: Device?)
+
+    /**
+     * Removes a push notification device.
+     *
+     * @param device The device to remove.
+     * @return Result indicating success or failure.
+     */
+    public suspend fun deleteDevice(device: Device): Result<Unit>
+
+    /**
+     * Returns the list of available network edges.
+     */
+    public suspend fun getEdges(): Result<List<EdgeData>>
+
+    /**
+     * Connects the user asynchronously.
+     *
+     * @return A deferred result with the connection timestamp.
+     */
+    public suspend fun connectAsync(): Deferred<Result<Long>>
+
+    /**
+     * Connects the user and suspends until connected.
+     *
+     * @return Result with the connection timestamp.
+     */
+    public suspend fun connect(): Result<Long>
+
+    /**
+     * Connects the user if not already connected.
+     */
+    public suspend fun connectIfNotAlreadyConnected()
+
+    /**
+     * Logs out the user, clearing internal state and push devices.
+     */
+    public fun logOut()
+
+    /**
+     * Cleans up all resources held by this client.
+     */
+    public fun cleanup()
+}


### PR DESCRIPTION
### Goal

Define the public interface contracts for the V2 SDK migration. This is the first in a series of PRs migrating stream-video-android to use stream-android-core as its foundation.

This introduces `StreamVideoClient` and `Call` as interfaces with sub-interfaces (`CameraManager`, `MicrophoneManager`, `SpeakerManager`, `ScreenShareManager`) following `stream-android-core`'s `api`/`internal` package pattern.

### Implementation

- New `api` package in `stream-video-android-core` with 6 interface files
- `StreamVideoClient` interface maps all current `StreamVideo` public methods (~17 methods)
- `Call` interface maps current `Call` class (~60 methods) with 4 sub-interface accessors (`camera`, `microphone`, `speaker`, `screenShare`)
- Sub-interfaces designed for delegation: self-contained ones (Camera, Microphone, Speaker) delegate with `by`, cross-cutting ones (ScreenShare) implemented directly on `CallImpl`
- API dump updated to include new interfaces

### Testing

- Compilation verified via `compileDebugKotlin`
- API dump regenerated and passes `apiCheck`
- No behavioral changes — interfaces only, implementations come in subsequent phases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive API interfaces for video call management, including call lifecycle operations (create, join, leave, end), media controls (camera, microphone, speaker, screen sharing), and participant management (mute, kick, block, pin/unpin participants).
  * Added support for recordings, HLS streaming, transcriptions, and closed captions within calls.
  * Added call permission and capability management for secure user access control.
  * Added event subscription and user feedback collection capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->