### PR TITLE
Add speaker toggle option in outgoing and ongoing call screen in demo-app

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -19,20 +19,24 @@ package io.getstream.video.android
 import android.content.Intent
 import android.os.Bundle
 import android.os.PersistableBundle
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.result.onSuccessSuspend
 import io.getstream.video.android.compose.ui.ComposeStreamCallActivity
 import io.getstream.video.android.compose.ui.StreamCallActivityComposeDelegate
-import io.getstream.video.android.compose.ui.components.call.activecall.AudioOnlyCallContent
 import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.MemberState
 import io.getstream.video.android.core.StreamVideo
+import io.getstream.video.android.core.call.state.CallAction
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.ui.call.CallScreen
 import io.getstream.video.android.ui.common.StreamActivityUiDelegate
@@ -117,14 +121,35 @@ class CallActivity : ComposeStreamCallActivity() {
         }
 
         @Composable
-        override fun StreamCallActivity.AudioCallContent(call: Call) {
-            val micEnabled by call.microphone.isEnabled.collectAsStateWithLifecycle()
-
-            AudioOnlyCallContent(
+        override fun StreamCallActivity.OutgoingCallContent(
+            modifier: Modifier,
+            call: Call,
+            isVideoType: Boolean,
+            isShowingHeader: Boolean,
+            headerContent: @Composable (ColumnScope.() -> Unit)?,
+            detailsContent: @Composable (ColumnScope.(List<MemberState>, Dp) -> Unit)?,
+            controlsContent: @Composable (BoxScope.() -> Unit)?,
+            onBackPressed: () -> Unit,
+            onCallAction: (CallAction) -> Unit,
+        ) {
+            DemoOutgoingCallContent(
                 call = call,
-                isMicrophoneEnabled = micEnabled,
-                onCallAction = { onCallAction(call, it) },
-                onBackPressed = { onBackPressed(call) },
+                isVideoType = isVideoType,
+                modifier = modifier,
+                isShowingHeader = isShowingHeader,
+                headerContent = headerContent,
+                detailsContent = detailsContent,
+                onBackPressed = onBackPressed,
+                onCallAction = onCallAction,
+            )
+        }
+
+        @Composable
+        override fun StreamCallActivity.AudioCallContent(call: Call) {
+            DemoAudioCallContent(
+                call,
+                { onCallAction(call, it) },
+                { onBackPressed(call) },
             )
         }
 

--- a/demo-app/src/main/kotlin/io/getstream/video/android/DemoAudioCallContent.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DemoAudioCallContent.kt
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.getstream.video.android.compose.theme.VideoTheme
+import io.getstream.video.android.compose.ui.components.base.styling.StreamFixedSizeButtonStyle
+import io.getstream.video.android.compose.ui.components.call.activecall.AudioOnlyCallContent
+import io.getstream.video.android.compose.ui.components.call.controls.actions.LeaveCallAction
+import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleMicrophoneAction
+import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleSpeakerphoneAction
+import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.call.state.CallAction
+
+@Composable
+fun DemoAudioCallContent(
+    call: Call,
+    onCallAction: (CallAction) -> Unit,
+    onBackPressed: () -> Unit,
+) {
+    val micEnabled by call.microphone.isEnabled.collectAsStateWithLifecycle()
+    val isSpeakerEnabled by call.speaker.isEnabled.collectAsStateWithLifecycle()
+
+    AudioOnlyCallContent(
+        call = call,
+        isMicrophoneEnabled = micEnabled,
+        onCallAction = onCallAction,
+        onBackPressed = onBackPressed,
+        controlsContent = {
+            AudioOnlyCallControls(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = VideoTheme.dimens.genericXxl),
+                isMicrophoneEnabled = micEnabled,
+                isSpeakerEnabled = isSpeakerEnabled,
+                onCallAction = onCallAction,
+            )
+        },
+    )
+}
+
+@Composable
+fun AudioOnlyCallControls(
+    modifier: Modifier,
+    isMicrophoneEnabled: Boolean,
+    isSpeakerEnabled: Boolean,
+    onCallAction: (CallAction) -> Unit,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        ToggleMicrophoneAction(
+            modifier = Modifier.testTag(
+                "Stream_MicrophoneToggle_Enabled_$isMicrophoneEnabled",
+            ),
+            isMicrophoneEnabled = isMicrophoneEnabled,
+            onCallAction = onCallAction,
+            offStyle = VideoTheme.styles.buttonStyles.secondaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+            onStyle = VideoTheme.styles.buttonStyles.tertiaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+        )
+
+        ToggleSpeakerphoneAction(
+            modifier = Modifier.testTag(
+                "Stream_SpeakerToggle_Enabled_$isSpeakerEnabled",
+            ),
+            isSpeakerphoneEnabled = isSpeakerEnabled,
+            offStyle = VideoTheme.styles.buttonStyles.secondaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+            onStyle = VideoTheme.styles.buttonStyles.tertiaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+            onCallAction = onCallAction,
+        )
+
+        LeaveCallAction(
+            modifier = Modifier.testTag("Stream_HangUpButton"),
+            onCallAction = onCallAction,
+            style = VideoTheme.styles.buttonStyles.primaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+        )
+    }
+}
+
+internal fun StreamFixedSizeButtonStyle.fillCircle(fraction: Float): StreamFixedSizeButtonStyle {
+    return this.copyFixed(
+        width * fraction,
+        height * fraction,
+        shape = CircleShape,
+    )
+}

