### PR TITLE
Deprecate StreamVideo.logOut() and document its actual behavior

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideo.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideo.kt
@@ -153,8 +153,27 @@ public interface StreamVideo : NotificationHandler {
     public suspend fun connect(): Result<Long>
 
     /**
-     * Clears the internal user state, removes push notification devices and clears the call state.
+     * Clears the locally stored push device token only. Does not call the
+     * server `DELETE /devices` endpoint, disconnect the coordinator socket, or
+     * clear any in-memory user / call state. The name and historical KDoc
+     * misrepresented this behavior; the method is kept for source compatibility
+     * but should not be used.
+     *
+     * For a full teardown, call [deleteDevice] (if a server-side device row
+     * should be removed) and then [StreamVideo.removeClient], which triggers
+     * [cleanup] and uninstalls the singleton.
      */
+    @Deprecated(
+        message = "logOut() only clears the local push device cache; it does not log the user " +
+            "out, remove the server-side device row, or disconnect the socket. Use " +
+            "StreamVideo.removeClient() for a full teardown (combine with deleteDevice() " +
+            "first if the server-side device row must be removed).",
+        replaceWith = ReplaceWith(
+            expression = "StreamVideo.removeClient()",
+            imports = ["io.getstream.video.android.core.StreamVideo"],
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     public fun logOut()
 
     public companion object {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -1165,6 +1165,14 @@ internal class StreamVideoClient internal constructor(
     /**
      * @see StreamVideo.logOut
      */
+    @Deprecated(
+        message = "Kept for source compatibility; see StreamVideo.logOut for migration guidance.",
+        replaceWith = ReplaceWith(
+            expression = "StreamVideo.removeClient()",
+            imports = ["io.getstream.video.android.core.StreamVideo"],
+        ),
+        level = DeprecationLevel.WARNING,
+    )
     override fun logOut() {
         scope.launch(
             CoroutineName("logOut"),


### PR DESCRIPTION
### Goal
Closes [AND-1217](https://linear.app/stream/issue/AND-1217/deprecate-streamvideologout-does-only-local-device-cache-clear-kdoc). `logOut()`'s KDoc claimed it cleared user state, removed push devices, and cleared call state. It only nulls the local `DeviceTokenStorage`. Deprecate it and point at `removeClient()` (+ `deleteDevice()` first if the server-side device row also needs removing).

### Implementation
`@Deprecated(WARNING)` on the `StreamVideo.logOut()` interface declaration and the `StreamVideoClient` override, with `ReplaceWith(StreamVideo.removeClient())`. KDoc rewritten to describe actual behavior.

### Testing
`compileDebugKotlin` + `apiCheck` pass. Annotation-only — no `.api` change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * The `logOut()` method is deprecated and will be removed in a future release. Applications should migrate to `removeClient()` for proper client cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->