### PR TITLE
Prevent DevicePreferences ClassCastException in updateDevice

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/storage/DeviceTokenStorage.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/internal/storage/DeviceTokenStorage.kt
@@ -35,7 +35,12 @@ internal class DeviceTokenStorage(val context: Context) {
         context.dataStore.data.map { it?.userDevice }
 
     suspend fun updateUserDevice(device: Device?) {
-        context.dataStore.updateData { preferences ->
+        // Assigning the result to a local forces this suspend function to be compiled as a
+        // state machine that returns Unit. Otherwise the compiler tail-call-optimizes the
+        // updateData() call and propagates its DevicePreferences result up the suspend chain,
+        // surfacing as "DevicePreferences cannot be cast to kotlin.Unit" at the caller.
+        @Suppress("UNUSED_VARIABLE")
+        val updated = context.dataStore.updateData { preferences ->
             (preferences ?: DevicePreferences()).copy(userDevice = device)
         }
     }


### PR DESCRIPTION
### Goal
Closes [AN-1219](https://linear.app/stream/issue/AND-1219/fix-classclassexception-reported-by-blink)

Fix a `java.lang.ClassCastException: io.getstream.video.android.core.notifications.internal.storage.DevicePreferences cannot be cast to kotlin.Unit` reported by customers when calling:

```kotlin
coroutineScope.launch { StreamVideo.instanceOrNull()?.updateDevice(null) }
```

### Implementation

The public `updateDevice` path is a chain of four nested suspend tail-calls:

```
StreamVideoClient.updateDevice → StreamNotificationManager.updateDevice
  → DeviceTokenStorage.updateUserDevice → DataStore.updateData  (returns DevicePreferences)
```

`DeviceTokenStorage.updateUserDevice` is declared to return `Unit`, but its last statement was the `DataStore.updateData { ... }` call (which returns `DevicePreferences`). Because that call sits in tail position, the Kotlin compiler tail-call-optimizes it: the `Unit.INSTANCE` conversion is emitted only on the synchronous path. DataStore disk I/O always suspends, so on the real (async) path the `DevicePreferences` value is propagated up the suspend chain to the caller's continuation **without ever being converted to `Unit`**.

The escaped value is normally discarded by the caller, so the latent bug stayed dormant for years. It only becomes a crash when the **call site is compiled with Kotlin 2.4.0**: the codegen for the safe-call `instanceOrNull()?.updateDevice(null)` now emits a `checkcast kotlin/Unit` on the result after the coroutine resumes. That cast lands on the escaped `DevicePreferences` and throws the `ClassCastException`. Older Kotlin compilers (1.9.25–2.2.0) did not emit this cast on that path, which is why the crash only surfaces for apps on the newer toolchain (the reporting customer is on Kotlin 2.4.0 / AGP 9.2.1).

The fix assigns the `updateData()` result to a local variable. This moves the call out of tail position, so the compiler emits a proper coroutine state machine that consumes the result and genuinely returns `Unit` on both the synchronous and suspend paths. The `DevicePreferences` can no longer escape, so the bad cast becomes impossible regardless of the consumer's compiler or how aggressively R8 inlines the chain.

```kotlin
suspend fun updateUserDevice(device: Device?) {
    @Suppress("UNUSED_VARIABLE")
    val updated = context.dataStore.updateData { preferences ->
        (preferences ?: DevicePreferences()).copy(userDevice = device)
    }
}
```

Note: a trailing `return` or `Unit` literal does **not** work — the compiler discards them and the bytecode is identical to the buggy version. Only binding the result to a local defeats the tail-call optimization.

### Testing

- **On-device end-to-end reproduction (customer toolchain)** — built a standalone app matching the reporting customer's environment (AGP 9.2.1 / Kotlin 2.4.0 / Gradle 9.4.1) depending on the released `stream-video-android-core:1.25.0`. Calling `StreamVideo.instanceOrNull()?.updateDevice(null)` crashes on a physical device with the exact reported stack trace:
  ```
  java.lang.ClassCastException: io.getstream.video.android.core.notifications.internal.storage.DevicePreferences cannot be cast to kotlin.Unit
      at ...MainActivity$onCreate$2$1.invokeSuspend(MainActivity.kt:44)
      at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:34)
  ```
- **Fix verified** — published this branch to `mavenLocal` (`./gradlew :stream-video-android-core:publishToMavenLocal`), pointed the same standalone app at the local artifact, and the call now completes without crashing.
- **Bytecode verification across compilers** — disassembled the generated `updateUserDevice` with kotlinc `1.9.25`, `2.0.21`, `2.1.21`, `2.2.0`, and `2.4.0`. The original emits the tail-call pattern (returns the non-`Unit` value on the suspend path); the fixed version emits a state machine (`checkcast Prefs; pop; Unit.INSTANCE; areturn`) that returns `Unit` on every version.
- **Build** — `:stream-video-android-core:compileDebugKotlin` passes; minified (R8, incl. full mode) demo builds successfully.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed notification device token storage to ensure proper data handling and registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
