### PR TITLE
Add `CallType.AudioRoom` for the `audio_room` server call type

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9648,6 +9648,11 @@ public final class io/getstream/video/android/core/call/CallType$AudioCall : io/
 	public static final field INSTANCE Lio/getstream/video/android/core/call/CallType$AudioCall;
 }
 
+public final class io/getstream/video/android/core/call/CallType$AudioRoom : io/getstream/video/android/core/call/CallType {
+	public static final field INSTANCE Lio/getstream/video/android/core/call/CallType$AudioRoom;
+	public fun getSortPreset ()Lio/getstream/video/android/core/sorting/SortPreset;
+}
+
 public final class io/getstream/video/android/core/call/CallType$Companion {
 	public final fun fromName (Ljava/lang/String;)Lio/getstream/video/android/core/call/CallType;
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/CallType.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/CallType.kt
@@ -30,6 +30,15 @@ sealed class CallType(val name: String) {
     object Livestream : CallType("livestream") {
         override val sortPreset: SortPreset get() = SortPreset.LivestreamOrAudioRoom
     }
+
+    /**
+     * Group audio chat (mirrors React's `audio_room` and iOS's `audio_room` call type).
+     * Distinct from [AudioCall], which is the Android-specific 1:1 voice call type.
+     */
+    object AudioRoom : CallType("audio_room") {
+        override val sortPreset: SortPreset get() = SortPreset.LivestreamOrAudioRoom
+    }
+
     object AudioCall : CallType("audio_call")
     object Default : CallType("default")
     object AnyMarker : CallType("ALL_CALL_TYPES")
@@ -43,7 +52,13 @@ sealed class CallType(val name: String) {
 
     companion object {
         fun fromName(name: String): CallType? {
-            return listOf(Livestream, AudioCall, Default, AnyMarker).find { it.name == name }
+            return listOf(
+                Livestream,
+                AudioRoom,
+                AudioCall,
+                Default,
+                AnyMarker,
+            ).find { it.name == name }
         }
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/sorting/CallTypeSortPresetTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/sorting/CallTypeSortPresetTest.kt
@@ -38,11 +38,24 @@ class CallTypeSortPresetTest {
     }
 
     @Test
+    fun `AudioRoom call type uses SortPreset LivestreamOrAudioRoom`() {
+        // CallType.AudioRoom mirrors the "audio_room" server type used by React and iOS.
+        // It applies the same livestream-style sort (activity + roles).
+        assertThat(CallType.AudioRoom.sortPreset).isEqualTo(SortPreset.LivestreamOrAudioRoom)
+    }
+
+    @Test
     fun `AudioCall call type falls back to SortPreset Default (1to1 audio is not livestream-like)`() {
-        // CallType.AudioCall represents a 1:1 audio call, not the React/iOS audio_room
-        // concept. Auto-applying LivestreamOrAudioRoom there would mis-sort the two
-        // participants. Stays on Default until a dedicated AudioRoom call type lands.
+        // CallType.AudioCall represents a 1:1 audio call, distinct from AudioRoom (group
+        // audio). Auto-applying LivestreamOrAudioRoom there would mis-sort the two
+        // participants. AudioCall stays on Default.
         assertThat(CallType.AudioCall.sortPreset).isEqualTo(SortPreset.Default)
+    }
+
+    @Test
+    fun `fromName audio_room resolves to AudioRoom call type with LivestreamOrAudioRoom preset`() {
+        val resolved = CallType.fromName("audio_room")?.sortPreset ?: SortPreset.Default
+        assertThat(resolved).isEqualTo(SortPreset.LivestreamOrAudioRoom)
     }
 
     @Test


### PR DESCRIPTION
### Goal

Adds `CallType.AudioRoom` for the `"audio_room"` server call type used by React and iOS, completing the cross-platform call-type parity left open by #1684.

### Implementation

- `CallType.AudioRoom : CallType("audio_room")` — new singleton.
- Overrides `sortPreset` to `SortPreset.LivestreamOrAudioRoom` so group audio rooms self-sort with role-aware ordering, matching React (`CallType.ts:120-122`) and iOS (`LivestreamPlayer.swift:103,129`).
- `CallType.fromName` lookup list updated to include `AudioRoom`.
- Distinct from `CallType.AudioCall`, which is the Android-specific 1:1 voice call type. `AudioCall` keeps `SortPreset.Default` — role-based sort doesn't make sense for a two-participant call.
- `apiCheck` vs `develop`: additive only.

### Testing

Manually: create an `"audio_room"` call type on the server, join it from the dogfood app, confirm participants sort by activity + role without any UI configuration.

### Depends on
#1684 — provides `SortPreset.LivestreamOrAudioRoom` and the `CallType.sortPreset` plumbing. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the "AudioRoom" call type to the Stream Video Android SDK, enabling developers to implement audio-only room-based calling experiences with automatic sorting and preset configurations integrated into the SDK's call management infrastructure.

* **Tests**
  * Added test coverage for the AudioRoom call type, verifying correct configuration and resolution behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-android/pull/1685?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->