### PR TITLE
Clear locally stored push device when deleteDevice API call fails

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManager.kt
@@ -136,13 +136,26 @@ internal class StreamNotificationManager private constructor(
      */
     suspend fun deleteDevice(device: Device): Result<Unit> {
         logger.d { "[deleteDevice] device: $device" }
-        return try {
+        val result = try {
             api.deleteDevice(device.id)
-            removeStoredDevice(device)
             Result.Success(Unit)
         } catch (e: Exception) {
             Result.Failure(Error.ThrowableError("Device couldn't be deleted", e))
         }
+        // Always purge the local cache — even when the server returns 404 or the
+        // network call fails. Keeping a stale token locally makes the next
+        // createDevice for a different user short-circuit on token equality and
+        // skip the API call, silently leaving the new user without a device row.
+        // Don't let local-cleanup failure mask the API call's outcome, and don't
+        // swallow CancellationException — structured concurrency depends on it.
+        try {
+            removeStoredDevice(device)
+        } catch (e: kotlinx.coroutines.CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.e(e) { "[deleteDevice] failed to remove stored device locally" }
+        }
+        return result
     }
 
     private fun PushDevice.toDevice(): Device =

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/internal/StreamNotificationManagerTest.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.notifications.internal
+
+import android.content.Context
+import io.getstream.android.video.generated.apis.ProductvideoApi
+import io.getstream.video.android.core.notifications.NotificationConfig
+import io.getstream.video.android.core.notifications.NotificationHandler
+import io.getstream.video.android.core.notifications.internal.storage.DeviceTokenStorage
+import io.getstream.video.android.model.Device
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class StreamNotificationManagerTest {
+
+    private val device = Device(
+        id = "fcm-token-abc",
+        pushProvider = "firebase",
+        pushProviderName = "firebase",
+    )
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    // Regression: existing happy-path. Local store is cleared when the API call succeeds.
+    @Test
+    fun `deleteDevice clears local store when API succeeds`() = runTest {
+        val api = mockk<ProductvideoApi>(relaxed = true)
+        val storage = mockk<DeviceTokenStorage>(relaxed = true) {
+            every { userDevice } returns flowOf(device)
+        }
+        val manager = makeManager(api = api, storage = storage)
+
+        val result = manager.deleteDevice(device)
+
+        assertTrue(result is io.getstream.result.Result.Success, "expected Success, got $result")
+        coVerify { storage.updateUserDevice(null) }
+    }
+
+    // AND-1214: the bug — server 404 or network failure left the cache populated,
+    // making the next createDevice short-circuit on token equality.
+    @Test
+    fun `deleteDevice clears local store when API throws`() = runTest {
+        val api = mockk<ProductvideoApi>(relaxed = true) {
+            coEvery { deleteDevice(device.id) } throws RuntimeException("boom")
+        }
+        val storage = mockk<DeviceTokenStorage>(relaxed = true) {
+            every { userDevice } returns flowOf(device)
+        }
+        val manager = makeManager(api = api, storage = storage)
+
+        val result = manager.deleteDevice(device)
+
+        assertTrue(result is io.getstream.result.Result.Failure, "expected Failure, got $result")
+        coVerify { storage.updateUserDevice(null) }
+    }
+
+    // The local-cleanup must not mask the API-call outcome.
+    @Test
+    fun `deleteDevice surfaces API failure even when local cleanup throws`() = runTest {
+        val api = mockk<ProductvideoApi>(relaxed = true) {
+            coEvery { deleteDevice(device.id) } throws RuntimeException("boom")
+        }
+        val storage = mockk<DeviceTokenStorage>(relaxed = true) {
+            every { userDevice } returns flowOf(device)
+            coEvery { updateUserDevice(any()) } throws RuntimeException("storage failed")
+        }
+        val manager = makeManager(api = api, storage = storage)
+
+        val result = manager.deleteDevice(device)
+
+        // The API call failed; that's what the caller needs to know — local-cleanup
+        // throwing must not turn this into a different exception or a Success.
+        assertTrue(result is io.getstream.result.Result.Failure, "expected Failure, got $result")
+        // And the cleanup must have been attempted — otherwise this test would still
+        // pass if a future refactor removed the cleanup path entirely.
+        coVerify { storage.updateUserDevice(null) }
+    }
+
+    private fun makeManager(
+        api: ProductvideoApi,
+        storage: DeviceTokenStorage,
+    ): StreamNotificationManager {
+        val notificationHandler = mockk<NotificationHandler>(relaxed = true)
+        val notificationConfig = mockk<NotificationConfig>(relaxed = true) {
+            every { this@mockk.notificationHandler } returns notificationHandler
+        }
+        // Private primary constructor — instantiate via reflection. Pick the 6-arg
+        // overload (Kotlin emits extra synthetic constructors for default values).
+        val ctor = StreamNotificationManager::class.java.declaredConstructors
+            .first { it.parameterCount == 6 }
+        ctor.isAccessible = true
+        return ctor.newInstance(
+            mockk<Context>(relaxed = true),
+            TestScope(),
+            notificationConfig,
+            api,
+            storage,
+            null,
+        ) as StreamNotificationManager
+    }
+}


### PR DESCRIPTION
### Goal
Closes [AND-1214](https://linear.app/stream/issue/AND-1214/stale-push-device-in-local-store-blocks-createdevice-after-user-change) — push notifications silently never arrive for a new user after a previous user logged out with a non-2xx `DELETE /devices`.

`StreamNotificationManager.deleteDevice` only purged the cached `Device` on API success. When `DELETE /devices` 404s or the network fails, the stale token stays in `deviceTokenStorage`. The next `createDevice` for a *different* user short-circuits on token equality (when `autoRegisterPushDevice=true`) and returns `Result.Success` without calling `POST /devices`. The new user ends up with no device row server-side.

Reproduced end-to-end on Pixel 7: clean install → authenticated user A signs in → SDK auto-registers → log out → `DELETE /devices` returns 404 → sign in as guest B → manual `createDevice` returns Success without any `POST /devices` HTTP request → killed-app ring never arrives.

### Implementation
- `StreamNotificationManager.deleteDevice`: split the API call and the local cleanup. API outcome → `Result`. Local cleanup runs unconditionally after, in its own `try`/`catch`.
- Guard the local-cleanup so a storage failure doesn't change the returned `Result`.
- Re-throw `CancellationException` from the local-cleanup catch so structured concurrency isn't broken.

### Testing
- New file `StreamNotificationManagerTest`:
  - `deleteDevice clears local store when API succeeds` — regression.
  - `deleteDevice clears local store when API throws` — the fix.
  - `deleteDevice surfaces API failure even when local cleanup throws` — guard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced device deletion to reliably clear local device information even if the API request encounters errors, ensuring consistent state management.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-video-android/pull/1705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->