### PR TITLE
Correctly update currentStrategy after reconnectDeadlineMillis has reached

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -866,7 +866,7 @@ public class Call(
             logger.d { "[reconnect] Active reconnect loop running — skipping ($reason)" }
             return
         }
-
+        var currentStrategy = strategy
         try {
             // Re-check after acquiring the lock — bail only if the user left.
             // We deliberately allow reconnect from Connected (SFU/network may
@@ -887,7 +887,6 @@ public class Call(
             }
 
             val loopStartTime = System.currentTimeMillis()
-            var currentStrategy = strategy
             // Local iteration counter for this reconnect() invocation only.
             // Controls MAX_RECONNECT_ATTEMPTS cap and FAST→REJOIN escalation.
             // Distinct from the class-level reconnectAttempts which is cumulative.
@@ -903,6 +902,19 @@ public class Call(
                     }
                     delay(RECONNECT_DELAY_MS)
                     continue
+                }
+
+                val currentTimeInMillis = System.currentTimeMillis()
+                if (currentTimeInMillis - loopStartTime >= reconnectDeadlineMillis) {
+                    currentStrategy = when (currentStrategy) {
+                        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,
+                        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_UNSPECIFIED,
+                        -> {
+                            WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_REJOIN
+                        }
+
+                        else -> currentStrategy
+                    }
                 }
 
                 val connectionState = state.connection.value
@@ -1007,6 +1019,9 @@ public class Call(
             // Always release the mutex — even on exceptions or coroutine
             // cancellation — so future reconnect() calls aren't permanently blocked.
             reconnectMutex.unlock()
+            logger.d {
+                "[reconnect] Free reconnectMutex, strategy: $strategy, currentStrategy: $currentStrategy"
+            }
         }
     }
 


### PR DESCRIPTION
### Goal

The `call.reconnect(WebsocketReconnectStrategy, reason)` logic continuously monitors network availability. However, once connectivity is restored, it fails to re-evaluate `reconnectDeadlineMillis`, which can result in selecting an incorrect reconnection strategy (e.g., initial-passed strategy like fastReconnect instead of fastRejoin).

### Implementation

Update the reconnection flow to recompute the effective strategy after network restoration, ensuring `reconnectDeadlineMillis` is respected before proceeding with reconnection in `call.reconnect(...)`

### 🎨 UI Changes

None

### Testing
1. Join a call with two participants
2. Disable internet for < 10 seconds → expect fastReconnect
3. Disable internet for ~15 seconds → expect fastRejoin
4. Verify both participants reconnect successfully and media streams are restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call reconnection handling by adapting reconnection strategy based on elapsed time, resulting in better management of timeout scenarios during network interruptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->