### PR TITLE
Fix frame drop(s) in main-thread by switching the work of audio switching off the main-thread

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -550,7 +550,8 @@ class MicrophoneManager(
     private val logger by taggedLogger("Media:MicrophoneManager")
 
     private lateinit var audioHandler: AudioHandler
-    private var setupCompleted: Boolean = false
+
+    @Volatile private var setupCompleted: Boolean = false
     internal var audioManager: AudioManager? = null
     internal var priorStatus: DeviceStatus? = null
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -83,6 +83,7 @@ import io.getstream.result.Error
 import io.getstream.result.Result
 import io.getstream.result.Result.Failure
 import io.getstream.result.Result.Success
+import io.getstream.video.android.core.audio.AudioHandlerThread
 import io.getstream.video.android.core.call.CallBusyHandler
 import io.getstream.video.android.core.errors.VideoErrorCode
 import io.getstream.video.android.core.events.VideoEventListener
@@ -210,6 +211,15 @@ internal class StreamVideoClient internal constructor(
     private val destroyedCalls = LruCache<Int, Call>(maxSize = 100)
     internal val callSoundAndVibrationPlayer = CallSoundAndVibrationPlayer(context)
 
+    /**
+     * Lazily created and shared across all concurrent calls. Keeps AudioSwitch IPC calls
+     * (setCommunicationDevice, requestAudioFocus, etc.) off the main thread.
+     * Released when the SDK client is cleaned up via cleanup().
+     */
+    private val audioHandlerThreadLazy = lazy { AudioHandlerThread() }
+
+    internal fun getOrCreateAudioHandlerThread(): AudioHandlerThread = audioHandlerThreadLazy.value
+
     val socketImpl = coordinatorConnectionModule.socketConnection
 
     fun onCallCleanUp(call: Call) {
@@ -245,6 +255,9 @@ internal class StreamVideoClient internal constructor(
             }
         }
         activeCall?.leave("client-cleanup")
+        if (audioHandlerThreadLazy.isInitialized()) {
+            audioHandlerThreadLazy.value.release()
+        }
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioHandler.kt
@@ -16,16 +16,7 @@
 
 package io.getstream.video.android.core.audio
 
-import android.content.Context
-import android.media.AudioManager
-import android.os.Handler
-import android.os.Looper
-import com.twilio.audioswitch.AudioDevice
-import com.twilio.audioswitch.AudioDeviceChangeListener
-import com.twilio.audioswitch.AudioSwitch
-import io.getstream.log.StreamLog
-import io.getstream.log.taggedLogger
-
+// TODO it should be internal and its function should return Result<>
 public interface AudioHandler {
     /**
      * Called when a room is started.
@@ -36,80 +27,4 @@ public interface AudioHandler {
      * Called when a room is disconnected.
      */
     public fun stop()
-}
-
-/**
- * TODO: this class should be merged into the Microphone Manager
- */
-public class AudioSwitchHandler(
-    private val context: Context,
-    private val preferredDeviceList: List<Class<out AudioDevice>>,
-    private var audioDeviceChangeListener: AudioDeviceChangeListener,
-) : AudioHandler {
-
-    private val logger by taggedLogger(TAG)
-    private var audioSwitch: AudioSwitch? = null
-    private val mainThreadHandler = Handler(Looper.getMainLooper())
-    private var isAudioSwitchInitScheduled = false
-
-    override fun start() {
-        synchronized(this) {
-            if (!isAudioSwitchInitScheduled) {
-                isAudioSwitchInitScheduled = true
-                mainThreadHandler.removeCallbacksAndMessages(null)
-
-                logger.d { "[start] Posting on main" }
-
-                mainThreadHandler.post {
-                    logger.d { "[start] Running on main" }
-
-                    val switch = AudioSwitch(
-                        context = context,
-                        audioFocusChangeListener = onAudioFocusChangeListener,
-                        preferredDeviceList = preferredDeviceList,
-                    )
-                    audioSwitch = switch
-                    switch.start(audioDeviceChangeListener)
-                }
-            }
-        }
-    }
-
-    override fun stop() {
-        logger.d { "[stop] no args" }
-        mainThreadHandler.removeCallbacksAndMessages(null)
-        mainThreadHandler.post {
-            audioSwitch?.stop()
-            audioSwitch = null
-        }
-    }
-
-    public fun selectDevice(audioDevice: AudioDevice?) {
-        logger.i { "[selectDevice] audioDevice: $audioDevice" }
-        audioSwitch?.selectDevice(audioDevice)
-        audioSwitch?.activate()
-    }
-
-    public companion object {
-        private const val TAG = "AudioSwitchHandler"
-        private val onAudioFocusChangeListener by lazy(LazyThreadSafetyMode.NONE) {
-            DefaultOnAudioFocusChangeListener()
-        }
-
-        private class DefaultOnAudioFocusChangeListener : AudioManager.OnAudioFocusChangeListener {
-            override fun onAudioFocusChange(focusChange: Int) {
-                val typeOfChange: String = when (focusChange) {
-                    AudioManager.AUDIOFOCUS_GAIN -> "AUDIOFOCUS_GAIN"
-                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT -> "AUDIOFOCUS_GAIN_TRANSIENT"
-                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE -> "AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE"
-                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK -> "AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK"
-                    AudioManager.AUDIOFOCUS_LOSS -> "AUDIOFOCUS_LOSS"
-                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> "AUDIOFOCUS_LOSS_TRANSIENT"
-                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> "AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK"
-                    else -> "AUDIOFOCUS_INVALID"
-                }
-                StreamLog.i(TAG) { "[onAudioFocusChange] focusChange: $typeOfChange" }
-            }
-        }
-    }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioHandlerThread.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioHandlerThread.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.audio
+
+import android.os.Handler
+import android.os.HandlerThread
+import io.getstream.video.android.core.StreamVideoClient
+
+/**
+ * Wraps a [HandlerThread] and its [Handler] for all AudioSwitch operations.
+ *
+ * Created lazily by [StreamVideoClient] and shared across all concurrent calls so that
+ * IPC-heavy audio-routing calls (setCommunicationDevice, requestAudioFocus, etc.) never
+ * block the main thread. The instance is released when the SDK client is cleaned up.
+ */
+internal class AudioHandlerThread {
+    private val thread = HandlerThread("audio-switch-thread").also { it.start() }
+    val handler: Handler = Handler(thread.looper)
+
+    fun release() {
+        handler.removeCallbacksAndMessages(null)
+        thread.quitSafely()
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioSwitchHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/audio/AudioSwitchHandler.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.audio
+
+import android.content.Context
+import android.media.AudioManager
+import android.os.Handler
+import com.twilio.audioswitch.AudioDevice
+import com.twilio.audioswitch.AudioDeviceChangeListener
+import com.twilio.audioswitch.AudioSwitch
+import io.getstream.log.StreamLog
+import io.getstream.log.taggedLogger
+import io.getstream.video.android.core.StreamVideo
+import io.getstream.video.android.core.StreamVideoClient
+
+/**
+ * TODO: this class should be merged into the Microphone Manager, should be internal class
+ */
+public class AudioSwitchHandler(
+    private val context: Context,
+    private val preferredDeviceList: List<Class<out AudioDevice>>,
+    private var audioDeviceChangeListener: AudioDeviceChangeListener,
+) : AudioHandler {
+
+    private val logger by taggedLogger(TAG)
+    private var audioSwitch: AudioSwitch? = null
+    private var isAudioSwitchInitScheduled = false
+    private var isActivated = false
+
+    // Resolved once on first use. If StreamVideoClient is not available there is no valid
+    // call context — all operations are skipped rather than creating a throwaway thread.
+    private val audioSwitchHandler: Handler? by lazy {
+        (StreamVideo.instanceOrNull() as? StreamVideoClient)
+            ?.getOrCreateAudioHandlerThread()
+            ?.handler
+    }
+
+    override fun start() {
+        val handler = audioSwitchHandler ?: run {
+            logger.w { "[start] StreamVideoClient not available, skipping AudioSwitch setup" }
+            return
+        }
+        synchronized(this) {
+            if (!isAudioSwitchInitScheduled) {
+                isAudioSwitchInitScheduled = true
+                handler.removeCallbacksAndMessages(null)
+
+                logger.d { "[start] Posting on audio-switch-thread" }
+
+                handler.post {
+                    logger.d { "[start] Running on audio-switch-thread" }
+
+                    val switch = AudioSwitch(
+                        context = context,
+                        audioFocusChangeListener = onAudioFocusChangeListener,
+                        preferredDeviceList = preferredDeviceList,
+                    )
+                    audioSwitch = switch
+                    switch.start(audioDeviceChangeListener)
+                }
+            }
+        }
+    }
+
+    override fun stop() {
+        logger.d { "[stop] no args" }
+        val handler = audioSwitchHandler ?: run {
+            logger.w { "[stop] StreamVideoClient not available, skipping" }
+            return
+        }
+        // Remove any pending work and stop AudioSwitch. We do NOT quit the HandlerThread here —
+        // it is owned by StreamVideoClient and shared across all concurrent calls.
+        handler.removeCallbacksAndMessages(null)
+        handler.post {
+            audioSwitch?.stop()
+            audioSwitch = null
+            isActivated = false
+        }
+    }
+
+    public fun selectDevice(audioDevice: AudioDevice?) {
+        logger.i { "[selectDevice] audioDevice: $audioDevice" }
+        val handler = audioSwitchHandler ?: run {
+            logger.w { "[selectDevice] StreamVideoClient not available, skipping" }
+            return
+        }
+        handler.post {
+            audioSwitch?.selectDevice(audioDevice)
+            // activate() is only needed for the STARTED → ACTIVATED transition.
+            // Once activated, selectDevice() triggers it internally via enumerateDevices().
+            if (!isActivated) {
+                audioSwitch?.activate()
+                isActivated = true
+            }
+        }
+    }
+
+    public companion object {
+        private const val TAG = "AudioSwitchHandler"
+        private val onAudioFocusChangeListener by lazy(LazyThreadSafetyMode.NONE) {
+            DefaultOnAudioFocusChangeListener()
+        }
+
+        private class DefaultOnAudioFocusChangeListener : AudioManager.OnAudioFocusChangeListener {
+            override fun onAudioFocusChange(focusChange: Int) {
+                val typeOfChange: String = when (focusChange) {
+                    AudioManager.AUDIOFOCUS_GAIN -> "AUDIOFOCUS_GAIN"
+                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT -> "AUDIOFOCUS_GAIN_TRANSIENT"
+                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE -> "AUDIOFOCUS_GAIN_TRANSIENT_EXCLUSIVE"
+                    AudioManager.AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK -> "AUDIOFOCUS_GAIN_TRANSIENT_MAY_DUCK"
+                    AudioManager.AUDIOFOCUS_LOSS -> "AUDIOFOCUS_LOSS"
+                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT -> "AUDIOFOCUS_LOSS_TRANSIENT"
+                    AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> "AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK"
+                    else -> "AUDIOFOCUS_INVALID"
+                }
+                StreamLog.i(TAG) { "[onAudioFocusChange] focusChange: $typeOfChange" }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Goal

Fix frame drop(s) in main-thread by switching the work of audio switching off the main-thread

We were making 4 IPC calls when toggling the speaker
```
→ SpeakerManager.setSpeakerPhone(true)
  → MicrophoneManager.select(Speakerphone)
    → AudioSwitchHandler.selectDevice(Speakerphone)
        → audioSwitch.selectDevice()           ← triggers enumerateDevices()
            → since state=ACTIVATED: activate() ← IPC #1: clearCommunicationDevice()
                                                  IPC #2: setCommunicationDevice()
        → audioSwitch.activate()  [explicit]   ← IPC #3: clearCommunicationDevice()
                                                  IPC #4: setCommunicationDevice()
```
This was causing 50-60 framedrops

### Implementation

We have changed any internal implementation
1. We switch the audio switch work from main thread to a new thread `audio-switch-thread`
2. Removed the duplicate IPC calls

### 🎨 UI Changes

None


### Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved thread safety for audio device management and state handling.
  * Fixed potential audio handler resource leaks through proper lifecycle cleanup.

* **Refactor**
  * Optimized audio operations to run on a dedicated background thread to prevent main thread blocking and improve app responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->