### PR TITLE
Remove unneeded direct Dokka dependency

### DIFF
--- a/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryComposeConventionPlugin.kt
@@ -13,7 +13,6 @@ class AndroidLibraryComposeConventionPlugin : Plugin<Project> {
             pluginManager.apply("io.getstream.android.library")
             pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("binary-compatibility-validator")
-            pluginManager.apply("org.jetbrains.dokka")
             pluginManager.apply("androidx.baselineprofile")
             pluginManager.apply("app.cash.paparazzi")
 

--- a/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidLibraryConventionPlugin.kt
@@ -11,7 +11,6 @@ class AndroidLibraryConventionPlugin : Plugin<Project> {
             pluginManager.apply("io.getstream.android.library")
             pluginManager.apply("org.jetbrains.kotlin.android")
             pluginManager.apply("binary-compatibility-validator")
-            pluginManager.apply("org.jetbrains.dokka")
             pluginManager.apply("androidx.baselineprofile")
 
             extensions.configure<LibraryExtension> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,6 @@ plugins {
   alias(libs.plugins.ksp) apply false
   alias(libs.plugins.wire) apply false
   alias(libs.plugins.google.gms) apply false
-  alias(libs.plugins.dokka)
   alias(libs.plugins.spotless) apply false
   alias(libs.plugins.paparazzi) apply false
   alias(libs.plugins.firebase.crashlytics) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,6 @@ kotlinSerialization = "1.6.3"
 kotlinSerializationConverter = "1.0.0"
 kotlinxCoroutines = "1.9.0"
 cameraCore = "1.4.2"
-kotlinDokka = "1.9.20"
 
 androidxMaterial = "1.12.0"
 androidxAppCompat = "1.7.0"
@@ -248,7 +247,6 @@ stream-android-library = { id = "io.getstream.android.library", version.ref = "s
 stream-android-test = { id = "io.getstream.android.test", version.ref = "streamConventions" }
 stream-java-library = { id = "io.getstream.java.library", version.ref = "streamConventions" }
 stream-java-platform = { id = "io.getstream.java.platform", version.ref = "streamConventions" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "kotlinDokka" }
 google-gms = { id = "com.google.gms.google-services", version.ref = "googleService" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }
 paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }

--- a/stream-video-android-bom/build.gradle.kts
+++ b/stream-video-android-bom/build.gradle.kts
@@ -1,5 +1,4 @@
 plugins {
-    alias(libs.plugins.dokka)
     alias(libs.plugins.stream.java.platform)
 }
 


### PR DESCRIPTION
### Goal

While working on the Dokka v2 bump in our conventions repo, I realized that in here we're still applying Dokka directly. That's not needed, the convention plugins do that already.

### Implementation

Remove Dokka plugin from the version catalog and all plugin applications


### Testing

Dokka should still work, e.g. `./gradlew dokkaHtmlMultimodule`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed Dokka build tool integration from project build configuration files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-android/pull/1680)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->