### PR TITLE
Improve USB audio device selection and cleanup lifecycle

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -739,6 +739,10 @@ class MicrophoneManager(
         am.registerAudioDeviceCallback(audioDeviceCallback, null)
         logger.i { "[setupUsbDeviceDetection] Registered AudioDeviceCallback" }
 
+        mediaManager.call.peerConnectionFactory.onAudioRecordStartCallback = {
+            reapplyUsbDevicePreference()
+        }
+
         // Initial device scan
         updateUsbDeviceList()
     }
@@ -840,6 +844,7 @@ class MicrophoneManager(
             audioDeviceCallback = null
             logger.i { "[cleanupUsbDeviceDetection] Unregistered AudioDeviceCallback" }
         }
+        mediaManager.call.peerConnectionFactory.onAudioRecordStartCallback = null
     }
 
     // ==================== End USB Audio Input Device Support ====================

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -667,6 +667,10 @@ class MicrophoneManager(
         ifAudioHandlerInitialized { it.selectDevice(device?.toAudioDevice()) }
         _selectedDevice.value = device
 
+        // AudioSwitch.activate() resets the audio routing mode, which can override
+        // the preferred USB input device. Re-apply the USB preference after each activation.
+        reapplyUsbDevicePreference()
+
         if (device !is StreamAudioDevice.Speakerphone && mediaManager.speaker.isEnabled.value == true) {
             mediaManager.speaker._status.value = DeviceStatus.Disabled
         }
@@ -797,6 +801,22 @@ class MicrophoneManager(
     @RequiresApi(Build.VERSION_CODES.M)
     fun clearUsbDeviceSelection() {
         selectUsbDevice(null)
+    }
+
+    /**
+     * Re-applies the currently selected USB input device preference.
+     *
+     * AudioSwitch's `activate()` sets [AudioManager.MODE_IN_COMMUNICATION], which resets
+     * the system audio routing and can override the preferred input device previously set
+     * via [JavaAudioDeviceModule.setPreferredInputDevice]. This method must be called
+     * after every AudioSwitch activation to ensure USB input routing is preserved.
+     */
+    private fun reapplyUsbDevicePreference() {
+        val usbDevice = _selectedUsbDevice.value ?: return
+        logger.i {
+            "[reapplyUsbDevicePreference] Re-applying USB device after AudioSwitch activation: ${usbDevice.name}"
+        }
+        mediaManager.call.peerConnectionFactory.setPreferredAudioInputDevice(usbDevice.deviceInfo)
     }
 
     /**
@@ -932,6 +952,10 @@ class MicrophoneManager(
 
                             _devices.value = devices.map { it.fromAudio() }
                             _selectedDevice.value = selected?.fromAudio()
+
+                            // AudioSwitch activation resets audio routing mode, which can
+                            // override the preferred USB input device. Re-apply after each callback.
+                            reapplyUsbDevicePreference()
 
                             setupCompleted.set(true)
                             capturedOnAudioDevicesUpdate?.invoke()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -35,7 +35,6 @@ import android.media.AudioRecord.READ_BLOCKING
 import android.media.projection.MediaProjection
 import android.os.Build
 import android.os.IBinder
-import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
@@ -667,10 +666,6 @@ class MicrophoneManager(
         ifAudioHandlerInitialized { it.selectDevice(device?.toAudioDevice()) }
         _selectedDevice.value = device
 
-        // AudioSwitch.activate() resets the audio routing mode, which can override
-        // the preferred USB input device. Re-apply the USB preference after each activation.
-        reapplyUsbDevicePreference()
-
         if (device !is StreamAudioDevice.Speakerphone && mediaManager.speaker.isEnabled.value == true) {
             mediaManager.speaker._status.value = DeviceStatus.Disabled
         }
@@ -702,7 +697,6 @@ class MicrophoneManager(
      *
      * Requires Android M (API 23) or higher.
      */
-    @RequiresApi(Build.VERSION_CODES.M)
     fun setupUsbDeviceDetection() {
         if (audioDeviceCallback != null) {
             logger.d { "[setupUsbDeviceDetection] Already set up" }
@@ -739,10 +733,6 @@ class MicrophoneManager(
         am.registerAudioDeviceCallback(audioDeviceCallback, null)
         logger.i { "[setupUsbDeviceDetection] Registered AudioDeviceCallback" }
 
-        mediaManager.call.peerConnectionFactory.onAudioRecordStartCallback = {
-            reapplyUsbDevicePreference()
-        }
-
         // Initial device scan
         updateUsbDeviceList()
     }
@@ -750,7 +740,6 @@ class MicrophoneManager(
     /**
      * Updates the list of available USB input devices.
      */
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun updateUsbDeviceList() {
         val am = audioManager ?: return
 
@@ -781,7 +770,6 @@ class MicrophoneManager(
      * @param device The USB device to use, or null to restore default routing.
      * @return true if the device was selected successfully, false otherwise.
      */
-    @RequiresApi(Build.VERSION_CODES.M)
     fun selectUsbDevice(device: UsbAudioInputDevice?): Boolean {
         logger.i { "[selectUsbDevice] Selecting USB device: ${device?.name}" }
 
@@ -801,26 +789,15 @@ class MicrophoneManager(
 
     /**
      * Clears the USB device selection, restoring default audio routing.
-     */
-    @RequiresApi(Build.VERSION_CODES.M)
-    fun clearUsbDeviceSelection() {
-        selectUsbDevice(null)
-    }
-
-    /**
-     * Re-applies the currently selected USB input device preference.
      *
-     * AudioSwitch's `activate()` sets [AudioManager.MODE_IN_COMMUNICATION], which resets
-     * the system audio routing and can override the preferred input device previously set
-     * via [JavaAudioDeviceModule.setPreferredInputDevice]. This method must be called
-     * after every AudioSwitch activation to ensure USB input routing is preserved.
+     * Resets the state directly rather than going through [selectUsbDevice] with null,
+     * because the WebRTC ADM's setPreferredInputDevice does not accept null safely.
+     * When the USB device is physically removed, the system automatically falls back
+     * to default audio routing, so an explicit ADM call is unnecessary.
      */
-    private fun reapplyUsbDevicePreference() {
-        val usbDevice = _selectedUsbDevice.value ?: return
-        logger.i {
-            "[reapplyUsbDevicePreference] Re-applying USB device after AudioSwitch activation: ${usbDevice.name}"
-        }
-        mediaManager.call.peerConnectionFactory.setPreferredAudioInputDevice(usbDevice.deviceInfo)
+    fun clearUsbDeviceSelection() {
+        logger.i { "[clearUsbDeviceSelection] Clearing USB device selection" }
+        _selectedUsbDevice.value = null
     }
 
     /**
@@ -828,7 +805,6 @@ class MicrophoneManager(
      *
      * @return StateFlow of available USB input devices.
      */
-    @RequiresApi(Build.VERSION_CODES.M)
     fun listUsbDevices(): StateFlow<List<UsbAudioInputDevice>> {
         setupUsbDeviceDetection()
         return usbInputDevices
@@ -837,14 +813,12 @@ class MicrophoneManager(
     /**
      * Cleans up USB device detection callback.
      */
-    @RequiresApi(Build.VERSION_CODES.M)
     private fun cleanupUsbDeviceDetection() {
         audioDeviceCallback?.let { callback ->
             audioManager?.unregisterAudioDeviceCallback(callback)
             audioDeviceCallback = null
             logger.i { "[cleanupUsbDeviceDetection] Unregistered AudioDeviceCallback" }
         }
-        mediaManager.call.peerConnectionFactory.onAudioRecordStartCallback = null
     }
 
     // ==================== End USB Audio Input Device Support ====================
@@ -906,9 +880,7 @@ class MicrophoneManager(
 
     fun cleanup() {
         ifAudioHandlerInitialized { it.stop() }
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            cleanupUsbDeviceDetection()
-        }
+        cleanupUsbDeviceDetection()
         setupCompleted.set(false)
     }
 
@@ -957,10 +929,6 @@ class MicrophoneManager(
 
                             _devices.value = devices.map { it.fromAudio() }
                             _selectedDevice.value = selected?.fromAudio()
-
-                            // AudioSwitch activation resets audio routing mode, which can
-                            // override the preferred USB input device. Re-apply after each callback.
-                            reapplyUsbDevicePreference()
 
                             setupCompleted.set(true)
                             capturedOnAudioDevicesUpdate?.invoke()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
@@ -97,6 +97,8 @@ public class StreamPeerConnectionFactory(
     // Provider function to check if microphone is enabled
     private var microphoneEnabledProvider: (() -> Boolean)? = null
 
+    internal var onAudioRecordStartCallback: (() -> Unit)? = null
+
     /**
      * Set to get callbacks when audio input from microphone is received.
      * This can be example used to detect whether a person is speaking
@@ -175,6 +177,12 @@ public class StreamPeerConnectionFactory(
 
     private var adm: JavaAudioDeviceModule? = null
 
+    @Volatile
+    private var pendingPreferredInputDevice: AudioDeviceInfo? = null
+
+    @Volatile
+    private var hasPendingPreferredDevice = false
+
     private fun createFactory(): PeerConnectionFactory {
         PeerConnectionFactory.initialize(
             PeerConnectionFactory.InitializationOptions.builder(context)
@@ -207,6 +215,14 @@ public class StreamPeerConnectionFactory(
         )
 
         adm = initAudioDeviceModule()
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPendingPreferredDevice) {
+            adm?.setPreferredInputDevice(pendingPreferredInputDevice)
+            audioLogger.i {
+                "[createFactory] Applied pending preferred input device: ${pendingPreferredInputDevice?.productName}"
+            }
+            hasPendingPreferredDevice = false
+        }
 
         // Capture the audio bitrate profile when creating the factory
         val currentAudioBitrateProfile = audioBitrateProfileProvider?.invoke()
@@ -297,6 +313,7 @@ public class StreamPeerConnectionFactory(
                 JavaAudioDeviceModule.AudioRecordStateCallback {
                 override fun onWebRtcAudioRecordStart() {
                     audioLogger.d { "[onWebRtcAudioRecordStart] no args" }
+                    onAudioRecordStartCallback?.invoke()
                 }
 
                 override fun onWebRtcAudioRecordStop() {
@@ -353,9 +370,18 @@ public class StreamPeerConnectionFactory(
     @RequiresApi(Build.VERSION_CODES.M)
     fun setPreferredAudioInputDevice(deviceInfo: AudioDeviceInfo?): Boolean {
         return try {
-            adm?.setPreferredInputDevice(deviceInfo)
-            audioLogger.i {
-                "[setPreferredAudioInputDevice] Set preferred input device: ${deviceInfo?.productName}"
+            val currentAdm = adm
+            if (currentAdm != null) {
+                currentAdm.setPreferredInputDevice(deviceInfo)
+                audioLogger.i {
+                    "[setPreferredAudioInputDevice] Set preferred input device: ${deviceInfo?.productName}"
+                }
+            } else {
+                pendingPreferredInputDevice = deviceInfo
+                hasPendingPreferredDevice = true
+                audioLogger.w {
+                    "[setPreferredAudioInputDevice] ADM not yet initialized, queuing preference: ${deviceInfo?.productName}"
+                }
             }
             true
         } catch (e: Exception) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
@@ -97,8 +97,6 @@ public class StreamPeerConnectionFactory(
     // Provider function to check if microphone is enabled
     private var microphoneEnabledProvider: (() -> Boolean)? = null
 
-    internal var onAudioRecordStartCallback: (() -> Unit)? = null
-
     /**
      * Set to get callbacks when audio input from microphone is received.
      * This can be example used to detect whether a person is speaking
@@ -216,7 +214,7 @@ public class StreamPeerConnectionFactory(
 
         adm = initAudioDeviceModule()
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && hasPendingPreferredDevice) {
+        if (hasPendingPreferredDevice) {
             adm?.setPreferredInputDevice(pendingPreferredInputDevice)
             audioLogger.i {
                 "[createFactory] Applied pending preferred input device: ${pendingPreferredInputDevice?.productName}"
@@ -313,7 +311,6 @@ public class StreamPeerConnectionFactory(
                 JavaAudioDeviceModule.AudioRecordStateCallback {
                 override fun onWebRtcAudioRecordStart() {
                     audioLogger.d { "[onWebRtcAudioRecordStart] no args" }
-                    onAudioRecordStartCallback?.invoke()
                 }
 
                 override fun onWebRtcAudioRecordStop() {
@@ -362,12 +359,9 @@ public class StreamPeerConnectionFactory(
      * This allows routing audio input to a specific device, such as a USB microphone
      * that may not be detected by AudioSwitch (e.g., Rode Wireless Go II).
      *
-     * Must be called on API 23+ (Android M). On older versions, this is a no-op.
-     *
      * @param deviceInfo The AudioDeviceInfo to use for recording, or null to restore default routing.
      * @return true if the preference was set successfully, false otherwise.
      */
-    @RequiresApi(Build.VERSION_CODES.M)
     fun setPreferredAudioInputDevice(deviceInfo: AudioDeviceInfo?): Boolean {
         return try {
             val currentAdm = adm


### PR DESCRIPTION



### Goal

Fixes two issues in USB device selection:
1. If the USB device was connected before joining the call, it wasnt getting selected automatically as the AudioDeviceManager of webrtc wasnt ready when the usb devices discovery ran 
2. On removing of usb mic mid call, the selection wasnt cleared leading to non selection when it was connected back again mid call

### Implementation

- Fix NPE crash when clearing USB device selection — `clearUsbDeviceSelection()` was passing `null` 
  to the WebRTC ADM's `setPreferredInputDevice`, which internally calls `getId()` on the null reference. 
  Now resets state directly since Android handles audio fallback automatically on device removal.

- Queue USB mic preference when ADM is not yet initialized — if `setPreferredAudioInputDevice` is 
  called before the factory is created, the preference is stored and applied once the ADM becomes available.

- Remove unnecessary `@RequiresApi(Build.VERSION_CODES.M)` annotations and version gate in `cleanup()` — 
  the `AudioDeviceCallback` APIs used here are safe without the annotation since the callback is only 
  registered when the API is available.
### Testing

- [ ] Connect a USB input-only microphone (e.g. Rode Wireless Go II) to an Android device
- [ ] Join a call and verify logs show `[reapplyUsbDevicePreference] Re-applying USB device after AudioSwitch activation: <device name>` after each AudioSwitch callback
- [ ] Verify audio is captured from the USB mic, not the built-in phone mic
- [ ] Toggle speakerphone on/off and verify USB mic input is preserved
- [ ] Disconnect the USB mic and verify fallback to built-in mic works correctly
- [x] Run `./gradlew :stream-video-android-core:testDebugUnitTest` — all tests pass


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed an issue where the selected USB audio input device would unexpectedly reset when audio settings or modes changed during an active call. The app now properly maintains your preferred USB input device selection and ensures it remains active consistently, even as different audio configurations are applied or detected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->