### PR TITLE
Improve join retries delay interval in video sdk

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -571,7 +571,7 @@ public class Call(
                     retryCount += 1
                 }
             }
-            delay(retryCount - 1 * 1000L)
+            delay((retryCount - 1) * 1000L)
         }
         session.value = null
         val errorMessage = "Join failed after 3 retries"


### PR DESCRIPTION
### Goal

Improve join-retries delay interval
The mathematical operation inside delay was wrong

### Implementation

Corrected the operation inside delay

### 🎨 UI Changes

None

### Testing

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed retry timing calculation for connection attempts. The system will now apply proper exponential backoff when join attempts fail, ensuring appropriate wait times between retry attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->