### PR TITLE
Set small icon on setting-up-call notification

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandler.kt
@@ -538,6 +538,18 @@ constructor(
     )
     override fun getSettingUpCallNotification(): Notification? {
         logger.d { "[getSettingUpCallNotification]" }
+        return buildSettingUpCallNotification()
+    }
+
+    /**
+     * Builds the default "setting up call" foreground-service notification (used for outgoing /
+     * livestream calls and as the fallback for any non-incoming trigger).
+     *
+     * A small icon is mandatory for foreground-service notifications. Without it Android 13+ rejects
+     * the notification with [android.app.RemoteServiceException.CannotPostForegroundServiceNotificationException]
+     * when this notification is used to start the call foreground service.
+     */
+    private fun buildSettingUpCallNotification(): Notification? {
         val channelId = notificationChannels.outgoingCallChannel.id
         val title = application.getString(R.string.stream_video_call_setup_notification_title)
         val description =
@@ -545,6 +557,7 @@ constructor(
         return ensureChannelAndBuildNotification(notificationChannels.outgoingCallChannel) {
             setContentTitle(title)
             setContentText(description)
+            setSmallIcon(R.drawable.stream_video_ic_call)
             setChannelId(channelId)
             setCategory(NotificationCompat.CATEGORY_CALL)
             setOngoing(true)
@@ -598,7 +611,7 @@ constructor(
                 }
             }
 
-            else -> getSettingUpCallNotification()
+            else -> buildSettingUpCallNotification()
         }
     }
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandlerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/notifications/handlers/StreamDefaultNotificationHandlerTest.kt
@@ -34,6 +34,7 @@ import io.getstream.video.android.core.call.CallBusyHandler
 import io.getstream.video.android.core.notifications.NotificationType
 import io.getstream.video.android.core.notifications.StreamIntentResolver
 import io.getstream.video.android.core.notifications.dispatchers.NotificationDispatcher
+import io.getstream.video.android.core.notifications.internal.service.CallService
 import io.getstream.video.android.core.notifications.internal.service.CallServiceConfig
 import io.getstream.video.android.core.notifications.internal.service.CallServiceConfigRegistry
 import io.getstream.video.android.model.StreamCallId
@@ -1118,5 +1119,35 @@ class StreamDefaultNotificationHandlerTest {
                 payload = payload,
             )
         }
+    }
+
+    @Test
+    fun `getSettingUpCallNotification sets a small icon for non-incoming trigger so startForeground does not crash`() {
+        // Given
+        val mockkApp = mockk<Application>(relaxed = true)
+        every { mockkApp.applicationContext } returns mockkApp
+        every { mockkApp.getString(any()) } returns "Test String"
+
+        testHandler = StreamDefaultNotificationHandler(
+            application = mockkApp,
+            notificationManager = mockNotificationManager,
+            notificationPermissionHandler = mockNotificationPermissionHandler,
+            intentResolver = mockIntentResolver,
+            hideRingingNotificationInForeground = false,
+            initialNotificationBuilderInterceptor = mockInitialInterceptor,
+            updateNotificationBuilderInterceptor = mockUpdateInterceptor,
+            permissionChecker = { _, _ -> PackageManager.PERMISSION_GRANTED },
+        )
+
+        // When - the non-incoming path (e.g. livestream/outgoing) is used to start the call
+        // foreground service; without a small icon Android rejects it on startForeground.
+        val result = testHandler.getSettingUpCallNotification(
+            CallService.TRIGGER_OUTGOING_CALL,
+            testCallId,
+        )
+
+        // Then
+        assertNotNull(result)
+        verify { anyConstructed<NotificationCompat.Builder>().setSmallIcon(any<Int>()) }
     }
 }


### PR DESCRIPTION
### Goal
fixes : [AN-1231](https://linear.app/stream/issue/AND-1231/set-small-icon-on-setting-up-call-notification-to-fix)
Fix `RemoteServiceException$CannotPostForegroundServiceNotificationException: Bad notification for startForeground`, which crashes apps on Android 13+ the moment a call's foreground service starts.

The "setting up call" foreground-service notification was built **without a small icon** for any non-incoming trigger. A small icon is mandatory for foreground-service notifications, so Android 13+ rejects the notification and kills the process when `startForeground` is called.

**Types of apps / flows affected**

The crash hits apps running on Android 13+ (API 33+, most visibly on 14/15) whenever the call foreground service is started by a **non-incoming** trigger:

- **Livestreaming apps** — a viewer or host joining a livestream call (most reliable repro).
- **Outgoing calls** — placing/joining a call without the incoming-call ringing flow.
- **Ongoing calls** — the active-call service notification.

Incoming/ringing calls are **not** affected, because that branch already sets a small icon. That's why the issue was easy to miss in 1:1 ringing flows but reproduced consistently in livestreaming.

### Implementation

In `StreamDefaultNotificationHandler`:

- The non-deprecated `getSettingUpCallNotification(trigger, callId)` delegated its `else` branch to the deprecated no-arg `getSettingUpCallNotification()`, which never called `setSmallIcon`.
- Extracted a non-deprecated `buildSettingUpCallNotification()` helper that always sets `setSmallIcon(R.drawable.stream_video_ic_call)`.
- Both the non-deprecated `else` branch and the deprecated no-arg overload now delegate to that helper, so every "setting up call" notification carries a small icon and the non-deprecated path no longer calls deprecated code.

### Testing

- Added a regression unit test in `StreamDefaultNotificationHandlerTest` that drives the non-incoming (`TRIGGER_OUTGOING_CALL`) path and asserts `setSmallIcon` is called.
- `./gradlew :stream-video-android-core:testDebugUnitTest` passes; Spotless applied; `apiCheck` passes (no public API change).
- Verified end-to-end against a locally-published build: a livestream viewer and a 1:1 video call both start the foreground service without crashing — with no app-side workaround in place.

### Workaround (for apps on already-released SDK versions)

Until this fix ships, an app can supply a custom notification handler that sets a small icon on the setting-up notification, wired through `NotificationConfig`:

```kotlin
class IconSafeNotificationHandler(
    private val application: Application,
) : CompatibilityStreamNotificationHandler(application) {
    override fun getSettingUpCallNotification(
        trigger: String,
        callId: StreamCallId,
    ): Notification {
        // Build a NotificationCompat notification on your own channel and make sure
        // setSmallIcon(...) is set, e.g. android.R.drawable.ic_menu_call.
    }
}

StreamVideoBuilder(
    context = context,
    apiKey = apiKey,
    user = user,
    token = token,
    notificationConfig = NotificationConfig(
        notificationHandler = IconSafeNotificationHandler(application),
    ),
).build()
```