### PR TITLE
Adopt createGuest's server-issued identity for guest users

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
@@ -76,6 +76,10 @@ class ClientState(private val client: StreamVideo) {
     /** Current user for the client. */
     public val user: StateFlow<User?> = _user
 
+    internal fun setUser(user: User?) {
+        _user.value = user
+    }
+
     /** Coordinator connection state */
     public val connection: StateFlow<ConnectionState> = _connection
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -126,9 +126,11 @@ import io.getstream.video.android.core.utils.safeSuspendingCallWithResult
 import io.getstream.video.android.core.utils.toEdge
 import io.getstream.video.android.core.utils.toQueriedCalls
 import io.getstream.video.android.core.utils.toQueriedMembers
+import io.getstream.video.android.core.utils.toUser
 import io.getstream.video.android.model.ApiKey
 import io.getstream.video.android.model.Device
 import io.getstream.video.android.model.User
+import io.getstream.video.android.model.UserType
 import kotlinx.coroutines.CoroutineName
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
@@ -165,7 +167,7 @@ internal const val defaultAudioUsage = AudioAttributes.USAGE_VOICE_COMMUNICATION
 internal class StreamVideoClient internal constructor(
     override val context: Context,
     internal val scope: CoroutineScope = ClientScope(),
-    override val user: User,
+    override var user: User,
     internal val apiKey: ApiKey,
     internal var token: String,
     private val lifecycle: Lifecycle,
@@ -207,7 +209,8 @@ internal class StreamVideoClient internal constructor(
 
     internal var guestUserJob: Deferred<Unit>? = null
 
-    public override val userId = user.id
+    public override val userId: String
+        get() = user.id
 
     private val logger by taggedLogger("Call:StreamVideo")
     private var subscriptions = mutableSetOf<EventSubscription>()
@@ -547,6 +550,10 @@ internal class StreamVideoClient internal constructor(
             response.onSuccess {
                 coordinatorConnectionModule.updateAuthType("jwt")
                 coordinatorConnectionModule.updateToken(it.accessToken)
+                // Adopt the server-issued user identity so the SDK's local user.id
+                // can't drift from the JWT's user_id claim (parity with the JS SDK,
+                // which connects with response.user from createGuest).
+                this@StreamVideoClient.user = it.user.toUser().copy(type = UserType.Guest)
             }
         }
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -554,6 +554,9 @@ internal class StreamVideoClient internal constructor(
                 // can't drift from the JWT's user_id claim (parity with the JS SDK,
                 // which connects with response.user from createGuest).
                 this@StreamVideoClient.user = it.user.toUser().copy(type = UserType.Guest)
+                // Mirror into ClientState so observers of state.user (snapshotted at
+                // construction from the integrator-supplied user) see the adopted id.
+                state.setUser(this@StreamVideoClient.user)
             }
         }
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocketConnection.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocketConnection.kt
@@ -71,8 +71,9 @@ public open class CoordinatorSocketConnection(
     private val apiKey: ApiKey,
     /** The URL to connect to */
     private val url: String,
-    /** The  user to connect. */
-    private val user: User,
+    /** The user to connect. Mutable so a guest user can be replaced with the server-issued
+     *  identity returned by createGuest before the WS auth payload is sent. */
+    private var user: User,
     /** The initial token. */
     @Deprecated(
         "token is not used",
@@ -233,10 +234,12 @@ public open class CoordinatorSocketConnection(
     override suspend fun sendEvent(event: VideoEvent): Boolean = internalSocket.sendEvent(event)
 
     override suspend fun connect(connectData: User) {
+        user = connectData
         internalSocket.connectUser(connectData, connectData.isAnonymous())
     }
 
     override suspend fun reconnect(data: User, force: Boolean) {
+        user = data
         internalSocket.reconnectUser(data, data.isAnonymous(), force)
     }
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
@@ -413,5 +413,10 @@ class StreamVideoClientTest {
         assertEquals("server_normalized_id", client.user.id)
         assertEquals("server_normalized_id", client.userId)
         assertEquals(UserType.Guest, client.user.type)
+        // ClientState.user is snapshotted at construction from the integrator-supplied
+        // user; the adoption path must mirror the new identity into it as well, otherwise
+        // observers of state.user keep seeing the old id.
+        assertEquals("server_normalized_id", client.state.user.value?.id)
+        assertEquals(UserType.Guest, client.state.user.value?.type)
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
@@ -18,9 +18,12 @@ package io.getstream.video.android.core
 
 import android.content.Context
 import androidx.lifecycle.Lifecycle
+import io.getstream.android.video.generated.apis.ProductvideoApi
 import io.getstream.android.video.generated.models.CallAcceptedEvent
 import io.getstream.android.video.generated.models.CallRingEvent
 import io.getstream.android.video.generated.models.CallSessionStartedEvent
+import io.getstream.android.video.generated.models.CreateGuestResponse
+import io.getstream.android.video.generated.models.UserResponse
 import io.getstream.android.video.generated.models.VideoEvent
 import io.getstream.video.android.core.call.CallBusyHandler
 import io.getstream.video.android.core.call.RtcSession
@@ -30,6 +33,9 @@ import io.getstream.video.android.core.notifications.internal.StreamNotification
 import io.getstream.video.android.core.socket.common.token.TokenRepository
 import io.getstream.video.android.core.sounds.RingingCallVibrationConfig
 import io.getstream.video.android.core.sounds.Sounds
+import io.getstream.video.android.model.User
+import io.getstream.video.android.model.UserType
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -45,6 +51,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
+import org.threeten.bp.OffsetDateTime
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -350,5 +357,61 @@ class StreamVideoClientTest {
             result is io.getstream.result.Result.Failure,
             "expected Result.Failure, got $result",
         )
+    }
+
+    // userId used to be captured at construction. After AND-1202 it has to track the live
+    // user reference so the server-issued guest identity (adopted on createGuest success)
+    // is reflected everywhere the SDK reads client.userId.
+    @Test
+    fun `userId tracks the current user reference`() {
+        client.user = User(id = "server_issued_guest", type = UserType.Guest)
+        assertEquals("server_issued_guest", client.userId)
+
+        client.user = User(id = "another_user", type = UserType.Authenticated)
+        assertEquals("another_user", client.userId)
+    }
+
+    // setupGuestUser must adopt response.user from createGuest so the SDK's local user.id
+    // matches the JWT's user_id claim. JS does this via connectUser(response.user, ...).
+    // Without it the socket auth payload and the device-registration JWT could disagree.
+    @Test
+    fun `setupGuestUser adopts the server-issued user identity on success`() = runTest {
+        val context = mockk<Context>(relaxed = true)
+        val lifecycle = mockk<Lifecycle>(relaxed = true)
+        val coordinator = mockk<CoordinatorConnectionModule>(relaxed = true)
+        val api = mockk<ProductvideoApi>(relaxed = true)
+        every { coordinator.api } returns api
+        coEvery { api.createGuest(any()) } returns CreateGuestResponse(
+            accessToken = "guest-jwt",
+            duration = "1ms",
+            user = UserResponse(
+                createdAt = OffsetDateTime.MIN,
+                id = "server_normalized_id",
+                language = "en",
+                role = "guest",
+                updatedAt = OffsetDateTime.MIN,
+                name = "Guest",
+            ),
+        )
+        val client = StreamVideoClient(
+            context = context,
+            user = User(id = "local_input_id", type = UserType.Guest),
+            apiKey = "apikey",
+            token = "",
+            lifecycle = lifecycle,
+            coordinatorConnectionModule = coordinator,
+            tokenRepository = mockk(relaxed = true),
+            streamNotificationManager = mockk(relaxed = true),
+            enableCallNotificationUpdates = false,
+            sounds = mockk(relaxed = true),
+            vibrationConfig = mockk(relaxed = true),
+        )
+
+        client.setupGuestUser(client.user)
+        client.guestUserJob?.await()
+
+        assertEquals("server_normalized_id", client.user.id)
+        assertEquals("server_normalized_id", client.userId)
+        assertEquals(UserType.Guest, client.user.type)
     }
 }


### PR DESCRIPTION
Stacked on #1703. Merge after parent.

### Goal
Refs [AND-1202](https://linear.app/stream/issue/AND-1202/guest-user-type-is-broken) — keep the SDK's in-memory guest user in sync with the server-issued identity returned by `createGuest`, matching the JS SDK's `connectUser(response.user, response.access_token)` semantics.

The SDK previously discarded `response.user` and only kept `response.accessToken`. If the server resolves a guest id to a different value than what the integrator passed in, the WS auth payload (built from `client.user.id`) and the JWT `user_id` claim drift apart.

### Implementation
- `setupGuestUser` now maps `response.user` via `UserResponse.toUser()`, re-applies `UserType.Guest`, and writes the result back to `StreamVideoClient.user`.
- `StreamVideoClient.user` becomes `var`; `userId` becomes `get() = user.id` so every reader (`CallState`, `ParticipantState`, ringing-state checks) picks up the new identity.
- `CoordinatorSocketConnection.user` becomes `var`, set from the `connectData`/`data` argument inside `connect()`/`reconnect()` so `onCreated()`'s WS auth payload reflects the latest user.

### Testing
- New tests in `StreamVideoClientTest`:
  - `userId tracks the current user reference` — the computed property.
  - `setupGuestUser adopts the server-issued user identity on success` — drives `setupGuestUser` with a mocked `api.createGuest` returning a different id; asserts `client.user.id`, `client.userId`, and preserved `UserType.Guest`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed guest user identity synchronization to correctly adopt server-issued credentials, preventing potential identity mismatches after guest account creation.
  * Improved user identity tracking to dynamically reflect the current user state rather than a fixed value captured at initial connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->