### PR TITLE
Introduce UserRepository as single source of truth for SDK user

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/ClientState.kt
@@ -62,23 +62,19 @@ public sealed interface RingingState {
 class ClientState(private val client: StreamVideo) {
     private val logger by taggedLogger("ClientState")
 
+    // Stream video client is used until full decoupling is archived between `CallState` and `StreamVideoClient (former StreamVideoImpl)
+    private val streamVideoClient: StreamVideoClient = client as StreamVideoClient
+
     // Internal data
-    private val _user: MutableStateFlow<User?> = MutableStateFlow(client.user)
     private val _connection: MutableStateFlow<ConnectionState> =
         MutableStateFlow(ConnectionState.PreConnect)
     internal val _ringingCall: MutableStateFlow<Call?> = MutableStateFlow(null)
     private val _activeCall: MutableStateFlow<Call?> = MutableStateFlow(null)
 
-    // Stream video client is used until full decoupling is archived between `CallState` and `StreamVideoClient (former StreamVideoImpl)
-    private val streamVideoClient: StreamVideoClient = client as StreamVideoClient
-
     // API
-    /** Current user for the client. */
-    public val user: StateFlow<User?> = _user
-
-    internal fun setUser(user: User?) {
-        _user.value = user
-    }
+    /** Current user for the client. Sourced from the UserRepository so observers see
+     *  identity updates (e.g. the server-issued guest user) without a local mirror. */
+    public val user: StateFlow<User?> = streamVideoClient.userRepository.userFlow
 
     /** Coordinator connection state */
     public val connection: StateFlow<ConnectionState> = _connection

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -45,6 +45,7 @@ import io.getstream.video.android.core.sounds.Sounds
 import io.getstream.video.android.core.sounds.defaultResourcesRingingConfig
 import io.getstream.video.android.core.sounds.disableVibrationConfig
 import io.getstream.video.android.core.sounds.toSounds
+import io.getstream.video.android.core.user.StreamUserRepositoryImpl
 import io.getstream.video.android.model.ApiKey
 import io.getstream.video.android.model.User
 import io.getstream.video.android.model.UserToken
@@ -241,6 +242,10 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             "ws://${it.trimEnd('/')}/video/connect"
         } ?: wssUrl ?: "wss://$videoDomain/video/connect"
 
+        // Single source of truth for the SDK user — shared between the client (writer)
+        // and the coordinator socket / ClientState (readers).
+        val userRepository = StreamUserRepositoryImpl(user)
+
         val coordinatorConnectionModule = CoordinatorConnectionModule(
             context = context,
             scope = scope,
@@ -248,7 +253,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             wssUrl = resolvedWssUrl,
             connectionTimeoutInMs = connectionTimeoutInMs,
             loggingLevel = loggingLevel,
-            user = user,
+            userRepository = userRepository,
             apiKey = apiKey,
             tokenProvider = tokenProvider,
             lifecycle = lifecycle,
@@ -276,13 +281,14 @@ public class StreamVideoBuilder @JvmOverloads constructor(
         val client = StreamVideoClient(
             context = context,
             scope = scope,
-            user = user,
+            initialUser = user,
             apiKey = apiKey,
             token = token,
             lifecycle = lifecycle,
             coordinatorConnectionModule = coordinatorConnectionModule,
             tokenProvider = tokenProvider,
             streamNotificationManager = streamNotificationManager,
+            userRepository = userRepository,
             enableCallNotificationUpdates = notificationConfig.enableCallNotificationUpdates,
             callServiceConfigRegistry = callConfigRegistry,
             sounds = sounds,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -314,8 +314,12 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             coordinatorConnectionModule.updateAuthType("anonymous")
         }
 
-        // Establish a WS connection with the coordinator (we don't support this for anonymous users)
-        if (user.type == UserType.Authenticated) {
+        // Auto-register push and open the coordinator WS for any user with an
+        // identity. Anonymous users don't have one, so neither path applies.
+        // Guest setup runs asynchronously inside StreamVideoClient — both
+        // registerPushDevice() and connectAsync() await guestUserJob before
+        // touching the coordinator, so the auth headers are set by then.
+        if (user.type == UserType.Authenticated || user.type == UserType.Guest) {
             scope.launch {
                 try {
                     if (notificationConfig.autoRegisterPushDevice) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -577,6 +577,12 @@ internal class StreamVideoClient internal constructor(
     }
 
     internal suspend fun registerPushDevice() {
+        // createDevice() inside StreamNotificationManager calls api.createDevice() directly
+        // rather than going through apiCall {}, so it doesn't inherit the guestUserJob await
+        // guard. Wait here instead — once guestUserJob completes, the coordinator module's
+        // auth headers are set to JWT, so the later (async) createDevice request lands on
+        // the guest identity instead of !anon. AND-1202.
+        guestUserJob?.takeIf { currentCoroutineContext()[Job] !== it }?.await()
         streamNotificationManager.registerPushDevice()
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -118,6 +118,8 @@ import io.getstream.video.android.core.socket.coordinator.state.VideoSocketState
 import io.getstream.video.android.core.sounds.CallSoundAndVibrationPlayer
 import io.getstream.video.android.core.sounds.RingingCallVibrationConfig
 import io.getstream.video.android.core.sounds.Sounds
+import io.getstream.video.android.core.user.StreamUserRepositoryImpl
+import io.getstream.video.android.core.user.WritableUserRepository
 import io.getstream.video.android.core.utils.LatencyResult
 import io.getstream.video.android.core.utils.getLatencyMeasurementsOKHttp
 import io.getstream.video.android.core.utils.safeCall
@@ -167,7 +169,7 @@ internal const val defaultAudioUsage = AudioAttributes.USAGE_VOICE_COMMUNICATION
 internal class StreamVideoClient internal constructor(
     override val context: Context,
     internal val scope: CoroutineScope = ClientScope(),
-    override var user: User,
+    initialUser: User,
     internal val apiKey: ApiKey,
     internal var token: String,
     private val lifecycle: Lifecycle,
@@ -175,6 +177,7 @@ internal class StreamVideoClient internal constructor(
     internal val tokenRepository: TokenRepository,
     internal val tokenProvider: TokenProvider = RepositoryTokenProvider(tokenRepository),
     internal val streamNotificationManager: StreamNotificationManager,
+    internal val userRepository: WritableUserRepository = StreamUserRepositoryImpl(initialUser),
     internal val enableCallNotificationUpdates: Boolean,
     internal val callServiceConfigRegistry: CallServiceConfigRegistry = CallServiceConfigRegistry(),
     internal val sounds: Sounds,
@@ -195,6 +198,11 @@ internal class StreamVideoClient internal constructor(
 
     private var locationJob: Deferred<Result<String>>? = null
 
+    /** Reads through [userRepository] so callers always see the latest identity
+     *  (e.g. the server-issued guest user adopted by [setupGuestUser]). */
+    public override val user: User
+        get() = userRepository.user
+
     /** the state for the client, includes the current user */
     override val state = ClientState(this)
     internal val callBusyHandler =
@@ -210,7 +218,7 @@ internal class StreamVideoClient internal constructor(
     internal var guestUserJob: Deferred<Unit>? = null
 
     public override val userId: String
-        get() = user.id
+        get() = userRepository.user.id
 
     private val logger by taggedLogger("Call:StreamVideo")
     private var subscriptions = mutableSetOf<EventSubscription>()
@@ -552,11 +560,10 @@ internal class StreamVideoClient internal constructor(
                 coordinatorConnectionModule.updateToken(it.accessToken)
                 // Adopt the server-issued user identity so the SDK's local user.id
                 // can't drift from the JWT's user_id claim (parity with the JS SDK,
-                // which connects with response.user from createGuest).
-                this@StreamVideoClient.user = it.user.toUser().copy(type = UserType.Guest)
-                // Mirror into ClientState so observers of state.user (snapshotted at
-                // construction from the integrator-supplied user) see the adopted id.
-                state.setUser(this@StreamVideoClient.user)
+                // which connects with response.user from createGuest). Writing through
+                // the repository propagates to every reader (socket, ClientState, …) at
+                // once — no further mirrors required.
+                userRepository.setUser(it.user.toUser().copy(type = UserType.Guest))
             }
         }
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/CoordinatorConnectionModule.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/CoordinatorConnectionModule.kt
@@ -30,8 +30,8 @@ import io.getstream.video.android.core.socket.common.token.TokenProvider
 import io.getstream.video.android.core.socket.common.token.TokenRepository
 import io.getstream.video.android.core.socket.coordinator.CoordinatorSocketConnection
 import io.getstream.video.android.core.trace.Tracer
+import io.getstream.video.android.core.user.UserRepository
 import io.getstream.video.android.model.ApiKey
-import io.getstream.video.android.model.User
 import io.getstream.video.android.model.UserToken
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -49,7 +49,7 @@ internal class CoordinatorConnectionModule(
     // Coordinator API
     context: Context,
     tokenProvider: TokenProvider,
-    user: User,
+    userRepository: UserRepository,
     val tokenRepository: TokenRepository,
     override val scope: CoroutineScope,
     // Common API
@@ -98,7 +98,7 @@ internal class CoordinatorConnectionModule(
     override val socketConnection: CoordinatorSocketConnection = CoordinatorSocketConnection(
         apiKey = apiKey,
         url = wssUrl,
-        user = user,
+        userRepository = userRepository,
         token = tokenRepository.getToken(),
         httpClient = http,
         networkStateProvider = networkStateProvider,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocketConnection.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocketConnection.kt
@@ -40,6 +40,8 @@ import io.getstream.video.android.core.socket.common.token.TokenManagerImpl
 import io.getstream.video.android.core.socket.common.token.TokenProvider
 import io.getstream.video.android.core.socket.common.token.TokenRepository
 import io.getstream.video.android.core.socket.coordinator.state.VideoSocketState
+import io.getstream.video.android.core.user.StreamUserRepositoryImpl
+import io.getstream.video.android.core.user.UserRepository
 import io.getstream.video.android.core.utils.isWhitespaceOnly
 import io.getstream.video.android.core.utils.mapState
 import io.getstream.video.android.model.ApiKey
@@ -67,13 +69,15 @@ import okhttp3.OkHttpClient
  *
  * This should be internal
  */
-public open class CoordinatorSocketConnection(
+public open class CoordinatorSocketConnection internal constructor(
     private val apiKey: ApiKey,
     /** The URL to connect to */
     private val url: String,
-    /** The user to connect. Mutable so a guest user can be replaced with the server-issued
-     *  identity returned by createGuest before the WS auth payload is sent. */
-    private var user: User,
+    /** Single source of truth for the current user. The WS auth payload (built in
+     *  [onCreated]) reads through this, so a guest user replaced mid-flight by
+     *  `setupGuestUser` is reflected automatically without any local copy to keep
+     *  in sync. */
+    private val userRepository: UserRepository,
     /** The initial token. */
     @Deprecated(
         "token is not used",
@@ -93,6 +97,41 @@ public open class CoordinatorSocketConnection(
     private val tokenRepository: TokenRepository,
 ) : SocketListener<VideoEvent, ConnectedEvent>(),
     SocketActions<VideoEvent, VideoEvent, StreamWebSocketEvent.Error, VideoSocketState, UserToken, User> {
+
+    /**
+     * Backwards-compatible constructor for callers that still pass a fixed [User].
+     * Internally wraps [user] in a fresh repository — identity updates made elsewhere
+     * (e.g. `setupGuestUser`) will NOT propagate to this socket. Prefer the
+     * [UserRepository]-based primary constructor for that.
+     */
+    @Deprecated(
+        message = "Pass a UserRepository so the WS auth payload picks up identity updates " +
+            "(e.g. an adopted guest user).",
+        level = DeprecationLevel.WARNING,
+    )
+    public constructor(
+        apiKey: ApiKey,
+        url: String,
+        user: User,
+        token: String,
+        httpClient: OkHttpClient,
+        networkStateProvider: NetworkStateProvider,
+        scope: CoroutineScope = UserScope(ClientScope()),
+        lifecycle: Lifecycle,
+        tokenProvider: TokenProvider,
+        tokenRepository: TokenRepository,
+    ) : this(
+        apiKey = apiKey,
+        url = url,
+        userRepository = StreamUserRepositoryImpl(user),
+        token = token,
+        httpClient = httpClient,
+        networkStateProvider = networkStateProvider,
+        scope = scope,
+        lifecycle = lifecycle,
+        tokenProvider = tokenProvider,
+        tokenRepository = tokenRepository,
+    )
 
     // Private state
     private val parser: VideoParser = MoshiVideoParser()
@@ -138,7 +177,8 @@ public open class CoordinatorSocketConnection(
         super.onCreated()
         logger.d { "[onCreated] Socket is created" }
         scope.launch {
-            logger.d { "[onConnected] Video socket created, user: $user" }
+            val currentUser = userRepository.user
+            logger.d { "[onConnected] Video socket created, user: $currentUser" }
             if (tokenManager.getToken().isEmpty()) {
                 logger.e { "[onConnected] Token is empty. Disconnecting." }
                 disconnect()
@@ -146,10 +186,10 @@ public open class CoordinatorSocketConnection(
                 val authRequest = WSAuthMessageRequest(
                     token = tokenManager.getToken().ifEmpty { tokenRepository.getToken() },
                     userDetails = ConnectUserDetailsRequest(
-                        id = user.id,
-                        name = user.name.takeUnless { it.isWhitespaceOnly() },
-                        image = user.image.takeUnless { it.isWhitespaceOnly() },
-                        custom = user.custom,
+                        id = currentUser.id,
+                        name = currentUser.name.takeUnless { it.isWhitespaceOnly() },
+                        image = currentUser.image.takeUnless { it.isWhitespaceOnly() },
+                        custom = currentUser.custom,
                     ),
                 )
 
@@ -234,12 +274,10 @@ public open class CoordinatorSocketConnection(
     override suspend fun sendEvent(event: VideoEvent): Boolean = internalSocket.sendEvent(event)
 
     override suspend fun connect(connectData: User) {
-        user = connectData
         internalSocket.connectUser(connectData, connectData.isAnonymous())
     }
 
     override suspend fun reconnect(data: User, force: Boolean) {
-        user = data
         internalSocket.reconnectUser(data, data.isAnonymous(), force)
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/user/UserRepository.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/user/UserRepository.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.user
+
+import io.getstream.video.android.model.User
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Read-only access to the SDK's current user.
+ *
+ * The repository is the single source of truth for the SDK user: every component
+ * that needs to read the current identity (socket auth payload, call state,
+ * notification routing, etc.) takes a [UserRepository] so it can never drift
+ * from the canonical value.
+ *
+ * Kept `internal` — the SDK's public surface for the current user is still
+ * `StreamVideo.user` and `ClientState.user`.
+ */
+internal interface UserRepository {
+    /** The current user. */
+    val user: User
+
+    /** Hot flow of the current user — emits on every [WritableUserRepository.setUser]. */
+    val userFlow: StateFlow<User>
+}
+
+/**
+ * Write side of [UserRepository]. Only the SDK owns a reference to this sub-interface;
+ * everyone else holds a [UserRepository] so we can't accidentally mutate user state
+ * from a reader and then have the rest of the SDK keep stale data.
+ */
+internal interface WritableUserRepository : UserRepository {
+    fun setUser(user: User)
+}
+
+/**
+ * Default in-memory implementation. The user is kept in a [MutableStateFlow] so
+ * observers (e.g. `ClientState.user`) update automatically when [setUser] is called.
+ */
+internal class StreamUserRepositoryImpl(initial: User) : WritableUserRepository {
+    private val _userFlow: MutableStateFlow<User> = MutableStateFlow(initial)
+    override val userFlow: StateFlow<User> = _userFlow
+    override val user: User get() = _userFlow.value
+    override fun setUser(user: User) {
+        _userFlow.value = user
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
@@ -91,7 +91,7 @@ class StreamVideoClientTest {
         return spyk(
             StreamVideoClient(
                 context = context,
-                user = mockk(relaxed = true),
+                initialUser = mockk(relaxed = true),
                 apiKey = "apikey",
                 token = "token",
                 lifecycle = lifecycle,
@@ -359,15 +359,15 @@ class StreamVideoClientTest {
         )
     }
 
-    // userId used to be captured at construction. After AND-1202 it has to track the live
-    // user reference so the server-issued guest identity (adopted on createGuest success)
+    // userId used to be captured at construction. After AND-1202 it reads through the
+    // UserRepository so the server-issued guest identity (adopted on createGuest success)
     // is reflected everywhere the SDK reads client.userId.
     @Test
     fun `userId tracks the current user reference`() {
-        client.user = User(id = "server_issued_guest", type = UserType.Guest)
+        client.userRepository.setUser(User(id = "server_issued_guest", type = UserType.Guest))
         assertEquals("server_issued_guest", client.userId)
 
-        client.user = User(id = "another_user", type = UserType.Authenticated)
+        client.userRepository.setUser(User(id = "another_user", type = UserType.Authenticated))
         assertEquals("another_user", client.userId)
     }
 
@@ -395,7 +395,7 @@ class StreamVideoClientTest {
         )
         val client = StreamVideoClient(
             context = context,
-            user = User(id = "local_input_id", type = UserType.Guest),
+            initialUser = User(id = "local_input_id", type = UserType.Guest),
             apiKey = "apikey",
             token = "",
             lifecycle = lifecycle,
@@ -413,9 +413,8 @@ class StreamVideoClientTest {
         assertEquals("server_normalized_id", client.user.id)
         assertEquals("server_normalized_id", client.userId)
         assertEquals(UserType.Guest, client.user.type)
-        // ClientState.user is snapshotted at construction from the integrator-supplied
-        // user; the adoption path must mirror the new identity into it as well, otherwise
-        // observers of state.user keep seeing the old id.
+        // state.user is sourced from the UserRepository, so it should reflect the
+        // adopted identity automatically — no separate mirror to keep in sync.
         assertEquals("server_normalized_id", client.state.user.value?.id)
         assertEquals(UserType.Guest, client.state.user.value?.type)
     }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
@@ -36,6 +36,7 @@ import io.getstream.video.android.core.sounds.Sounds
 import io.getstream.video.android.model.User
 import io.getstream.video.android.model.UserType
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.spyk
@@ -357,6 +358,30 @@ class StreamVideoClientTest {
             result is io.getstream.result.Result.Failure,
             "expected Result.Failure, got $result",
         )
+    }
+
+    // Regression: StreamNotificationManager.createDevice() calls api.createDevice() directly
+    // instead of going through apiCall {}, so it doesn't inherit the guestUserJob await guard.
+    // registerPushDevice() must await guestUserJob itself — otherwise the push generator can
+    // kick off and fire createDevice() before the coordinator's auth headers flip from
+    // anonymous to JWT. AND-1202.
+    @Test
+    fun `registerPushDevice waits for guestUserJob to complete before delegating`() = runTest {
+        val notificationManager = client.streamNotificationManager
+        val guestJob = CompletableDeferred<Unit>()
+        client::class.java.getDeclaredField("guestUserJob").apply {
+            isAccessible = true
+            set(client, guestJob)
+        }
+
+        val registerJob = launch { client.registerPushDevice() }
+
+        runCurrent()
+        coVerify(exactly = 0) { notificationManager.registerPushDevice() }
+
+        guestJob.complete(Unit)
+        registerJob.join()
+        coVerify(exactly = 1) { notificationManager.registerPushDevice() }
     }
 
     // userId used to be captured at construction. After AND-1202 it reads through the

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/user/StreamUserRepositoryImplTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/user/StreamUserRepositoryImplTest.kt
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.user
+
+import io.getstream.video.android.model.User
+import io.getstream.video.android.model.UserType
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotSame
+import kotlin.test.assertSame
+
+class StreamUserRepositoryImplTest {
+
+    private val initial = User(id = "initial", type = UserType.Authenticated)
+    private val replacement = User(id = "server_issued", type = UserType.Guest)
+
+    @Test
+    fun `user returns the seed passed to the constructor`() {
+        val repo = StreamUserRepositoryImpl(initial)
+
+        assertSame(initial, repo.user)
+    }
+
+    @Test
+    fun `userFlow holds the seed as its initial value`() = runTest {
+        val repo = StreamUserRepositoryImpl(initial)
+
+        assertSame(initial, repo.userFlow.value)
+        assertSame(initial, repo.userFlow.first())
+    }
+
+    @Test
+    fun `setUser updates user and userFlow_value atomically`() {
+        val repo = StreamUserRepositoryImpl(initial)
+
+        repo.setUser(replacement)
+
+        assertSame(replacement, repo.user)
+        assertSame(replacement, repo.userFlow.value)
+    }
+
+    // Validates that `state.user` (which is the same StateFlow under the hood) sees
+    // the adopted identity instead of being stuck on the integrator-supplied seed.
+    @Test
+    fun `setUser emits the new value to active collectors`() = runTest {
+        val repo = StreamUserRepositoryImpl(initial)
+
+        val collected = mutableListOf<User>()
+        // UNDISPATCHED so the collector subscribes before setUser fires — otherwise
+        // StateFlow's conflation would drop the initial value and take(2) would hang.
+        val job = launch(start = CoroutineStart.UNDISPATCHED) {
+            repo.userFlow.take(2).toList(collected)
+        }
+
+        repo.setUser(replacement)
+        job.join()
+
+        assertEquals(listOf(initial, replacement), collected)
+    }
+
+    // StateFlow is conflated by reference equality — re-setting the same instance
+    // shouldn't re-emit, but a distinct instance with the same data should still flow
+    // through. Guards against accidentally treating equality semantics as identity.
+    @Test
+    fun `setUser with a structurally different user replaces the value`() {
+        val repo = StreamUserRepositoryImpl(initial)
+        val sameIdDifferentInstance = User(id = "initial", type = UserType.Anonymous)
+
+        repo.setUser(sameIdDifferentInstance)
+
+        assertSame(sameIdDifferentInstance, repo.user)
+        assertNotSame(initial, repo.user)
+    }
+}


### PR DESCRIPTION
Stacked on #1704. Merge after parent.

### Goal
Refs [AND-1202](https://linear.app/stream/issue/AND-1202/guest-user-type-is-broken) — address [Rahul's review comment](https://github.com/GetStream/stream-video-android/pull/1704#discussion_r3371808322) on #1704. Stop keeping `var user: User` in parallel on `StreamVideoClient`, `CoordinatorSocketConnection`, and the `_user` mirror in `ClientState`. Move to a single `UserRepository` so the SDK can't accidentally drift again.

### Implementation
- New file `core/user/UserRepository.kt` (all internal — no new public surface):
  - `internal interface UserRepository` — read-only access: `user: User`, `userFlow: StateFlow<User>`.
  - `internal interface WritableUserRepository : UserRepository` — adds `setUser(User)`. Only `StreamVideoClient` holds a write reference.
  - `internal class StreamUserRepositoryImpl(initial: User)` — `MutableStateFlow`-backed default impl.
- `StreamVideoBuilder.build()` constructs one `StreamUserRepositoryImpl` and passes it to both `CoordinatorConnectionModule` and `StreamVideoClient`.
- `StreamVideoClient`:
  - Drops `override var user: User`; ctor takes `initialUser: User` (seed) and `userRepository: WritableUserRepository` (with a default for tests).
  - `override val user: User get() = userRepository.user`; `userId` reads through the repo.
  - `setupGuestUser` writes via `userRepository.setUser(...)` — the separate `state.setUser(...)` mirror added in #1704 is gone.
- `CoordinatorSocketConnection`:
  - **Primary ctor changed to `internal constructor`** taking `UserRepository`. WS auth payload in `onCreated()` reads through the repo, so an adopted guest identity flows in automatically. `connect()` / `reconnect()` no longer mutate a local user copy.
  - **`@Deprecated` secondary `public constructor` (User-based)** preserves backwards compatibility — wraps `user` in a fresh repository internally. External callers compile and link unchanged.
- `ClientState.user` is now sourced from `userRepository.userFlow` (`StateFlow<User>` is assignment-compatible with the existing public `StateFlow<User?>`). The local `_user` mirror and the internal `setUser` helper are removed.

### Public API impact
**Zero net change** — `:apiDump` against `develop` is empty for `stream-video-android-core.api`. The old `CoordinatorSocketConnection(User, …)` constructor is still present (now `@Deprecated`); the new `UserRepository`-based primary ctor is `internal` and doesn't appear in the dump. `UserRepository` is internal.

### Testing
- `StreamVideoClientTest`:
  - `userId tracks the current user reference` — rewritten to write via `client.userRepository.setUser(...)` instead of mutating `client.user`.
  - `setupGuestUser adopts the server-issued user identity on success` — unchanged assertions; ctor migrated to `initialUser = ...`.
- Full `:stream-video-android-core:testDebugUnitTest` — 792 tests, 0 failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored user identity management to centralize user state through a unified repository, improving consistency and eliminating duplicate user tracking across SDK components. User identity is now sourced from a single point of truth.

* **Tests**
  * Updated tests to align with the new repository-based user identity pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->