### PR TITLE
Fix frozen self-view by reinitialize video renderer after reconnect

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -868,10 +868,15 @@ public class RtcSession internal constructor(
     }
 
     internal val mediaScope = CoroutineScope(Dispatchers.Default)
+    private var cameraStatusJob: Job? = null
+    private var microphoneStatusJob: Job? = null
+    private var screenShareStatusJob: Job? = null
 
     private fun listenToMediaChanges() {
         logger.d { "[trackPublishing] listenToMediaChanges" }
-        mediaScope.launch {
+
+        cameraStatusJob?.cancel()
+        cameraStatusJob = mediaScope.launch {
             // update the tracks when the camera or microphone status changes
             call.mediaManager.camera.status.collectLatest {
                 val canUserSendVideo = call.state.ownCapabilities.value.contains(
@@ -912,7 +917,8 @@ public class RtcSession internal constructor(
             }
         }
 
-        mediaScope.launch {
+        microphoneStatusJob?.cancel()
+        microphoneStatusJob = mediaScope.launch {
             call.mediaManager.microphone.status.collectLatest {
                 if (it == DeviceStatus.Enabled) {
                     createAndPublishAudioTrack()
@@ -923,7 +929,8 @@ public class RtcSession internal constructor(
             }
         }
 
-        mediaScope.launch {
+        screenShareStatusJob?.cancel()
+        screenShareStatusJob = mediaScope.launch {
             call.mediaManager.screenShare.status.collectLatest {
                 val canUserShareScreen = call.state.ownCapabilities.value.contains(
                     OwnCapability.Screenshare,

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.SignalWifiBad
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -117,70 +118,76 @@ public fun VideoRenderer(
             if (isIncomingVideoEnabled(call, sessionId, videoEnabledOverrides)) {
                 val mediaTrack = video.track
                 val trackType = video.type
+                key(mediaTrack?.streamId) {
+                    var view: VideoTextureViewRenderer? by remember { mutableStateOf(null) }
 
-                var view: VideoTextureViewRenderer? by remember { mutableStateOf(null) }
+                    if (videoRendererConfig.updateVisibility) {
+                        DisposableEffect(call, video) {
+                            // inform the call that we want to render this video track. (this will trigger a subscription to the track)
+                            call.setVisibility(sessionId, trackType, true, viewportId)
 
-                if (videoRendererConfig.updateVisibility) {
-                    DisposableEffect(call, video) {
-                        // inform the call that we want to render this video track. (this will trigger a subscription to the track)
-                        call.setVisibility(sessionId, trackType, true, viewportId)
-
-                        onDispose {
-                            cleanTrack(view, mediaTrack)
-                            // inform the call that we no longer want to render this video track
-                            call.setVisibility(sessionId, trackType, false, viewportId)
+                            onDispose {
+                                cleanTrack(view, mediaTrack)
+                                // inform the call that we no longer want to render this video track
+                                call.setVisibility(sessionId, trackType, false, viewportId)
+                            }
                         }
                     }
-                }
 
-                if (mediaTrack != null) {
-                    StreamLog.d("VideoRenderer") { "Rendering video track: $mediaTrack" }
-                    Box(
-                        modifier = videoRendererConfig.modifiers.containerModifier.invoke(this)
-                            .testTag("Stream_VideoViewWithMediaTrack"),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        StreamLog.d("VideoRenderer") { "Rendering video viewportId: $viewportId" }
-                        AndroidView(
-                            factory = { context ->
-                                StreamVideoTextureViewRenderer(context).apply {
+                    if (mediaTrack != null) {
+                        StreamLog.d("VideoRenderer") { "Rendering video track: $mediaTrack" }
+                        Box(
+                            modifier = videoRendererConfig.modifiers.containerModifier
+                                .invoke(this)
+                                .testTag("Stream_VideoViewWithMediaTrack"),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            StreamLog.d(
+                                "VideoRenderer",
+                            ) { "Rendering video viewportId: $viewportId" }
+                            AndroidView(
+                                factory = { context ->
+                                    StreamVideoTextureViewRenderer(context).apply {
+                                        StreamLog.d(
+                                            "VideoRenderer",
+                                        ) { "Rendering video (init renderer)" }
+                                        call.initRenderer(
+                                            viewportId = viewportId,
+                                            videoRenderer = this,
+                                            sessionId = sessionId,
+                                            trackType = trackType,
+                                            onRendered = onRendered,
+                                        )
+                                        setMirror(videoRendererConfig.mirrorStream)
+                                        setScalingType(
+                                            videoRendererConfig.scalingType.toCommonScalingType(),
+                                        )
+                                        setupVideo(mediaTrack, this)
+
+                                        view = this
+                                    }
+                                },
+                                update = { v ->
                                     StreamLog.d(
                                         "VideoRenderer",
-                                    ) { "Rendering video (init renderer)" }
-                                    call.initRenderer(
-                                        viewportId = viewportId,
-                                        videoRenderer = this,
-                                        sessionId = sessionId,
-                                        trackType = trackType,
-                                        onRendered = onRendered,
-                                    )
-                                    setMirror(videoRendererConfig.mirrorStream)
-                                    setScalingType(
+                                    ) { "Rendering video (update renderer)" }
+                                    v.setMirror(videoRendererConfig.mirrorStream)
+                                    v.setScalingType(
                                         videoRendererConfig.scalingType.toCommonScalingType(),
                                     )
-                                    setupVideo(mediaTrack, this)
-
-                                    view = this
-                                }
-                            },
-                            update = { v ->
-                                StreamLog.d("VideoRenderer") { "Rendering video (update renderer)" }
-                                v.setMirror(videoRendererConfig.mirrorStream)
-                                v.setScalingType(
-                                    videoRendererConfig.scalingType.toCommonScalingType(),
-                                )
-                                setupVideo(mediaTrack, v)
-                            },
-                            modifier = videoRendererConfig
-                                .modifiers
-                                .componentModifier(
-                                    this,
-                                )
-                                .testTag("video_renderer"),
-                        )
+                                    setupVideo(mediaTrack, v)
+                                },
+                                modifier = videoRendererConfig
+                                    .modifiers
+                                    .componentModifier(
+                                        this,
+                                    )
+                                    .testTag("video_renderer"),
+                            )
+                        }
+                    } else {
+                        // Do something when there is no media track
                     }
-                } else {
-                    // Do something when there is no media track
                 }
             }
         } else {
@@ -304,7 +311,9 @@ internal fun DefaultBadNetworkFallbackContent(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
-            modifier = Modifier.padding(12.dp).align(CenterVertically),
+            modifier = Modifier
+                .padding(12.dp)
+                .align(CenterVertically),
             imageVector = Icons.Default.SignalWifiBad,
             contentDescription = null,
             tint = VideoTheme.colors.basePrimary,


### PR DESCRIPTION
### Goal

Fix a bug where the local self-view video frame freezes after a network reconnect (both fast reconnect and rejoin). The remote side continues to see live video, but the local preview is stuck on the last frame. Toggling the camera on/off was the only workaround, because it forced the renderer to be destroyed and recreated.

### Implementation

After reconnect, Compose batches state changes fast enough that the `AndroidView` in `VideoRenderer` never leaves the composition tree — only `update` is called, never `factory`. Since `initRenderer()` (which sets up the GL thread) only runs in `factory`, the renderer is never re-initialized and shows a frozen frame.

- Wrap the renderer block in `key(mediaTrack?.streamId)`. After every reconnect, `listenToMediaChanges()` produces a new `streamId` (UUID), which causes Compose to destroy and recreate the block — running `factory` → `initRenderer()` → fresh renderer.

- Cancel duplicate subscriptions in listenToMediaChanges

### 🎨 UI Changes

None

### Testing

1. Perform fast reconnect via airplane mode
2. Perform rejoin via airplane mode
3. You should not see frozen self-view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed video renderer to properly reinitialize when switching between different media streams, ensuring consistent playback and preventing potential display issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->