### PR TITLE
Add configurable WebRTC logging level

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
@@ -63,6 +63,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.runBlocking
+import org.webrtc.Logging
 
 public enum class InitializedState {
     NOT_STARTED, RUNNING, FINISHED, FAILED
@@ -235,7 +236,10 @@ object StreamVideoInitHelper {
                         apiKey = authData.apiKey,
                         user = loggedInUser,
                         token = authData.token,
-                        loggingLevel = LoggingLevel(priority = Priority.VERBOSE),
+                        loggingLevel = LoggingLevel(
+                            priority = Priority.VERBOSE,
+                            webRtcLoggingLevel = Logging.Severity.LS_WARNING,
+                        ),
                     )
                 }
             }
@@ -291,7 +295,10 @@ object StreamVideoInitHelper {
                 apiKey = authData.apiKey,
                 user = guestUser,
                 token = "",
-                loggingLevel = LoggingLevel(priority = Priority.VERBOSE),
+                loggingLevel = LoggingLevel(
+                    priority = Priority.VERBOSE,
+                    webRtcLoggingLevel = Logging.Severity.LS_WARNING,
+                ),
             )
 
             StreamVideo.instanceOrNull()?.connect()

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -12391,6 +12391,7 @@ public final class io/getstream/video/android/core/logging/LoggingLevel {
 	public final fun component1 ()Lio/getstream/log/Priority;
 	public final fun component2 ()Lio/getstream/video/android/core/logging/HttpLoggingLevel;
 	public final fun component3 ()Lorg/webrtc/Logging$Severity;
+	public final fun copy (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;)Lio/getstream/video/android/core/logging/LoggingLevel;
 	public final fun copy (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;Lorg/webrtc/Logging$Severity;)Lio/getstream/video/android/core/logging/LoggingLevel;
 	public static synthetic fun copy$default (Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;Lorg/webrtc/Logging$Severity;ILjava/lang/Object;)Lio/getstream/video/android/core/logging/LoggingLevel;
 	public fun equals (Ljava/lang/Object;)Z

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9729,8 +9729,8 @@ public class io/getstream/video/android/core/call/connection/StreamPeerConnectio
 }
 
 public final class io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory {
-	public fun <init> (Landroid/content/Context;ILkotlin/jvm/functions/Function0;Lorg/webrtc/ManagedAudioProcessingFactory;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Landroid/content/Context;ILkotlin/jvm/functions/Function0;Lorg/webrtc/ManagedAudioProcessingFactory;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;ILkotlin/jvm/functions/Function0;Lorg/webrtc/ManagedAudioProcessingFactory;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lorg/webrtc/Logging$Severity;)V
+	public synthetic fun <init> (Landroid/content/Context;ILkotlin/jvm/functions/Function0;Lorg/webrtc/ManagedAudioProcessingFactory;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lorg/webrtc/Logging$Severity;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun clearPreferredAudioInputDevice ()V
 	public final fun getEglBase ()Lorg/webrtc/EglBase;
 	public final fun getSenderCapabilities (Lorg/webrtc/MediaStreamTrack$MediaType;)Lorg/webrtc/RtpCapabilities;
@@ -12386,14 +12386,17 @@ public final class io/getstream/video/android/core/logging/LoggingLevel {
 	public fun <init> ()V
 	public fun <init> (Lio/getstream/log/Priority;)V
 	public fun <init> (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;)V
-	public synthetic fun <init> (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;Lorg/webrtc/Logging$Severity;)V
+	public synthetic fun <init> (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;Lorg/webrtc/Logging$Severity;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/log/Priority;
 	public final fun component2 ()Lio/getstream/video/android/core/logging/HttpLoggingLevel;
-	public final fun copy (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;)Lio/getstream/video/android/core/logging/LoggingLevel;
-	public static synthetic fun copy$default (Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;ILjava/lang/Object;)Lio/getstream/video/android/core/logging/LoggingLevel;
+	public final fun component3 ()Lorg/webrtc/Logging$Severity;
+	public final fun copy (Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;Lorg/webrtc/Logging$Severity;)Lio/getstream/video/android/core/logging/LoggingLevel;
+	public static synthetic fun copy$default (Lio/getstream/video/android/core/logging/LoggingLevel;Lio/getstream/log/Priority;Lio/getstream/video/android/core/logging/HttpLoggingLevel;Lorg/webrtc/Logging$Severity;ILjava/lang/Object;)Lio/getstream/video/android/core/logging/LoggingLevel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHttpLoggingLevel ()Lio/getstream/video/android/core/logging/HttpLoggingLevel;
 	public final fun getPriority ()Lio/getstream/log/Priority;
+	public final fun getWebRtcLoggingLevel ()Lorg/webrtc/Logging$Severity;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -271,6 +271,7 @@ public class Call(
                     audioUsageProvider = { clientImpl.callServiceConfigRegistry.get(type).audioUsage },
                     audioBitrateProfileProvider = { mediaManager.microphone.audioBitrateProfile.value },
                     sharedEglBaseProvider = { eglBase },
+                    webRtcLoggingLevel = clientImpl.loggingLevel.webRtcLoggingLevel,
                 )
             }
             return _peerConnectionFactory!!

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -80,7 +80,7 @@ import java.net.ConnectException
  * @property user The user object. Can be an authenticated user, guest user or anonymous.
  * @property token The token for this user, generated using your API secret on your server.
  * @property tokenProvider Used to make a request to your backend for a new token when the token has expired.
- * @property loggingLevel Represents and wraps the HTTP logging level for our API service.
+ * @property loggingLevel Represents and wraps SDK logging levels for Stream logger, HTTP interceptor and native WebRTC logging.
  * @property notificationConfig The configurations for handling push notification.
  * @property ringNotification Overwrite the default notification logic for incoming calls.
  * @property connectionTimeoutInMs Connection timeout in seconds.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -290,6 +290,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             crashOnMissingPermission = crashOnMissingPermission,
             appName = appName,
             audioProcessing = audioProcessing,
+            loggingLevel = loggingLevel,
             leaveAfterDisconnectSeconds = leaveAfterDisconnectSeconds,
             enableCallUpdatesAfterLeave = callUpdatesAfterLeave,
             enableStatsCollection = enableStatsReporting,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -90,6 +90,7 @@ import io.getstream.video.android.core.events.VideoEventListener
 import io.getstream.video.android.core.filter.Filters
 import io.getstream.video.android.core.filter.toMap
 import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
+import io.getstream.video.android.core.logging.LoggingLevel
 import io.getstream.video.android.core.model.EdgeData
 import io.getstream.video.android.core.model.MuteUsersData
 import io.getstream.video.android.core.model.QueriedCalls
@@ -178,6 +179,7 @@ internal class StreamVideoClient internal constructor(
     internal val crashOnMissingPermission: Boolean = false,
     internal val appName: String? = null,
     internal val audioProcessing: ManagedAudioProcessingFactory? = null,
+    internal val loggingLevel: LoggingLevel = LoggingLevel(),
     internal val leaveAfterDisconnectSeconds: Long = 30,
     internal val appVersion: String? = null,
     internal val enableCallUpdatesAfterLeave: Boolean = false,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
@@ -75,6 +75,7 @@ public class StreamPeerConnectionFactory(
     private var audioProcessing: ManagedAudioProcessingFactory? = null,
     private val audioBitrateProfileProvider: (() -> stream.video.sfu.models.AudioBitrateProfile)? = null,
     private val sharedEglBaseProvider: () -> EglBase = { EglBase.create() },
+    private val webRtcLoggingLevel: Logging.Severity = Logging.Severity.LS_WARNING,
 ) {
     /**
      * The audio bitrate profile that was used when this factory was created.
@@ -208,7 +209,7 @@ public class StreamPeerConnectionFactory(
 
                         else -> {}
                     }
-                }, Logging.Severity.LS_VERBOSE)
+                }, webRtcLoggingLevel)
                 .createInitializationOptions(),
         )
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
@@ -33,4 +33,11 @@ public data class LoggingLevel @JvmOverloads constructor(
     public val priority: Priority = Priority.ERROR,
     public val httpLoggingLevel: HttpLoggingLevel = HttpLoggingLevel.BASIC,
     public val webRtcLoggingLevel: Logging.Severity = Logging.Severity.LS_WARNING,
-)
+) {
+    // Restores the binary-compatible copy(Priority, HttpLoggingLevel) signature that existed
+    // before webRtcLoggingLevel was added.
+    public fun copy(
+        priority: Priority,
+        httpLoggingLevel: HttpLoggingLevel,
+    ): LoggingLevel = LoggingLevel(priority, httpLoggingLevel, this.webRtcLoggingLevel)
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
@@ -20,7 +20,7 @@ import io.getstream.log.Priority
 import org.webrtc.Logging
 
 /**
- * Represents and wraps the HTTP logging level for our API service.
+ * Represents and wraps SDK logging levels for Stream logger, HTTP interceptor and native WebRTC logging.
  *
  * @property priority The priority level of information logged by the Stream Android logger.
  * @property httpLoggingLevel The level of information logged by our HTTP interceptor.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
@@ -32,7 +32,7 @@ import org.webrtc.Logging
 public data class LoggingLevel @JvmOverloads constructor(
     public val priority: Priority = Priority.ERROR,
     public val httpLoggingLevel: HttpLoggingLevel = HttpLoggingLevel.BASIC,
-    public val webRtcLoggingLevel: Logging.Severity = Logging.Severity.LS_WARNING,
+    public val webRtcLoggingLevel: Logging.Severity = Logging.Severity.LS_ERROR,
 ) {
     // Restores the binary-compatible copy(Priority, HttpLoggingLevel) signature that existed
     // before webRtcLoggingLevel was added.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
@@ -32,7 +32,7 @@ import org.webrtc.Logging
 public data class LoggingLevel @JvmOverloads constructor(
     public val priority: Priority = Priority.ERROR,
     public val httpLoggingLevel: HttpLoggingLevel = HttpLoggingLevel.BASIC,
-    public val webRtcLoggingLevel: Logging.Severity = Logging.Severity.LS_ERROR,
+    public val webRtcLoggingLevel: Logging.Severity = Logging.Severity.LS_NONE,
 ) {
     // Restores the binary-compatible copy(Priority, HttpLoggingLevel) signature that existed
     // before webRtcLoggingLevel was added.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/logging/LoggingLevel.kt
@@ -17,14 +17,20 @@
 package io.getstream.video.android.core.logging
 
 import io.getstream.log.Priority
+import org.webrtc.Logging
 
 /**
  * Represents and wraps the HTTP logging level for our API service.
  *
  * @property priority The priority level of information logged by the Stream Android logger.
  * @property httpLoggingLevel The level of information logged by our HTTP interceptor.
+ * @property webRtcLoggingLevel The minimum severity for native WebRTC log messages delivered to
+ *   the injectable logger. Defaults to [Logging.Severity.LS_WARNING] to avoid the heavy string
+ *   allocation caused by codec-negotiation VERBOSE messages, which compounds under reconnect
+ *   storms. Set to [Logging.Severity.LS_VERBOSE] when debugging WebRTC internals.
  */
 public data class LoggingLevel @JvmOverloads constructor(
     public val priority: Priority = Priority.ERROR,
     public val httpLoggingLevel: HttpLoggingLevel = HttpLoggingLevel.BASIC,
+    public val webRtcLoggingLevel: Logging.Severity = Logging.Severity.LS_WARNING,
 )


### PR DESCRIPTION
### Goal

The WebRTC injectable logger was hardcoded to `LS_VERBOSE`, causing the native layer to allocate and forward every log message — including codec-capability negotiation strings — to Kotlin on every cycle. This compounds under reconnect storms and contributes to OOM pressure

This PR exposes `webRtcLoggingLevel` on LoggingLevel, defaulting to `LS_NONE`. The native layer now filters messages before string allocation, so verbose codec/ICE noise never crosses the JNI boundary in production. The threshold remains fully configurable for debugging

### Implementation

Example Usage

**1. Default (production — warnings and errors only, no change needed):**

```kotlin
StreamVideoBuilder(
    apiKey = "...",
    // webRtcLoggingLevel defaults to LS_NONE automatically
).build()
```

**2. Explicit production hardening:**
```kotlin
StreamVideoBuilder(
    loggingLevel = LoggingLevel(
        priority = Priority.ERROR,
        webRtcLoggingLevel = Logging.Severity.LS_NONE,
    ),
).build()
```
**3. Debug / WebRTC diagnostics:**

```kotlin
StreamVideoBuilder(
    context = context,
    apiKey = "...",
    user = user,
    token = token,
    loggingLevel = LoggingLevel(
        priority = Priority.DEBUG,
        webRtcLoggingLevel = Logging.Severity.LS_WARNING,
    ),
).build()
```

### 🎨 UI Changes

None

### Testing
Todo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebRTC logging level is now configurable, allowing fine-grained control over the verbosity of native WebRTC diagnostic logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->