### PR TITLE
Fix NullPointerException in SortedParticipantsState when constructing a Call on production dispatchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## stream-video-android
 ### 🐞 Fixed
+Fix `NullPointerException` logged from `SortedParticipantsState.init` on every `Call` construction. The internal sort coroutine read `Call.events` before the field was initialized, racing against the rest of `Call`'s constructor on production dispatchers. The error was captured by the call scope's exception handler — calls continued to work — but the call-event-driven resort path was effectively dead.
 
 ### ⬆️ Improved
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -199,6 +199,10 @@ public class Call(
 
     internal val scope = CoroutineScope(clientImpl.scope.coroutineContext + supervisorJob)
 
+    // Must be initialized before `state` — CallState → SortedParticipantsState
+    // launches a coroutine that reads `call.events` (leaking-this race).
+    val events = MutableSharedFlow<VideoEvent>(extraBufferCapacity = 150)
+
     /** The call state contains all state such as the participant list, reactions etc */
     val state = CallState(client, this, user, scope)
 
@@ -1623,8 +1627,6 @@ public class Call(
         val request = UpdateCallMembersRequest(updateMembers = memberRequests)
         return clientImpl.updateMembers(type, id, request)
     }
-
-    val events = MutableSharedFlow<VideoEvent>(extraBufferCapacity = 150)
 
     fun fireEvent(event: VideoEvent) = synchronized(subscriptions) {
         subscriptions.forEach { sub ->

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallFieldDeclarationOrderTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallFieldDeclarationOrderTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+
+/**
+ * Structural regression guard for a leaking-this race in [Call]'s primary constructor.
+ *
+ * `Call` declares `val state = CallState(client, this, user, scope)` which passes
+ * `this` to [CallState]. CallState constructs [io.getstream.video.android.core.sorting.SortedParticipantsState],
+ * whose `init` launches `scope.launch { call.events.collect { ... } }`. Kotlin
+ * runs field initializers in textual order, so if `events` is declared after
+ * `state`, the launched coroutine reads `call.events` while the field is still
+ * null and NPEs into the scope's CoroutineExceptionHandler on production
+ * dispatchers (Default/Main/IO).
+ *
+ * The full test suite uses [kotlinx.coroutines.test.UnconfinedTestDispatcher],
+ * which captures the NPE silently in the scope's exception handler — no
+ * existing test fails. This structural check is the cheapest, least-flaky
+ * guard against a future refactor reordering the declarations and
+ * re-introducing the race.
+ *
+ * Reads [Call] from the module's source directory because the Gradle test
+ * working directory is the module root.
+ */
+class CallFieldDeclarationOrderTest {
+
+    @Test
+    fun `Call_events is declared before Call_state to prevent NPE in sorted-participants init`() {
+        val callSource = File(
+            "src/main/kotlin/io/getstream/video/android/core/Call.kt",
+        ).readText()
+
+        val lines = callSource.lines()
+        val eventsLine = lines.indexOfFirst {
+            it.contains("val events = MutableSharedFlow<VideoEvent>(")
+        }
+        val stateLine = lines.indexOfFirst {
+            it.contains("val state = CallState(")
+        }
+
+        assertThat(eventsLine).isGreaterThan(-1)
+        assertThat(stateLine).isGreaterThan(-1)
+        assertThat(eventsLine).isLessThan(stateLine)
+    }
+}


### PR DESCRIPTION
### Goal

Fixes [AND-1211](https://linear.app/stream/issue/AND-1211/npe-in-sortedparticipantsstateinit-when-constructing-a-call-1240).

Fix the `NullPointerException` logged from `SortedParticipantsState.kt:78` on every `Call` construction. The internal sort coroutine launched in `SortedParticipantsState.init` reads `call.events` while the field is still null, because Kotlin runs property initializers in textual order and `Call.kt` declared `val events = MutableSharedFlow<VideoEvent>(...)` over a thousand lines after `val state = CallState(client, this, user, scope)` — `state` transitively constructs `SortedParticipantsState` and `scope.launch { call.events.collect { ... } }` races the rest of `Call`'s constructor on production dispatchers (Default/Main/IO).

The NPE is captured by the call scope's `CoroutineExceptionHandler`, so the process keeps running — but the call-event-driven resort path is dead and the exception is logged on every join.

### Implementation

Move `val events = MutableSharedFlow<VideoEvent>(extraBufferCapacity = 150)` in `Call.kt` to immediately before `val state = CallState(...)`. Kotlin's textual-order initialization then guarantees `events` is set before `state = CallState(this, ...)` runs, and `scope.launch` provides the happens-before barrier so the launched lambda sees the populated field. A two-line comment above the moved declaration documents the ordering constraint, since it is non-obvious and trivially undoable.

Diff is +4/-2 in `Call.kt`.

### Testing

Added `CallFieldDeclarationOrderTest` in `stream-video-android-core`'s test sources. The bug lives in the textual order of two specific lines in `Call.kt`, so the regression guard is a structural test that reads `Call.kt` from the module's source directory and asserts the `events` line appears before the `state` line. Class KDoc explains the leaking-this race.

Verified locally:

```
./gradlew :stream-video-android-core:spotlessApply
./gradlew :stream-video-android-core:testDebugUnitTest \
  --tests "io.getstream.video.android.core.sorting.*" \
  --tests "io.getstream.video.android.core.CallStateTest" \
  --tests "io.getstream.video.android.core.CallFieldDeclarationOrderTest"
```

Both BUILD SUCCESSFUL. New test passes; existing sorting + CallState tests unchanged.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs