### PR TITLE
Set required permissions for the SDK size checks

### DIFF
--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -3,6 +3,11 @@ name: SDK size checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Goal

SDK size checks need write permissions for writing comments, so we're adding the relevant permission block. Up until now, this didn't cause problems because the token we're using has those permissions, but that doesn't work for Dependabot PRs. [They receive a read-only token](https://docs.github.com/en/code-security/reference/supply-chain-security/troubleshoot-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows) unless we declare permissions, which is why the comment step 403s on #1661.

### Implementation

Add the permissions block

### Testing

After merging this PR, we should update dependabot's PR and verify that the SDK size check succeeds