### PR TITLE
Add FailureInjector for in-app SDK failure simulation (1/3)

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/App.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/App.kt
@@ -28,6 +28,7 @@ import io.getstream.video.android.core.moderations.CallModerationConstants
 import io.getstream.video.android.data.model.PolicyViolationUiData
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.tooling.util.StreamBuildFlavorUtil
+import io.getstream.video.android.ui.FailureInjectorImpl
 import io.getstream.video.android.util.StreamVideoInitHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -80,6 +81,12 @@ class App : Application() {
 
         observePolicyViolation()
         observeCallReadyToJoin()
+        injectFault()
+    }
+
+    private fun injectFault() {
+        val faultInjector = FailureInjectorImpl()
+        StreamVideo.instanceOrNull()?.state?.failureInjector = faultInjector
     }
 
     private fun observeCallReadyToJoin() {

--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -67,6 +67,7 @@ class CallActivity : ComposeStreamCallActivity() {
     override val uiDelegate: StreamActivityUiDelegate<StreamCallActivity> = StreamDemoUiDelegate()
     var observeCallReadyToJoinJob: Job? = null
     var observeRingingJob: Job? = null
+    var isNavigatingBackToMainScreen = false
     private val previousRingingStates = ConcurrentHashMap.newKeySet<RingingState>()
     override val callJoinInterceptor = DemoCallJoinInterceptor(previousRingingStates)
 
@@ -194,6 +195,7 @@ class CallActivity : ComposeStreamCallActivity() {
 
         private fun StreamCallActivity.goBackToMainScreen() {
             if (!isFinishing) {
+                (this as CallActivity).isNavigatingBackToMainScreen = true
                 val intent = Intent(this, MainActivity::class.java).apply {
                     flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
                 }
@@ -208,5 +210,13 @@ class CallActivity : ComposeStreamCallActivity() {
         observeCallReadyToJoinJob?.cancel()
         observeRingingJob?.cancel()
         previousRingingStates.clear()
+
+        if (!isNavigatingBackToMainScreen) {
+            isNavigatingBackToMainScreen = true
+            val intent = Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            startActivity(intent)
+        }
     }
 }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorImpl.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorImpl.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.ui
+
+import io.getstream.result.Error
+import io.getstream.video.android.core.failureinjector.FailureInjector
+import io.getstream.video.android.core.failureinjector.FailureKey
+import retrofit2.HttpException
+import retrofit2.Response
+
+internal class FailureInjectorImpl : FailureInjector {
+    private val enabledFaults = mutableMapOf<FailureKey, Boolean>()
+
+    override fun enable(key: FailureKey) {
+        enabledFaults[key] = true
+    }
+
+    override fun disable(key: FailureKey) {
+        enabledFaults[key] = false
+    }
+
+    override fun setEnabled(key: FailureKey, enabled: Boolean) {
+        enabledFaults[key] = enabled
+    }
+
+    override fun isEnabled(key: FailureKey): Boolean {
+        return enabledFaults[key] == true
+    }
+
+    override fun clear() {
+        enabledFaults.clear()
+    }
+
+    override fun throwDebugFault(key: FailureKey) {
+        if (enabledFaults[key] == true) {
+            throw when (key) {
+                FailureKey.FAIL_LOCATION -> HttpException(
+                    Response.error<String>(
+                        100,
+                        okhttp3.ResponseBody.create(null, ""),
+                    ),
+                )
+                else -> RuntimeException("Failure injected: $key")
+            }
+        }
+    }
+
+    override fun sendFailResult(key: FailureKey): io.getstream.result.Result.Failure {
+        return io.getstream.result.Result.Failure(
+            Error.GenericError("Failure injected: $key"),
+        )
+    }
+}

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorImpl.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorImpl.kt
@@ -50,7 +50,7 @@ internal class FailureInjectorImpl : FailureInjector {
             throw when (key) {
                 FailureKey.FAIL_LOCATION -> HttpException(
                     Response.error<String>(
-                        100,
+                        499,
                         okhttp3.ResponseBody.create(null, ""),
                     ),
                 )

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorUi.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorUi.kt
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
+import androidx.compose.material.Checkbox
+import androidx.compose.material.CheckboxDefaults
+import androidx.compose.material.Icon
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.getstream.result.Error
+import io.getstream.video.android.compose.theme.VideoTheme
+import io.getstream.video.android.core.failureinjector.FailureInjector
+import io.getstream.video.android.core.failureinjector.FailureKey
+import io.getstream.video.android.core.internal.InternalStreamVideoApi
+
+@OptIn(InternalStreamVideoApi::class)
+@Composable
+fun FailureInjectorUi(
+    modifier: Modifier = Modifier,
+    failureInjector: FailureInjector,
+    onClose: () -> Unit,
+) {
+    val checkedState = remember {
+        mutableStateMapOf<FailureKey, Boolean>().apply {
+            FailureKey.entries.forEach { key -> put(key, failureInjector.isEnabled(key)) }
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(VideoTheme.colors.baseSheetPrimary),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(VideoTheme.colors.baseSheetSecondary)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Failure Injection",
+                style = VideoTheme.typography.subtitleM,
+                color = VideoTheme.colors.basePrimary,
+            )
+
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = "Clear all",
+                    modifier = Modifier.clickable {
+                        failureInjector.clear()
+                        FailureKey.entries.forEach { key -> checkedState[key] = false }
+                    },
+                    style = VideoTheme.typography.bodyS,
+                    color = VideoTheme.colors.brandPrimary,
+                )
+
+                Box(
+                    modifier = Modifier
+                        .background(
+                            color = VideoTheme.colors.baseSheetTertiary,
+                            shape = RoundedCornerShape(999.dp),
+                        )
+                        .clickable(onClick = onClose)
+                        .padding(8.dp),
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Close,
+                        contentDescription = "Close",
+                        tint = VideoTheme.colors.basePrimary,
+                    )
+                }
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            items(FailureKey.entries) { key ->
+                val checked = checkedState[key] ?: false
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            val next = !checked
+                            checkedState[key] = next
+                            failureInjector.setEnabled(key, next)
+                        }
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    Checkbox(
+                        checked = checked,
+                        onCheckedChange = { next ->
+                            checkedState[key] = next
+                            failureInjector.setEnabled(key, next)
+                        },
+                        colors = CheckboxDefaults.colors(
+                            checkedColor = VideoTheme.colors.brandPrimary,
+                            uncheckedColor = VideoTheme.colors.baseSecondary,
+                            checkmarkColor = VideoTheme.colors.baseSheetPrimary,
+                        ),
+                    )
+                    Text(
+                        text = key.name,
+                        style = VideoTheme.typography.bodyM,
+                        color = VideoTheme.colors.basePrimary,
+                    )
+                }
+            }
+        }
+
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(VideoTheme.colors.baseSheetSecondary)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        ) {
+            Button(
+                onClick = onClose,
+                modifier = Modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(8.dp),
+                colors = ButtonDefaults.buttonColors(
+                    backgroundColor = VideoTheme.colors.brandPrimary,
+                    contentColor = VideoTheme.colors.baseSheetPrimary,
+                ),
+            ) {
+                Text(
+                    text = "OK",
+                    style = VideoTheme.typography.labelL,
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun FaultInjectorUiDemo() {
+    VideoTheme {
+        FailureInjectorUi(
+            Modifier,
+            object : FailureInjector {
+                override fun enable(key: FailureKey) {}
+
+                override fun disable(key: FailureKey) {}
+
+                override fun setEnabled(
+                    key: FailureKey,
+                    enabled: Boolean,
+                ) {}
+
+                override fun isEnabled(key: FailureKey): Boolean = false
+
+                override fun clear() {}
+
+                override fun throwDebugFault(key: FailureKey) {}
+                override fun sendFailResult(
+                    key: FailureKey,
+                ): io.getstream.result.Result.Failure {
+                    return io.getstream.result.Result.Failure(
+                        Error.GenericError("Failure injected: $key"),
+                    )
+                }
+            },
+        ) {}
+    }
+}

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorUi.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/FailureInjectorUi.kt
@@ -41,9 +41,11 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.result.Error
+import io.getstream.video.android.R
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.core.failureinjector.FailureInjector
 import io.getstream.video.android.core.failureinjector.FailureKey
@@ -76,7 +78,7 @@ fun FailureInjectorUi(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(
-                text = "Failure Injection",
+                text = stringResource(id = R.string.failure_injection),
                 style = VideoTheme.typography.subtitleM,
                 color = VideoTheme.colors.basePrimary,
             )
@@ -86,7 +88,7 @@ fun FailureInjectorUi(
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = "Clear all",
+                    text = stringResource(id = R.string.clear_all),
                     modifier = Modifier.clickable {
                         failureInjector.clear()
                         FailureKey.entries.forEach { key -> checkedState[key] = false }
@@ -106,7 +108,7 @@ fun FailureInjectorUi(
                 ) {
                     Icon(
                         imageVector = Icons.Default.Close,
-                        contentDescription = "Close",
+                        contentDescription = stringResource(id = R.string.close),
                         tint = VideoTheme.colors.basePrimary,
                     )
                 }
@@ -171,7 +173,7 @@ fun FailureInjectorUi(
                 ),
             ) {
                 Text(
-                    text = "OK",
+                    text = stringResource(id = R.string.ok),
                     style = VideoTheme.typography.labelL,
                 )
             }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
@@ -50,6 +50,7 @@ import androidx.compose.material.icons.filled.Call
 import androidx.compose.material.icons.filled.QrCodeScanner
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.VideoCall
+import androidx.compose.material.icons.filled.Warning
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -98,11 +99,13 @@ import io.getstream.video.android.compose.ui.components.base.StreamButton
 import io.getstream.video.android.compose.ui.components.base.StreamDialogPositiveNegative
 import io.getstream.video.android.compose.ui.components.base.StreamIconToggleButton
 import io.getstream.video.android.compose.ui.components.base.StreamTextField
+import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.defaultCallId
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewUsers
 import io.getstream.video.android.model.User
 import io.getstream.video.android.tooling.util.StreamBuildFlavorUtil
+import io.getstream.video.android.ui.FailureInjectorUi
 import io.getstream.video.android.ui.LogFilesScreen
 import io.getstream.video.android.ui.SingleButtonDialog
 import io.getstream.video.android.util.config.AppConfig
@@ -125,6 +128,8 @@ fun CallJoinScreen(
     val isNetworkAvailable by callJoinViewModel.isNetworkAvailable.collectAsStateWithLifecycle()
 
     var renderLogsFileUi by remember { mutableStateOf(false) }
+    var renderFaultInjectorUi by remember { mutableStateOf(false) }
+    var renderNetworkSettingsUi by remember { mutableStateOf(false) }
 
     HandleCallJoinUiState(
         callJoinUiState = uiState,
@@ -150,6 +155,9 @@ fun CallJoinScreen(
             },
             onLogsClick = {
                 renderLogsFileUi = true
+            },
+            onFaultInjectionClick = {
+                renderFaultInjectorUi = true
             },
         )
 
@@ -195,6 +203,18 @@ fun CallJoinScreen(
             renderLogsFileUi = false
         })
     }
+
+    if (renderFaultInjectorUi) {
+        val faultInjector = StreamVideo.instanceOrNull()?.state?.failureInjector
+        faultInjector?.let {
+            FailureInjectorUi(failureInjector = it, onClose = {
+                renderFaultInjectorUi = false
+            })
+        }
+    }
+
+    if (renderNetworkSettingsUi) {
+    }
 }
 
 @Composable
@@ -224,6 +244,7 @@ private fun CallJoinHeader(
     onDirectCallClick: () -> Unit,
     onSignOutClick: () -> Unit,
     onLogsClick: () -> Unit,
+    onFaultInjectionClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -337,6 +358,19 @@ private fun CallJoinHeader(
                                 onClick = {
                                     showMenu = false
                                     onLogsClick()
+                                },
+                            )
+                            Spacer(modifier = Modifier.width(5.dp))
+                            StreamButton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .testTag("Stream_FaultInjectorButton"),
+                                icon = Icons.Filled.Warning,
+                                style = VideoTheme.styles.buttonStyles.tertiaryButtonStyle(),
+                                text = stringResource(id = R.string.failure_injector),
+                                onClick = {
+                                    showMenu = false
+                                    onFaultInjectionClick()
                                 },
                             )
                             Spacer(modifier = Modifier.width(5.dp))
@@ -743,6 +777,6 @@ private fun CallJoinScreenLandscapePreview() {
 private fun CallJoinScreenHeader() {
     StreamPreviewDataUtils.initializeStreamVideo(LocalContext.current)
     VideoTheme {
-        CallJoinHeader(previewUsers[0], false, true, {}, {}, {}, {})
+        CallJoinHeader(previewUsers[0], false, true, {}, {}, {}, {}, {})
     }
 }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinScreen.kt
@@ -212,9 +212,6 @@ fun CallJoinScreen(
             })
         }
     }
-
-    if (renderNetworkSettingsUi) {
-    }
 }
 
 @Composable

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -31,6 +31,10 @@
     <string name="sign_out">Sign out</string>
     <string name="logs">Share Logs</string>
     <string name="failure_injector">Fault Injector</string>
+    <string name="clear_all">Clear all</string>
+    <string name="failure_injection">Failure Injection</string>
+    <string name="close">Close</string>
+    <string name="ok">OK</string>
     <string name="join_description">Start a new call, join a meeting by \nentering the call ID or by scanning \na QR code.</string>
     <string name="join_call">Join Call</string>
     <string name="join_call_by_qr_code">Scan QR meeting code</string>

--- a/demo-app/src/main/res/values/strings.xml
+++ b/demo-app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="sign_in_contact_us">Contact us</string>
     <string name="sign_out">Sign out</string>
     <string name="logs">Share Logs</string>
+    <string name="failure_injector">Fault Injector</string>
     <string name="join_description">Start a new call, join a meeting by \nentering the call ID or by scanning \na QR code.</string>
     <string name="join_call">Join Call</string>
     <string name="join_call_by_qr_code">Scan QR meeting code</string>

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -76,6 +76,7 @@ import io.getstream.video.android.core.closedcaptions.ClosedCaptionsSettings
 import io.getstream.video.android.core.events.GoAwayEvent
 import io.getstream.video.android.core.events.JoinCallResponseEvent
 import io.getstream.video.android.core.events.VideoEventListener
+import io.getstream.video.android.core.failureinjector.FailureKey
 import io.getstream.video.android.core.internal.InternalStreamVideoApi
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.getstream.video.android.core.model.AudioTrack
@@ -1801,6 +1802,11 @@ public class Call(
         notify: Boolean = false,
         hintHighScaleLivestreamPublisher: Boolean? = null,
     ): Result<JoinCallResponse> {
+        with(client.state.failureInjector) {
+            if (isEnabled(FailureKey.FAIL_JOIN_CALL)) {
+                return sendFailResult(FailureKey.FAIL_JOIN_CALL)
+            }
+        }
         val migratingFromList = migratingFromList ?: getFailedSfuIdsSnapshot().takeIf { it.isNotEmpty() }
         val result = clientImpl.joinCall(
             type, id,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
@@ -23,6 +23,8 @@ import io.getstream.android.video.generated.models.ConnectedEvent
 import io.getstream.android.video.generated.models.VideoEvent
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
+import io.getstream.video.android.core.failureinjector.FailureInjector
+import io.getstream.video.android.core.failureinjector.NoOpFailureInjector
 import io.getstream.video.android.core.internal.InternalStreamVideoApi
 import io.getstream.video.android.core.notifications.internal.service.CallService
 import io.getstream.video.android.core.notifications.internal.service.ServiceIntentBuilder
@@ -87,6 +89,9 @@ class ClientState(private val client: StreamVideo) {
 
     public val callConfigRegistry = (client as StreamVideoClient).callServiceConfigRegistry
     private val serviceLauncher = ServiceLauncher(client.context)
+
+    @InternalStreamVideoApi
+    public var failureInjector: FailureInjector = NoOpFailureInjector()
 
     @InternalStreamVideoApi
     public val rejectCallWhenBusy: Boolean = (client as StreamVideoClient).rejectCallWhenBusy

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -87,6 +87,7 @@ import io.getstream.video.android.core.audio.AudioExecutionContext
 import io.getstream.video.android.core.call.CallBusyHandler
 import io.getstream.video.android.core.errors.VideoErrorCode
 import io.getstream.video.android.core.events.VideoEventListener
+import io.getstream.video.android.core.failureinjector.FailureKey
 import io.getstream.video.android.core.filter.Filters
 import io.getstream.video.android.core.filter.toMap
 import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
@@ -440,6 +441,9 @@ internal class StreamVideoClient internal constructor(
     var location: String? = null
 
     internal suspend fun getCachedLocation(): Result<String> {
+        if (state.failureInjector.isEnabled(FailureKey.FAIL_LOCATION)) {
+            return state.failureInjector.sendFailResult(FailureKey.FAIL_LOCATION)
+        }
         val job = loadLocationAsync()
         job.join()
         location?.let {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/failureinjector/FailureInjector.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/failureinjector/FailureInjector.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.failureinjector
+
+import io.getstream.video.android.core.internal.InternalStreamVideoApi
+
+@InternalStreamVideoApi
+public interface FailureInjector {
+
+    fun enable(key: FailureKey)
+
+    fun disable(key: FailureKey)
+
+    fun setEnabled(key: FailureKey, enabled: Boolean)
+
+    fun isEnabled(key: FailureKey): Boolean
+
+    fun clear()
+
+    fun throwDebugFault(key: FailureKey)
+
+    fun sendFailResult(key: FailureKey): io.getstream.result.Result.Failure
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/failureinjector/FailureKey.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/failureinjector/FailureKey.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.failureinjector
+
+import io.getstream.video.android.core.internal.InternalStreamVideoApi
+
+@InternalStreamVideoApi
+public enum class FailureKey {
+
+    // REST
+    FAIL_JOIN_CALL,
+    FAIL_LOCATION,
+
+    // WebSocket
+    FAIL_WS_CONNECT,
+
+    // Reconnect Strategy
+    FAIL_FAST_RECONNECT,
+    FAIL_FULL_REJOIN,
+    FAIL_MIGRATE,
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/failureinjector/NoOpFailureInjector.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/failureinjector/NoOpFailureInjector.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.failureinjector
+
+import io.getstream.result.Error
+
+internal class NoOpFailureInjector : FailureInjector {
+
+    override fun enable(key: FailureKey) {}
+    override fun disable(key: FailureKey) {}
+    override fun setEnabled(key: FailureKey, enabled: Boolean) {}
+    override fun isEnabled(key: FailureKey): Boolean = false
+    override fun clear() {}
+    override fun throwDebugFault(key: FailureKey) {}
+    override fun sendFailResult(key: FailureKey): io.getstream.result.Result.Failure {
+        return io.getstream.result.Result.Failure(
+            Error.GenericError("Failure injected: $key"),
+        )
+    }
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
@@ -20,6 +20,7 @@ package io.getstream.video.android.core.socket.sfu
 
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
+import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.errors.DisconnectCause
 import io.getstream.video.android.core.errors.VideoErrorCode
@@ -29,6 +30,7 @@ import io.getstream.video.android.core.events.SFUHealthCheckEvent
 import io.getstream.video.android.core.events.SfuDataEvent
 import io.getstream.video.android.core.events.SfuDataRequest
 import io.getstream.video.android.core.events.UnknownEvent
+import io.getstream.video.android.core.failureinjector.FailureKey
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.getstream.video.android.core.lifecycle.NoOpLifecycleHandler
 import io.getstream.video.android.core.lifecycle.StreamLifecycleObserver
@@ -107,6 +109,7 @@ internal open class SfuSocket(
             streamWebSocket?.close("connectUser:cleanup")
             when (networkStateProvider.isConnected()) {
                 true -> {
+                    debugFaultInjectors(connectionConf)
                     streamWebSocket =
                         socketFactory.createSocket<SfuDataEvent>(connectionConf, "#sfu").apply {
                             listeners.forEach { it.onCreated() }
@@ -215,6 +218,31 @@ internal open class SfuSocket(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private fun debugFaultInjectors(connectionConf: ConnectionConf.SfuConnectionConf) {
+        StreamVideo.instanceOrNull()?.state?.failureInjector?.let { faultInjector ->
+            if (faultInjector.isEnabled(FailureKey.FAIL_WS_CONNECT)) {
+                faultInjector.throwDebugFault(FailureKey.FAIL_WS_CONNECT)
+            }
+            val isFastReconnect =
+                connectionConf.joinRequest.reconnect_details?.strategy == WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST
+            if (isFastReconnect && faultInjector.isEnabled(FailureKey.FAIL_FAST_RECONNECT)) {
+                faultInjector.throwDebugFault(FailureKey.FAIL_FAST_RECONNECT)
+            }
+
+            val isFullRejoin =
+                connectionConf.joinRequest.reconnect_details?.strategy == WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_REJOIN
+            if (isFullRejoin && faultInjector.isEnabled(FailureKey.FAIL_FULL_REJOIN)) {
+                faultInjector.throwDebugFault(FailureKey.FAIL_FULL_REJOIN)
+            }
+
+            val isMigrate =
+                connectionConf.joinRequest.reconnect_details?.strategy == WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_MIGRATE
+            if (isMigrate && faultInjector.isEnabled(FailureKey.FAIL_MIGRATE)) {
+                faultInjector.throwDebugFault(FailureKey.FAIL_MIGRATE)
             }
         }
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
@@ -109,7 +109,7 @@ internal open class SfuSocket(
             streamWebSocket?.close("connectUser:cleanup")
             when (networkStateProvider.isConnected()) {
                 true -> {
-                    debugFaultInjectors(connectionConf)
+                    debugFailureInjectors(connectionConf)
                     streamWebSocket =
                         socketFactory.createSocket<SfuDataEvent>(connectionConf, "#sfu").apply {
                             listeners.forEach { it.onCreated() }
@@ -222,7 +222,7 @@ internal open class SfuSocket(
         }
     }
 
-    private fun debugFaultInjectors(connectionConf: ConnectionConf.SfuConnectionConf) {
+    private fun debugFailureInjectors(connectionConf: ConnectionConf.SfuConnectionConf) {
         StreamVideo.instanceOrNull()?.state?.failureInjector?.let { faultInjector ->
             if (faultInjector.isEnabled(FailureKey.FAIL_WS_CONNECT)) {
                 faultInjector.throwDebugFault(FailureKey.FAIL_WS_CONNECT)


### PR DESCRIPTION
### Goal

Introduces a `FailureInjector` subsystem to the Stream Video Android SDK, allowing engineers to simulate specific SDK failure scenarios at runtime directly from the demo app — without network proxies or source code changes.

- [Linear](https://linear.app/stream/issue/AND-1188/add-failureinjector-for-in-app-sdk-failure-simulation-13) 
- [Notion](https://www.notion.so/stream-wiki/Failure-Injector-in-Video-SDK-36c6a5d7f9f680ab8009f826956fee6a?source=copy_link)

### Implementation

| Component | Description |
| --- | --- |
| FailureKey | Enum of all injectable failure points, grouped by subsystem (REST, WebSocket, Reconnect Strategy) |
| FailureInjector | Public interface exposing `enable`, `disable`, `setEnabled`, `isEnabled`, `clear`, `throwDebugFault`, and `sendFailResult` |
| NoOpFailureInjector | Default implementation where all methods are no-ops and `isEnabled` always returns `false`, resulting in zero production overhead |
| ClientState | Exposes `var failureInjector: FailureInjector`, defaulting to `NoOpFailureInjector` |
| Call.kt | Guards `join()` with `FAIL_JOIN_CALL` |
| StreamVideoClient.kt | Guards location fetch with `FAIL_LOCATION` |
| SfuSocket.kt | Guards WebSocket connect and reconnect strategies: `FAIL_WS_CONNECT`, `FAIL_FAST_RECONNECT`, `FAIL_FULL_REJOIN`, `FAIL_MIGRATE` |

### 🎨 UI Changes

| Screen 1 | Detailed Screen |
| --- | --- |
| <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/8c6baafd-71ab-4f9d-90d7-c8f687a2d40a" /> | <img width="300" height="600" alt="image" src="https://github.com/user-attachments/assets/90211948-bde0-40e4-88b3-9277357e2aed" /> |

### Testing
- [ ] Toggle `FAIL_JOIN_CALL` — verify `call.join()` returns an error
- [ ] Toggle `FAIL_LOCATION` — verify location routing fails gracefully
- [ ] Toggle `FAIL_WS_CONNECT` — verify WS connection error is handled
- [ ] Toggle `FAIL_FAST_RECONNECT` / `FAIL_FULL_REJOIN` / `FAIL_MIGRATE` —
      verify reconnect fallback behaviour
- [ ] Clear all — verify all keys reset and normal flow resumes
- [ ] Confirm no behaviour change in a clean build (no flags toggled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a failure injection testing interface accessible through the demo app's settings menu, enabling simulation of various failure scenarios across API operations like joining calls and location retrieval
  * Provides a user-friendly UI for toggling individual failure cases with options to clear all or close the interface

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-android/pull/1698?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->