### PR TITLE
Improve Telecom enabled audio routing

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -941,9 +941,6 @@ class MicrophoneManager(
             var capturedOnAudioDevicesUpdate = onAudioDevicesUpdate
 
             if (setupCompleted) {
-                logger.d {
-                    "[setup] Already complete (preferSpeaker=$preferSpeaker), invoking callback immediately"
-                }
                 capturedOnAudioDevicesUpdate?.invoke()
                 capturedOnAudioDevicesUpdate = null
 
@@ -959,28 +956,22 @@ class MicrophoneManager(
             }
 
             if (canHandleDeviceSwitch() && !::audioHandler.isInitialized) {
-                val preferredDeviceList = listOf(
-                    AudioDevice.BluetoothHeadset::class.java,
-                    AudioDevice.WiredHeadset::class.java,
-                ) + if (preferSpeaker) {
-                    listOf(
-                        AudioDevice.Speakerphone::class.java,
-                        AudioDevice.Earpiece::class.java,
-                    )
-                } else {
-                    listOf(
-                        AudioDevice.Earpiece::class.java,
-                        AudioDevice.Speakerphone::class.java,
-                    )
-                }
-
-                logger.d {
-                    "[setup] Creating audioHandler with preferSpeaker=$preferSpeaker, preferredDeviceList=${preferredDeviceList.map { it.simpleName }}"
-                }
-
                 audioHandler = AudioSwitchHandler(
                     context = mediaManager.context,
-                    preferredDeviceList = preferredDeviceList,
+                    preferredDeviceList = listOf(
+                        AudioDevice.BluetoothHeadset::class.java,
+                        AudioDevice.WiredHeadset::class.java,
+                    ) + if (preferSpeaker) {
+                        listOf(
+                            AudioDevice.Speakerphone::class.java,
+                            AudioDevice.Earpiece::class.java,
+                        )
+                    } else {
+                        listOf(
+                            AudioDevice.Earpiece::class.java,
+                            AudioDevice.Speakerphone::class.java,
+                        )
+                    },
                     audioDeviceChangeListener = { devices, selected ->
                         logger.i { "[audioSwitch] audio devices. selected $selected, available devices are $devices" }
 
@@ -997,7 +988,7 @@ class MicrophoneManager(
                 logger.d { "[setup] Calling start on instance $audioHandler" }
                 audioHandler.start()
             } else {
-                logger.d { "[setup] audioHandler already initialized or MEDIA usage — invoking callback directly" }
+                logger.d { "[MediaManager#setup] Usage is MEDIA or audioHandle is already initialized" }
                 capturedOnAudioDevicesUpdate?.invoke()
             }
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -39,6 +39,7 @@ import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
+import androidx.core.telecom.CallEndpointCompat
 import com.twilio.audioswitch.AudioDevice
 import io.getstream.android.video.generated.models.VideoSettingsResponse
 import io.getstream.log.taggedLogger
@@ -53,6 +54,8 @@ import io.getstream.video.android.core.audio.UsbAudioInputDevice.Companion.isUsb
 import io.getstream.video.android.core.call.video.FilterVideoProcessor
 import io.getstream.video.android.core.camera.CameraCharacteristicsValidator
 import io.getstream.video.android.core.camera.DefaultCameraCharacteristicsValidator
+import io.getstream.video.android.core.notifications.internal.telecom.jetpack.TelecomCall
+import io.getstream.video.android.core.notifications.internal.telecom.jetpack.TelecomCallAction
 import io.getstream.video.android.core.screenshare.StreamScreenShareService
 import io.getstream.video.android.core.utils.buildAudioConstraints
 import io.getstream.video.android.core.utils.mapState
@@ -148,7 +151,6 @@ class SpeakerManager(
      */
     fun setEnabled(enabled: Boolean, fromUser: Boolean = true) {
         logger.i { "setEnabled $enabled" }
-        // TODO: what is fromUser?
         if (enabled) {
             enable(fromUser = fromUser)
         } else {
@@ -648,12 +650,10 @@ class MicrophoneManager(
      * Enable or disable the microphone
      */
     fun setEnabled(enabled: Boolean, fromUser: Boolean = true) {
-        enforceSetup {
-            if (enabled) {
-                enable(fromUser = fromUser)
-            } else {
-                disable(fromUser = fromUser)
-            }
+        if (enabled) {
+            enable(fromUser = fromUser)
+        } else {
+            disable(fromUser = fromUser)
         }
     }
 
@@ -664,6 +664,14 @@ class MicrophoneManager(
         logger.i { "selecting device $device" }
         ifAudioHandlerInitialized { it.selectDevice(device?.toAudioDevice()) }
         _selectedDevice.value = device
+
+        // For Telecom-managed calls (e.g. audio calls registered as CALL_TYPE_AUDIO_CALL),
+        // the Telecom framework controls audio routing and has higher priority than
+        // AudioManager.setCommunicationDevice(). Route the switch through the Telecom API
+        // so the OS honours it on all devices including Samsung S21 Ultra (Android 14).
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            switchTelecomEndpointForDevice(device)
+        }
 
         if (device !is StreamAudioDevice.Speakerphone && mediaManager.speaker.isEnabled.value == true) {
             mediaManager.speaker._status.value = DeviceStatus.Disabled
@@ -676,6 +684,46 @@ class MicrophoneManager(
         if (device !is StreamAudioDevice.BluetoothHeadset && device !is StreamAudioDevice.WiredHeadset) {
             nonHeadsetFallbackDevice = device
         }
+    }
+
+    /**
+     * When a call is registered with the Android Telecom framework (e.g. audio calls use
+     * CALL_TYPE_AUDIO_CALL), the framework owns audio routing and can override
+     * AudioManager.setCommunicationDevice(). This function mirrors any device selection to the
+     * Telecom endpoint API so the routing is actually honoured.
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun switchTelecomEndpointForDevice(device: StreamAudioDevice?) {
+        val telecomCall = mediaManager.call.state.jetpackTelecomRepository
+            ?.currentCall?.value as? TelecomCall.Registered ?: return
+
+        val targetEndpointType = when (device) {
+            is StreamAudioDevice.Speakerphone -> CallEndpointCompat.TYPE_SPEAKER
+            is StreamAudioDevice.Earpiece -> CallEndpointCompat.TYPE_EARPIECE
+            is StreamAudioDevice.BluetoothHeadset -> CallEndpointCompat.TYPE_BLUETOOTH
+            is StreamAudioDevice.WiredHeadset -> CallEndpointCompat.TYPE_WIRED_HEADSET
+            else -> return
+        }
+
+        val endpoint = telecomCall.availableCallEndpoints
+            .firstOrNull { it.type == targetEndpointType }
+
+        if (endpoint == null) {
+            logger.w {
+                "[switchTelecomEndpointForDevice] No Telecom endpoint of type=$targetEndpointType available; available=${telecomCall.availableCallEndpoints.map { it.name }}"
+            }
+            return
+        }
+
+        if (telecomCall.currentCallEndpoint?.identifier == endpoint.identifier) {
+            logger.d { "[switchTelecomEndpointForDevice] Telecom endpoint already set to '${endpoint.name}'" }
+            return
+        }
+
+        logger.i {
+            "[switchTelecomEndpointForDevice] Switching Telecom endpoint to '${endpoint.name}' (type=$targetEndpointType)"
+        }
+        telecomCall.processAction(TelecomCallAction.SwitchAudioEndpoint(endpoint.identifier))
     }
 
     /**
@@ -893,6 +941,9 @@ class MicrophoneManager(
             var capturedOnAudioDevicesUpdate = onAudioDevicesUpdate
 
             if (setupCompleted) {
+                logger.d {
+                    "[setup] Already complete (preferSpeaker=$preferSpeaker), invoking callback immediately"
+                }
                 capturedOnAudioDevicesUpdate?.invoke()
                 capturedOnAudioDevicesUpdate = null
 
@@ -908,22 +959,28 @@ class MicrophoneManager(
             }
 
             if (canHandleDeviceSwitch() && !::audioHandler.isInitialized) {
+                val preferredDeviceList = listOf(
+                    AudioDevice.BluetoothHeadset::class.java,
+                    AudioDevice.WiredHeadset::class.java,
+                ) + if (preferSpeaker) {
+                    listOf(
+                        AudioDevice.Speakerphone::class.java,
+                        AudioDevice.Earpiece::class.java,
+                    )
+                } else {
+                    listOf(
+                        AudioDevice.Earpiece::class.java,
+                        AudioDevice.Speakerphone::class.java,
+                    )
+                }
+
+                logger.d {
+                    "[setup] Creating audioHandler with preferSpeaker=$preferSpeaker, preferredDeviceList=${preferredDeviceList.map { it.simpleName }}"
+                }
+
                 audioHandler = AudioSwitchHandler(
                     context = mediaManager.context,
-                    preferredDeviceList = listOf(
-                        AudioDevice.BluetoothHeadset::class.java,
-                        AudioDevice.WiredHeadset::class.java,
-                    ) + if (preferSpeaker) {
-                        listOf(
-                            AudioDevice.Speakerphone::class.java,
-                            AudioDevice.Earpiece::class.java,
-                        )
-                    } else {
-                        listOf(
-                            AudioDevice.Earpiece::class.java,
-                            AudioDevice.Speakerphone::class.java,
-                        )
-                    },
+                    preferredDeviceList = preferredDeviceList,
                     audioDeviceChangeListener = { devices, selected ->
                         logger.i { "[audioSwitch] audio devices. selected $selected, available devices are $devices" }
 
@@ -940,7 +997,7 @@ class MicrophoneManager(
                 logger.d { "[setup] Calling start on instance $audioHandler" }
                 audioHandler.start()
             } else {
-                logger.d { "[MediaManager#setup] Usage is MEDIA or audioHandle is already initialized" }
+                logger.d { "[setup] audioHandler already initialized or MEDIA usage — invoking callback directly" }
                 capturedOnAudioDevicesUpdate?.invoke()
             }
         }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/MicrophoneManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/MicrophoneManagerTest.kt
@@ -18,71 +18,51 @@ package io.getstream.video.android.core
 
 import android.content.Context
 import android.media.AudioAttributes
+import android.media.AudioDeviceInfo
 import android.media.AudioManager
+import android.net.Uri
+import android.os.Build
+import android.os.ParcelUuid
+import androidx.core.telecom.CallAttributesCompat
+import androidx.core.telecom.CallEndpointCompat
+import com.twilio.audioswitch.AudioDevice
+import io.getstream.android.video.generated.models.AudioSettingsResponse
+import io.getstream.android.video.generated.models.CallSettingsResponse
 import io.getstream.android.video.generated.models.OwnCapability
-import io.getstream.video.android.core.audio.AudioSwitchHandler
+import io.getstream.video.android.core.audio.StreamAudioDevice
+import io.getstream.video.android.core.audio.UsbAudioInputDevice
+import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
+import io.getstream.video.android.core.notifications.internal.telecom.jetpack.JetpackTelecomRepository
+import io.getstream.video.android.core.notifications.internal.telecom.jetpack.TelecomCall
+import io.getstream.video.android.core.notifications.internal.telecom.jetpack.TelecomCallAction
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.spyk
 import io.mockk.verify
 import io.mockk.verifyOrder
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.webrtc.AudioTrack
+import stream.video.sfu.models.AudioBitrateProfile
 
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O_MR1])
 class MicrophoneManagerTest {
 
     private val audioUsage = AudioAttributes.USAGE_VOICE_COMMUNICATION
     private val audioUsageProvider = { AudioAttributes.USAGE_VOICE_COMMUNICATION }
-
-    @Test
-    fun `Ensure setup is called prior to any action onto the microphone manager`() = runTest {
-        // Given
-        val mediaManager = mockk<MediaManagerImpl>(relaxed = true)
-        val actual = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
-        val context = mockk<Context>(relaxed = true)
-        every { mediaManager.context } returns context
-        every { context.getSystemService(any()) } returns mockk<AudioManager>(relaxed = true)
-
-        val speakerManager = mockk<SpeakerManager>(relaxed = true)
-        val isEnabledStateFlow = MutableStateFlow(true)
-        every { speakerManager.isEnabled } returns isEnabledStateFlow
-        every { mediaManager.speaker } returns speakerManager
-
-        val screenShareManager = mockk<ScreenShareManager>(relaxed = true)
-        val audioEnabledStateFlow = MutableStateFlow(false)
-        every { screenShareManager.audioEnabled } returns audioEnabledStateFlow
-        every { mediaManager.screenShare } returns screenShareManager
-
-        val microphoneManager = spyk(actual)
-        val slot = slot<() -> Unit>()
-        every { microphoneManager.setup(any(), capture(slot)) } answers { slot.captured.invoke() }
-        every {
-            microphoneManager["ifAudioHandlerInitialized"](
-                any<(AudioSwitchHandler) -> Unit>(),
-            )
-        } answers { true }
-
-        val mockCallState = mockk<CallState>(relaxed = true)
-        every { mediaManager.call.state } returns mockCallState
-        every { mockCallState.ownCapabilities.value } returns listOf(OwnCapability.SendAudio)
-
-        // When
-        microphoneManager.enable() // 1
-        microphoneManager.select(null) // 0
-        microphoneManager.resume() // 2, 3, Resume calls enable internally, thus two invocations
-        microphoneManager.disable() // 4
-        microphoneManager.pause() // 5
-        microphoneManager.setEnabled(true) // 6, 7, calls enable internally
-        microphoneManager.setEnabled(false) // 8, 9, calls disable internally
-
-        // Then
-        verify(exactly = 9) {
-            // Setup will be called exactly 10 times
-            microphoneManager.setup(any(), any())
-        }
-    }
 
     @Test
     fun `Don't crash when accessing audioHandler prior to setup`() {
@@ -110,33 +90,27 @@ class MicrophoneManagerTest {
     }
 
     @Test
-    fun `Ensure setup if ever the manager was cleaned`() {
-        // Given
+    fun `resume calls setup again after cleanup`() {
         val mediaManager = mockk<MediaManagerImpl>(relaxed = true)
-        val actual = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
         val context = mockk<Context>(relaxed = true)
-        val microphoneManager = spyk(actual)
+        val microphoneManager =
+            spyk(MicrophoneManager(mediaManager, audioUsage, audioUsageProvider))
+
         every { mediaManager.context } returns context
         every { context.getSystemService(any()) } returns mockk<AudioManager>(relaxed = true)
-
-        val slot = slot<() -> Unit>()
-        every { microphoneManager.setup(any(), capture(slot)) } answers { slot.captured.invoke() }
-
-        // When
-        microphoneManager.setup()
-        microphoneManager.cleanup() // Clean and then invoke again
-        microphoneManager.resume() // Should call setup again
-
-        // Then
-        verify(exactly = 1) {
-            // Setup was called twice
-            microphoneManager.setup(any())
+        every { microphoneManager.setup(any(), any()) } answers {
+            secondArg<(() -> Unit)?>()?.invoke()
         }
+
+        microphoneManager.setup()
+        microphoneManager.cleanup()
+        microphoneManager.resume()
+
         verifyOrder {
-            microphoneManager.setup(any()) // Manual call
-            microphoneManager.cleanup() // Manual call
-            microphoneManager.resume() // Manual call
-            microphoneManager.setup(any(), any()) // Auto. Part of enforce setup strategy of resume
+            microphoneManager.setup()
+            microphoneManager.cleanup()
+            microphoneManager.resume()
+            microphoneManager.setup(any(), any())
         }
     }
 
@@ -166,5 +140,373 @@ class MicrophoneManagerTest {
             // Setup was called twice
             spyMicrophoneManager.enable()
         }
+    }
+
+    @Test
+    fun `enable should update status and enable audio track`() {
+        val audioTrack = mockk<AudioTrack>(relaxed = true)
+        val microphoneManager = microphoneManagerWithImmediateSetup(audioTrack = audioTrack)
+
+        microphoneManager.enable(fromUser = true)
+
+        assertEquals(DeviceStatus.Enabled, microphoneManager.status.value)
+        verify(exactly = 1) { audioTrack.trySetEnabled(true) }
+    }
+
+    @Test
+    fun `disable should update status and disable audio track`() {
+        val audioTrack = mockk<AudioTrack>(relaxed = true)
+        val microphoneManager = microphoneManagerWithImmediateSetup(audioTrack = audioTrack)
+
+        microphoneManager.disable(fromUser = true)
+
+        assertEquals(DeviceStatus.Disabled, microphoneManager.status.value)
+        verify(exactly = 1) { audioTrack.trySetEnabled(false) }
+    }
+
+    @Test
+    fun `enable should NOT override status when fromUser is false`() {
+        val audioTrack = mockk<AudioTrack>(relaxed = true)
+        val microphoneManager = microphoneManagerWithImmediateSetup(audioTrack = audioTrack)
+        microphoneManager.disable(fromUser = true)
+        clearMocks(audioTrack)
+
+        microphoneManager.enable(fromUser = false)
+
+        assertEquals(DeviceStatus.Disabled, microphoneManager.status.value)
+        verify(exactly = 1) { audioTrack.trySetEnabled(true) }
+    }
+
+    @Test
+    fun `pause should store prior status and disable`() {
+        val audioTrack = mockk<AudioTrack>(relaxed = true)
+        val microphoneManager = microphoneManagerWithImmediateSetup(audioTrack = audioTrack)
+        microphoneManager.enable(fromUser = true)
+        clearMocks(audioTrack)
+
+        microphoneManager.pause(fromUser = true)
+
+        assertEquals(DeviceStatus.Enabled, microphoneManager.priorStatus)
+        assertEquals(DeviceStatus.Disabled, microphoneManager.status.value)
+        verify(exactly = 1) { audioTrack.trySetEnabled(false) }
+    }
+
+    @Test
+    fun `resume should restore enabled state if previously enabled`() {
+        val audioTrack = mockk<AudioTrack>(relaxed = true)
+        val microphoneManager = microphoneManagerWithImmediateSetup(audioTrack = audioTrack)
+        microphoneManager.enable(fromUser = true)
+        microphoneManager.pause(fromUser = true)
+        clearMocks(audioTrack)
+
+        microphoneManager.resume(fromUser = true)
+
+        assertEquals(DeviceStatus.Enabled, microphoneManager.status.value)
+        verify(exactly = 1) { audioTrack.trySetEnabled(true) }
+    }
+
+    @Test
+    fun `resume should NOT enable if prior status was not enabled`() {
+        val audioTrack = mockk<AudioTrack>(relaxed = true)
+        val microphoneManager = microphoneManagerWithImmediateSetup(audioTrack = audioTrack)
+        microphoneManager.disable(fromUser = true)
+        microphoneManager.pause(fromUser = true)
+        clearMocks(audioTrack)
+
+        microphoneManager.resume(fromUser = true)
+
+        assertEquals(DeviceStatus.Disabled, microphoneManager.status.value)
+        verify(exactly = 0) { audioTrack.trySetEnabled(true) }
+    }
+
+    @Test
+    fun `setEnabled true should call enable`() {
+        val microphoneManager = microphoneManagerWithImmediateSetup()
+
+        microphoneManager.setEnabled(true)
+
+        verify(exactly = 1) { microphoneManager.enable(true) }
+    }
+
+    @Test
+    fun `setEnabled false should call disable`() {
+        val microphoneManager = microphoneManagerWithImmediateSetup()
+
+        microphoneManager.setEnabled(false)
+
+        verify(exactly = 1) { microphoneManager.disable(true) }
+    }
+
+    @Test
+    fun `select should update selected device`() {
+        val mediaManager = mockMediaManager()
+        val speakerManager = mockSpeakerManager(isEnabled = false)
+        every { mediaManager.speaker } returns speakerManager
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+        val selectedDevice = StreamAudioDevice.Earpiece(audio = mockk<AudioDevice>())
+
+        microphoneManager.select(selectedDevice)
+
+        assertEquals(selectedDevice, microphoneManager.selectedDevice.value)
+    }
+
+    @Test
+    fun `select speaker should enable speaker status`() {
+        val mediaManager = mockMediaManager()
+        val speakerStatus = MutableStateFlow<DeviceStatus>(DeviceStatus.NotSelected)
+        val speakerManager = mockSpeakerManager(isEnabled = false, status = speakerStatus)
+        every { mediaManager.speaker } returns speakerManager
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        microphoneManager.select(StreamAudioDevice.Speakerphone(audio = mockk<AudioDevice>()))
+
+        assertEquals(DeviceStatus.Enabled, speakerStatus.value)
+    }
+
+    @Test
+    fun `select non headset should update fallback device`() {
+        val mediaManager = mockMediaManager()
+        val speakerManager = mockSpeakerManager(isEnabled = false)
+        every { mediaManager.speaker } returns speakerManager
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+        val earpiece = StreamAudioDevice.Earpiece(audio = mockk<AudioDevice>())
+
+        microphoneManager.select(earpiece)
+
+        assertEquals(earpiece, microphoneManager.nonHeadsetFallbackDevice)
+    }
+
+    @Test
+    fun `select should switch telecom endpoint when matching endpoint exists`() {
+        val endpointId = ParcelUuid.fromString("11111111-1111-1111-1111-111111111111")
+        val speakerEndpoint = mockTelecomEndpoint(
+            type = CallEndpointCompat.TYPE_SPEAKER,
+            identifier = endpointId,
+            name = "Speaker",
+        )
+        val telecomCall =
+            spyk(
+                registeredTelecomCall(
+                    currentEndpoint = null,
+                    availableEndpoints = listOf(speakerEndpoint),
+                ),
+            )
+        val mediaManager = mockMediaManagerWithTelecom(telecomCall)
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        microphoneManager.select(StreamAudioDevice.Speakerphone(audio = mockk<AudioDevice>()))
+
+        verify(exactly = 1) {
+            telecomCall.processAction(TelecomCallAction.SwitchAudioEndpoint(endpointId))
+        }
+    }
+
+    @Test
+    fun `select should not switch telecom endpoint when endpoint already selected`() {
+        val endpointId = ParcelUuid.fromString("22222222-2222-2222-2222-222222222222")
+        val earpieceEndpoint = mockTelecomEndpoint(
+            type = CallEndpointCompat.TYPE_EARPIECE,
+            identifier = endpointId,
+            name = "Earpiece",
+        )
+        val telecomCall = registeredTelecomCall(
+            currentEndpoint = earpieceEndpoint,
+            availableEndpoints = listOf(earpieceEndpoint),
+        )
+        val mediaManager = mockMediaManagerWithTelecom(telecomCall)
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        microphoneManager.select(StreamAudioDevice.Earpiece(audio = mockk<AudioDevice>()))
+
+        assertNull(telecomCall.actionSource.tryReceive().getOrNull())
+    }
+
+    @Test
+    fun `select should not switch telecom endpoint when no matching endpoint exists`() {
+        val bluetoothEndpoint = mockTelecomEndpoint(
+            type = CallEndpointCompat.TYPE_BLUETOOTH,
+            identifier = ParcelUuid.fromString("33333333-3333-3333-3333-333333333333"),
+            name = "Bluetooth",
+        )
+        val telecomCall = registeredTelecomCall(
+            currentEndpoint = null,
+            availableEndpoints = listOf(bluetoothEndpoint),
+        )
+        val mediaManager = mockMediaManagerWithTelecom(telecomCall)
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        microphoneManager.select(StreamAudioDevice.WiredHeadset(audio = mockk<AudioDevice>()))
+
+        assertNull(telecomCall.actionSource.tryReceive().getOrNull())
+    }
+
+    @Test
+    fun `selectUsbDevice success should update state`() {
+        val mediaManager = mockMediaManager()
+        val call = mockk<Call>(relaxed = true)
+        val peerConnectionFactory = mockk<StreamPeerConnectionFactory>()
+        val deviceInfo = mockk<AudioDeviceInfo>(relaxed = true)
+        val usbDevice = UsbAudioInputDevice(deviceInfo)
+        every { mediaManager.call } returns call
+        every { call.peerConnectionFactory } returns peerConnectionFactory
+        every { peerConnectionFactory.setPreferredAudioInputDevice(deviceInfo) } returns true
+
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        val result = microphoneManager.selectUsbDevice(usbDevice)
+
+        assertTrue(result)
+        assertEquals(usbDevice, microphoneManager.selectedUsbDevice.value)
+    }
+
+    @Test
+    fun `selectUsbDevice failure should NOT update state`() {
+        val mediaManager = mockMediaManager()
+        val call = mockk<Call>(relaxed = true)
+        val peerConnectionFactory = mockk<StreamPeerConnectionFactory>()
+        val deviceInfo = mockk<AudioDeviceInfo>(relaxed = true)
+        val usbDevice = UsbAudioInputDevice(deviceInfo)
+        every { mediaManager.call } returns call
+        every { call.peerConnectionFactory } returns peerConnectionFactory
+        every { peerConnectionFactory.setPreferredAudioInputDevice(deviceInfo) } returns false
+
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        val result = microphoneManager.selectUsbDevice(usbDevice)
+
+        assertFalse(result)
+        assertNull(microphoneManager.selectedUsbDevice.value)
+    }
+
+    @Test
+    fun `setAudioBitrateProfile should fail if call already joined`() = runTest {
+        val mediaManager = mockMediaManager(
+            connection = MutableStateFlow(
+                RealtimeConnection.Joined(mockk<RtcSession>(relaxed = true)),
+            ),
+            settings = MutableStateFlow(mockCallSettings(hifiAudioEnabled = true)),
+        )
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        val result = microphoneManager.setAudioBitrateProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_HIGH_QUALITY,
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_STANDARD_UNSPECIFIED,
+            microphoneManager.audioBitrateProfile.value,
+        )
+    }
+
+    @Test
+    fun `setAudioBitrateProfile should fail if hifi disabled`() = runTest {
+        val mediaManager = mockMediaManager(
+            connection = MutableStateFlow(RealtimeConnection.PreJoin),
+            settings = MutableStateFlow(mockCallSettings(hifiAudioEnabled = false)),
+        )
+        val microphoneManager = MicrophoneManager(mediaManager, audioUsage, audioUsageProvider)
+
+        val result = microphoneManager.setAudioBitrateProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_MUSIC_HIGH_QUALITY,
+        )
+
+        assertTrue(result.isFailure)
+        assertEquals(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_STANDARD_UNSPECIFIED,
+            microphoneManager.audioBitrateProfile.value,
+        )
+    }
+
+    private fun microphoneManagerWithImmediateSetup(
+        mediaManager: MediaManagerImpl = mockMediaManager(),
+        audioTrack: AudioTrack = mockk(relaxed = true),
+    ): MicrophoneManager {
+        every { mediaManager.audioTrack } returns audioTrack
+        every { mediaManager.speaker } returns mockSpeakerManager(isEnabled = false)
+
+        val microphoneManager =
+            spyk(MicrophoneManager(mediaManager, audioUsage, audioUsageProvider))
+        every { microphoneManager.setup(any(), any()) } answers {
+            secondArg<(() -> Unit)?>()?.invoke()
+        }
+        return microphoneManager
+    }
+
+    private fun mockMediaManager(
+        connection: MutableStateFlow<RealtimeConnection> =
+            MutableStateFlow(RealtimeConnection.PreJoin),
+        settings: MutableStateFlow<CallSettingsResponse?> =
+            MutableStateFlow(mockCallSettings(true)),
+        call: Call = mockk(relaxed = true),
+        callState: CallState = mockk(relaxed = true),
+    ): MediaManagerImpl {
+        val mediaManager = mockk<MediaManagerImpl>(relaxed = true)
+        every { mediaManager.call } returns call
+        every { call.state } returns callState
+        every { callState.connection } returns connection
+        every { callState.settings } returns settings
+        every { callState.jetpackTelecomRepository } returns null
+        return mediaManager
+    }
+
+    private fun mockMediaManagerWithTelecom(telecomCall: TelecomCall.Registered): MediaManagerImpl {
+        val callState = mockk<CallState>(relaxed = true)
+        val telecomRepository = mockk<JetpackTelecomRepository>(relaxed = true)
+        every { telecomRepository.currentCall } returns MutableStateFlow<TelecomCall>(telecomCall)
+        return mockMediaManager(callState = callState).also {
+            every { callState.jetpackTelecomRepository } returns telecomRepository
+            every { it.speaker } returns mockSpeakerManager(isEnabled = false)
+        }
+    }
+
+    private fun mockSpeakerManager(
+        isEnabled: Boolean,
+        status: MutableStateFlow<DeviceStatus> = MutableStateFlow(DeviceStatus.NotSelected),
+    ): SpeakerManager {
+        val speakerManager = mockk<SpeakerManager>(relaxed = true)
+        every { speakerManager.isEnabled } returns MutableStateFlow(isEnabled)
+        every { speakerManager._status } returns status
+        return speakerManager
+    }
+
+    private fun mockCallSettings(hifiAudioEnabled: Boolean): CallSettingsResponse {
+        val audioSettings = mockk<AudioSettingsResponse>(relaxed = true)
+        every { audioSettings.hifiAudioEnabled } returns hifiAudioEnabled
+
+        return mockk(relaxed = true) {
+            every { audio } returns audioSettings
+        }
+    }
+
+    private fun registeredTelecomCall(
+        currentEndpoint: CallEndpointCompat?,
+        availableEndpoints: List<CallEndpointCompat>,
+    ): TelecomCall.Registered {
+        return TelecomCall.Registered(
+            id = ParcelUuid.fromString("00000000-0000-0000-0000-000000000001"),
+            callAttributes = CallAttributesCompat(
+                displayName = "Test",
+                address = Uri.parse("tel:123456789"),
+                direction = CallAttributesCompat.DIRECTION_OUTGOING,
+                callType = CallAttributesCompat.CALL_TYPE_AUDIO_CALL,
+                callCapabilities = 0,
+            ),
+            isActive = true,
+            isOnHold = false,
+            isMuted = false,
+            errorCode = null,
+            currentCallEndpoint = currentEndpoint,
+            availableCallEndpoints = availableEndpoints,
+            actionSource = Channel(Channel.UNLIMITED),
+        )
+    }
+
+    private fun mockTelecomEndpoint(
+        type: Int,
+        identifier: ParcelUuid,
+        name: String,
+    ): CallEndpointCompat {
+        return CallEndpointCompat(name, type, identifier)
     }
 }


### PR DESCRIPTION
### Goal

Improve Telecom based audio output routing
For telecom based calls, the the audio output routing is owned by telecom which overrides `AudioManager.setCommunicationDevice()`

### Implementation

For telecom registered calls, when a user wants to switch to speaker then we will coordinate with Telecom API to switch the audio output via
```kotin
telecomCall.processAction(TelecomCallAction.SwitchAudioEndpoint(...))
```

### 🎨 UI Changes

None

### Testing


Depends on PR: https://github.com/GetStream/stream-video-android/pull/1650

1. Click on direct call 
2. select user to make audio/video call

3. Check if telecom is enabled for audio/video call (its enabled by default in demo-app)
like this
```kotlin
        val callServiceConfigRegistry = CallServiceConfigRegistry()
        callServiceConfigRegistry.apply {
            register(
                CallType.AudioCall.name,
                DefaultCallConfigurations.audioCall.copy(enableTelecom = false),
            )

        return StreamVideoBuilder(
            callServiceConfigRegistry = callServiceConfigRegistry,
```

2. Make an audio/video-call
3. Once the call accepted, then try to toggle speaker and see the behaviour

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated Android Telecom framework for audio endpoint routing during device selection.

* **Bug Fixes**
  * Modified microphone enable/disable control flow to provide more immediate response.

* **Tests**
  * Added comprehensive test coverage for microphone management state transitions, device selection behaviors, USB audio handling, and audio bitrate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->