### PR TITLE
Add a sort by source in the `LivestreamPlayer` default implementation

### DIFF
--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/livestream/LivestreamPlayer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/livestream/LivestreamPlayer.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import stream.video.sfu.models.ParticipantSource
 
 /**
  * Renders a livestream video player UI based on the current state of the provided [call].
@@ -92,7 +93,9 @@ public fun LivestreamPlayer(
                     .map { (participant, _) -> participant }
             }
         }.flatMapLatest { participantWithVideo ->
-            participantWithVideo.firstOrNull()?.video ?: flow { emit(null) }
+            participantWithVideo.minByOrNull {
+                participantSourceRank(it.source)
+            }?.video ?: flow { emit(null) }
         },
     rendererContent: @Composable BoxScope.(Call) -> Unit = defaultRenderer,
     overlayContent: @Composable BoxScope.(Call) -> Unit = defaultLivestreamPlayerOverlay,
@@ -330,4 +333,13 @@ private val defaultRenderer: @Composable BoxScope.(Call) -> Unit = { call ->
 }
 private val defaultLivestreamPlayerOverlay: @Composable BoxScope.(Call) -> Unit = { call ->
     LivestreamPlayerOverlay(call = call)
+}
+
+private fun participantSourceRank(s: ParticipantSource): Int = when (s) {
+    ParticipantSource.PARTICIPANT_SOURCE_RTMP -> 0
+    ParticipantSource.PARTICIPANT_SOURCE_WHIP -> 1
+    ParticipantSource.PARTICIPANT_SOURCE_RTSP -> 2
+    ParticipantSource.PARTICIPANT_SOURCE_SRT -> 3
+    ParticipantSource.PARTICIPANT_SOURCE_WEBRTC_UNSPECIFIED -> 4
+    ParticipantSource.PARTICIPANT_SOURCE_SIP -> 2
 }


### PR DESCRIPTION
### Goal

`LivestreamPlayer` default implementation does not consider the rank of the participant by source. This causes a WebRTC participant to be sometimes chosen instead of an RRMP participant.

### Implementation

Sort by source when choosing participant with video instead of always taking the first one.

### Testing

Run a livestream with 2 publishers one RTMP and other WebRTC. The RTMP one should be shown in the UI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved livestream player video selection to intelligently prioritize the host video based on participant hierarchy, ensuring optimal content delivery and viewing experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-android/pull/1681)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->