--- a/demo-app/src/main/kotlin/io/getstream/video/android/DemoOutgoingCallContent.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DemoOutgoingCallContent.kt
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.Dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.getstream.video.android.compose.theme.VideoTheme
+import io.getstream.video.android.compose.ui.components.call.controls.actions.CancelCallAction
+import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleCameraAction
+import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleMicrophoneAction
+import io.getstream.video.android.compose.ui.components.call.controls.actions.ToggleSpeakerphoneAction
+import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.MemberState
+import io.getstream.video.android.core.call.state.CallAction
+
+@Composable
+fun DemoOutgoingCallContent(
+    modifier: Modifier,
+    call: Call,
+    isVideoType: Boolean,
+    isShowingHeader: Boolean,
+    headerContent: @Composable (ColumnScope.() -> Unit)?,
+    detailsContent: @Composable (
+        ColumnScope.(List<MemberState>, Dp) -> Unit
+    )?,
+    onBackPressed: () -> Unit,
+    onCallAction: (CallAction) -> Unit,
+) {
+    val micEnabled by call.microphone.isEnabled.collectAsStateWithLifecycle()
+    val isSpeakerEnabled by call.speaker.isEnabled.collectAsStateWithLifecycle()
+    val isCameraEnabled by call.camera.isEnabled.collectAsStateWithLifecycle()
+
+    io.getstream.video.android.compose.ui.components.call.ringing.outgoingcall.OutgoingCallContent(
+        call = call,
+        isVideoType = isVideoType,
+        modifier = modifier,
+        isShowingHeader = isShowingHeader,
+        headerContent = headerContent,
+        detailsContent = detailsContent,
+        controlsContent = {
+            OutgoingCallControls(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = VideoTheme.dimens.genericXxl),
+                isVideoType,
+                isCameraEnabled,
+                micEnabled,
+                isSpeakerEnabled,
+                onCallAction,
+            )
+        },
+        onBackPressed = onBackPressed,
+        onCallAction = onCallAction,
+    )
+}
+
+@Composable
+private fun OutgoingCallControls(
+    modifier: Modifier = Modifier,
+    isVideoCall: Boolean,
+    isCameraEnabled: Boolean,
+    isMicrophoneEnabled: Boolean,
+    isSpeakerEnabled: Boolean,
+    onCallAction: (CallAction) -> Unit,
+) {
+    Row(
+        modifier = modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly,
+    ) {
+        ToggleMicrophoneAction(
+            modifier = Modifier
+                .testTag("Stream_MicrophoneToggle_Enabled_$isMicrophoneEnabled"),
+            isMicrophoneEnabled = isMicrophoneEnabled,
+            onCallAction = onCallAction,
+            offStyle = VideoTheme.styles.buttonStyles.secondaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+            onStyle = VideoTheme.styles.buttonStyles.tertiaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+        )
+
+        ToggleSpeakerphoneAction(
+            modifier = Modifier.testTag(
+                "Stream_SpeakerToggle_Enabled_$isSpeakerEnabled",
+            ),
+            isSpeakerphoneEnabled = isSpeakerEnabled,
+            offStyle = VideoTheme.styles.buttonStyles.secondaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+            onStyle = VideoTheme.styles.buttonStyles.tertiaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+            onCallAction = onCallAction,
+        )
+
+        if (isVideoCall) {
+            ToggleCameraAction(
+                modifier = Modifier
+                    .testTag("Stream_CameraToggle_Enabled_$isCameraEnabled"),
+                offStyle = VideoTheme.styles.buttonStyles.secondaryIconButtonStyle().fillCircle(
+                    1.5f,
+                ),
+                onStyle = VideoTheme.styles.buttonStyles.tertiaryIconButtonStyle().fillCircle(
+                    1.5f,
+                ),
+                isCameraEnabled = isCameraEnabled,
+                onCallAction = onCallAction,
+            )
+        }
+
+        CancelCallAction(
+            modifier = Modifier.testTag("Stream_DeclineCallButton"),
+            onCallAction = onCallAction,
+            style = VideoTheme.styles.buttonStyles.primaryIconButtonStyle().fillCircle(
+                1.5f,
+            ),
+        )
+    }
+}

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -1270,7 +1270,7 @@ public final class io/getstream/video/android/compose/ui/components/call/control
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/controls/actions/ToggleSpeakerphoneActionKt {
-	public static final fun ToggleSpeakerphoneAction-uMBdHk4 (Landroidx/compose/ui/Modifier;ZZLandroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ToggleSpeakerphoneAction-m_EyDiA (Landroidx/compose/ui/Modifier;ZZLandroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Landroidx/compose/ui/graphics/Color;Lio/getstream/video/android/compose/ui/components/base/styling/StreamFixedSizeButtonStyle;Lio/getstream/video/android/compose/ui/components/base/styling/StreamFixedSizeButtonStyle;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
 	public static final fun ToggleSpeakerphoneActionPreview (Landroidx/compose/runtime/Composer;I)V
 }
 

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/controls/actions/ToggleSpeakerphoneAction.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/controls/actions/ToggleSpeakerphoneAction.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.tooling.preview.Preview
 import io.getstream.video.android.compose.theme.VideoTheme
+import io.getstream.video.android.compose.ui.components.base.styling.StreamFixedSizeButtonStyle
 import io.getstream.video.android.core.call.state.CallAction
 import io.getstream.video.android.core.call.state.ToggleSpeakerphone
 
@@ -49,6 +50,8 @@ public fun ToggleSpeakerphoneAction(
     disabledColor: Color? = null,
     enabledIconTint: Color? = null,
     disabledIconTint: Color? = null,
+    onStyle: StreamFixedSizeButtonStyle? = null,
+    offStyle: StreamFixedSizeButtonStyle? = null,
     onCallAction: (ToggleSpeakerphone) -> Unit,
 ): Unit = ToggleAction(
     modifier = modifier,
@@ -59,6 +62,8 @@ public fun ToggleSpeakerphoneAction(
     enabledIconTint = enabledIconTint,
     disabledIconTint = disabledIconTint,
     isActionActive = isSpeakerphoneEnabled,
+    onStyle = onStyle,
+    offStyle = offStyle,
     iconOnOff = Pair(Icons.AutoMirrored.Filled.VolumeUp, Icons.Default.VolumeOff),
 ) {
     onCallAction(ToggleSpeakerphone(isSpeakerphoneEnabled.not()))


### PR DESCRIPTION
### Goal

Add speaker toggle option in outgoing and ongoing call screen in demo-app

### Implementation

1. Add speaker toggle option in outgoing and ongoing call screen in demo-app
2. We need to update `ToggleSpeakerphoneAction` params to accept new params to match style of Mic icon

### 🎨 UI Changes

| Screen | Before | After |
|--------|--------|-------|
| Outgoing | <img src="https://github.com/user-attachments/assets/129a1df1-6cdd-4f32-b989-322b47cab439" width="167" height="401" /> | <img src="https://github.com/user-attachments/assets/3a9de798-9a00-4d54-80da-4256c8649c2e" width="162" height="400" /> |
| Ongoing | <img src="https://github.com/user-attachments/assets/8bea9a8c-6464-467d-9596-632ab45f7560" width="167" height="401" /> | <img src="https://github.com/user-attachments/assets/cdf5c8e9-781f-479f-aebc-b5ce09137ff1" width="167" height="401" /> |

### Testing

1. Open demo-app
2. Click Direct Call
3. Select user to make audio/video call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced audio call UI with improved microphone and speaker controls.
  * Added new outgoing call screen with customizable header, details, and control sections.

* **Refactor**
  * Reorganized call screen UI components for better customization and styling flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->