### PR TITLE
Add `hint_high_scale_livestream_publisher` to the coordinator `JoinCallRequest`

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -3890,9 +3890,10 @@ public final class io/getstream/android/video/generated/models/IngressVideoLayer
 }
 
 public final class io/getstream/android/video/generated/models/JoinCallRequest {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()Ljava/lang/String;
@@ -3901,11 +3902,12 @@ public final class io/getstream/android/video/generated/models/JoinCallRequest {
 	public final fun component7 ()Ljava/lang/Boolean;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Lio/getstream/android/video/generated/models/CallRequest;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;)Lio/getstream/android/video/generated/models/JoinCallRequest;
-	public static synthetic fun copy$default (Lio/getstream/android/video/generated/models/JoinCallRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;ILjava/lang/Object;)Lio/getstream/android/video/generated/models/JoinCallRequest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;Ljava/lang/Boolean;)Lio/getstream/android/video/generated/models/JoinCallRequest;
+	public static synthetic fun copy$default (Lio/getstream/android/video/generated/models/JoinCallRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/android/video/generated/models/CallRequest;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/android/video/generated/models/JoinCallRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCreate ()Ljava/lang/Boolean;
 	public final fun getData ()Lio/getstream/android/video/generated/models/CallRequest;
+	public final fun getHintHighScaleLivestreamPublisher ()Ljava/lang/Boolean;
 	public final fun getLocation ()Ljava/lang/String;
 	public final fun getMembersLimit ()Ljava/lang/Integer;
 	public final fun getMigratingFrom ()Ljava/lang/String;
@@ -8591,8 +8593,8 @@ public final class io/getstream/video/android/core/Call {
 	public final fun isPinnedParticipant (Ljava/lang/String;)Z
 	public final fun isServerPin (Ljava/lang/String;)Z
 	public final fun isVideoEnabled ()Z
-	public final fun join (ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun join$default (Lio/getstream/video/android/core/Call;ZLio/getstream/video/android/core/CreateCallOptions;ZZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun join (ZLio/getstream/video/android/core/CreateCallOptions;ZZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun join$default (Lio/getstream/video/android/core/Call;ZLio/getstream/video/android/core/CreateCallOptions;ZZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun joinAndRing (Ljava/util/List;Lio/getstream/video/android/core/CreateCallOptions;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun joinAndRing$default (Lio/getstream/video/android/core/Call;Ljava/util/List;Lio/getstream/video/android/core/CreateCallOptions;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun kickUser (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/android/video/generated/models/JoinCallRequest.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/android/video/generated/models/JoinCallRequest.kt
@@ -64,5 +64,8 @@ data class JoinCallRequest (
     val video: kotlin.Boolean? = null,
 
     @Json(name = "data")
-    val data: io.getstream.android.video.generated.models.CallRequest? = null
+    val data: io.getstream.android.video.generated.models.CallRequest? = null,
+
+    @Json(name = "hint_high_scale_livestream_publisher")
+    val hintHighScaleLivestreamPublisher: kotlin.Boolean? = null
 )

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -512,6 +512,7 @@ public class Call(
         createOptions: CreateCallOptions? = null,
         ring: Boolean = false,
         notify: Boolean = false,
+        hintHighScaleLivestreamPublisher: Boolean? = null,
     ): Result<RtcSession> {
         logger.d {
             "[join] #ringing; #track; create: $create, ring: $ring, notify: $notify, createOptions: $createOptions"
@@ -545,7 +546,7 @@ public class Call(
 
         atomicLeave = AtomicUnitCall()
         while (retryCount < 3) {
-            result = _join(create, createOptions, ring, notify)
+            result = _join(create, createOptions, ring, notify, hintHighScaleLivestreamPublisher)
             if (result is Success) {
                 // we initialise the camera, mic and other according to local + backend settings
                 // only when the call is joined to make sure we don't switch and override
@@ -614,6 +615,7 @@ public class Call(
         createOptions: CreateCallOptions? = null,
         ring: Boolean = false,
         notify: Boolean = false,
+        hintHighScaleLivestreamPublisher: Boolean? = null,
     ): Result<RtcSession> {
         reconnectAttepmts = 0
         sfuEvents?.cancel()
@@ -641,7 +643,14 @@ public class Call(
             } else {
                 null
             }
-        val result = joinRequest(options, locationResult.value, ring = ring, notify = notify)
+        val result =
+            joinRequest(
+                options,
+                locationResult.value,
+                ring = ring,
+                notify = notify,
+                hintHighScaleLivestreamPublisher = hintHighScaleLivestreamPublisher,
+            )
 
         if (result !is Success) {
             return result as Failure
@@ -1539,6 +1548,7 @@ public class Call(
         migratingFromList: List<String>? = null,
         ring: Boolean = false,
         notify: Boolean = false,
+        hintHighScaleLivestreamPublisher: Boolean? = null,
     ): Result<JoinCallResponse> {
         val migratingFromList = migratingFromList ?: getFailedSfuIdsSnapshot().takeIf { it.isNotEmpty() }
         val result = clientImpl.joinCall(
@@ -1554,6 +1564,7 @@ public class Call(
             location = location,
             migratingFrom = migratingFrom,
             migratingFromList = migratingFromList,
+            hintHighScaleLivestreamPublisher = hintHighScaleLivestreamPublisher,
         )
         result.onSuccess {
             state.updateFromResponse(it)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/MediaManager.kt
@@ -35,6 +35,7 @@ import android.media.AudioRecord.READ_BLOCKING
 import android.media.projection.MediaProjection
 import android.os.Build
 import android.os.IBinder
+import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -805,6 +805,7 @@ internal class StreamVideoClient internal constructor(
         location: String,
         migratingFrom: String? = null,
         migratingFromList: List<String>? = null,
+        hintHighScaleLivestreamPublisher: Boolean? = null,
     ): Result<JoinCallResponse> {
         val joinCallRequest = JoinCallRequest(
             create = create,
@@ -820,6 +821,7 @@ internal class StreamVideoClient internal constructor(
             location = location,
             migratingFrom = migratingFrom,
             migratingFromList = migratingFromList,
+            hintHighScaleLivestreamPublisher = hintHighScaleLivestreamPublisher,
         )
 
         val result = apiCall {


### PR DESCRIPTION
### Goal

Allow callers to hint that the participant is publishing to a large audience when joining a call.

Mirrors [GetStream/stream-video-js#2199](https://github.com/GetStream/stream-video-js/pull/2199).

### Implementation

Added optional `hintHighScaleLivestreamPublisher: Boolean?` parameter threaded through:

`Call.join()` → `Call._join()` → `Call.joinRequest()` → `StreamVideoClient.joinCall()` → `JoinCallRequest`

Field is nullable with `null` default — fully backward compatible.

### Testing

- Debug compilation passes
- Note: release compilation has a pre-existing `RequiresApi` import issue in `MediaManager.kt` (unrelated to this change)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `hintHighScaleLivestreamPublisher` parameter to call joining methods, enabling developers to indicate high-scale livestream publishing scenarios when joining calls. This parameter is now threaded through the entire join flow and forwarded to the API request for enhanced call configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->