### PR TITLE
Auto-connect and register push device for guest users

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -314,8 +314,11 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             coordinatorConnectionModule.updateAuthType("anonymous")
         }
 
-        // Establish a WS connection with the coordinator (we don't support this for anonymous users)
-        if (user.type == UserType.Authenticated) {
+        // Auto-register push and open the coordinator WS for any user with an
+        // identity. Anonymous users don't have one, so neither path applies.
+        // Guest setup runs asynchronously inside StreamVideoClient — both
+        // registerPushDevice() and connectAsync() already await guestUserJob.
+        if (user.type == UserType.Authenticated || user.type == UserType.Guest) {
             scope.launch {
                 try {
                     if (notificationConfig.autoRegisterPushDevice) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -317,7 +317,8 @@ public class StreamVideoBuilder @JvmOverloads constructor(
         // Auto-register push and open the coordinator WS for any user with an
         // identity. Anonymous users don't have one, so neither path applies.
         // Guest setup runs asynchronously inside StreamVideoClient — both
-        // registerPushDevice() and connectAsync() already await guestUserJob.
+        // registerPushDevice() and connectAsync() await guestUserJob before
+        // touching the coordinator, so the auth headers are set by then.
         if (user.type == UserType.Authenticated || user.type == UserType.Guest) {
             scope.launch {
                 try {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -577,6 +577,12 @@ internal class StreamVideoClient internal constructor(
     }
 
     internal suspend fun registerPushDevice() {
+        // createDevice() inside StreamNotificationManager calls api.createDevice() directly
+        // rather than going through apiCall {}, so it doesn't inherit the guestUserJob await
+        // guard. Wait here instead — once guestUserJob completes, the coordinator module's
+        // auth headers are set to JWT, so the later (async) createDevice request lands on
+        // the guest identity instead of !anon. AND-1202.
+        guestUserJob?.takeIf { currentCoroutineContext()[Job] !== it }?.await()
         streamNotificationManager.registerPushDevice()
     }
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
@@ -36,6 +36,7 @@ import io.getstream.video.android.core.sounds.Sounds
 import io.getstream.video.android.model.User
 import io.getstream.video.android.model.UserType
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -357,6 +358,30 @@ class StreamVideoClientTest {
             result is io.getstream.result.Result.Failure,
             "expected Result.Failure, got $result",
         )
+    }
+
+    // Regression: StreamNotificationManager.createDevice() calls api.createDevice() directly
+    // instead of going through apiCall {}, so it doesn't inherit the guestUserJob await guard.
+    // registerPushDevice() must await guestUserJob itself — otherwise the push generator can
+    // kick off and fire createDevice() before the coordinator's auth headers flip from
+    // anonymous to JWT. AND-1202.
+    @Test
+    fun `registerPushDevice waits for guestUserJob to complete before delegating`() = runTest {
+        val notificationManager = client.streamNotificationManager
+        val guestJob = CompletableDeferred<Unit>()
+        client::class.java.getDeclaredField("guestUserJob").apply {
+            isAccessible = true
+            set(client, guestJob)
+        }
+
+        val registerJob = launch { client.registerPushDevice() }
+
+        runCurrent()
+        coVerify(exactly = 0) { notificationManager.registerPushDevice() }
+
+        guestJob.complete(Unit)
+        registerJob.join()
+        coVerify(exactly = 1) { notificationManager.registerPushDevice() }
     }
 
     // userId used to be captured at construction. After AND-1202 it reads through the


### PR DESCRIPTION
Stacked on #1704. Merge after parent.

### Goal
Refs [AND-1202](https://linear.app/stream/issue/AND-1202/guest-user-type-is-broken) — `StreamVideoBuilder` previously ran auto-register-push and auto-connect only for `UserType.Authenticated`. Guest integrators had to write the same boilerplate (manual `registerPushDevice` + `connect()` after `build`) — boilerplate iOS and JS SDKs don't require.

Third behavior gap in the guest-mode series, stacked above #1703 (race fix) and #1704 (response.user adoption). Both are functional prerequisites: `registerPushDevice()` and `connectAsync()` await `guestUserJob`, which only works correctly with #1703.

### Implementation
- `StreamVideoBuilder.build()`: widen the gate at the auto-register/auto-connect block to `UserType.Authenticated || UserType.Guest`. Anonymous still excluded (no identity to register against).
- Both inner branches (`autoRegisterPushDevice` and `connectOnInit`) remain integrator-opt-out — Guest users can still set either flag to `false` to keep manual control of either path.

### Testing
- No dedicated unit test added. The change is a one-line widening of an existing condition; the methods it now invokes for Guest (`StreamVideoClient.connectAsync()`, `StreamNotificationManager.registerPushDevice()`) already have regression coverage in `StreamVideoClientTest` (added by #1703) and the existing notification-manager tests. `StreamVideoBuilderTest` is `@Ignore`d at class level for full builds (run via `isolatedTest`), so a direct gate test would duplicate the existing isolated coverage without unique signal.
- End-to-end functional verification on device pending — smoke test on a Guest build with default config recommended before lifting from Draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Guest users now automatically receive push notifications and WebSocket connection support, matching the capabilities previously available only to authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->