### PR TITLE
Do not show error message while video is loading

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -70,13 +69,10 @@ import io.getstream.video.android.CallActivity
 import io.getstream.video.android.R
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.avatar.UserAvatar
-import io.getstream.video.android.compose.ui.components.avatar.UserAvatarBackground
 import io.getstream.video.android.compose.ui.components.base.StreamButton
 import io.getstream.video.android.compose.ui.components.call.controls.ControlActions
 import io.getstream.video.android.compose.ui.components.call.lobby.CallLobby
 import io.getstream.video.android.compose.ui.components.call.lobby.buildDefaultLobbyControlActions
-import io.getstream.video.android.compose.ui.components.video.VideoRenderer
-import io.getstream.video.android.compose.ui.components.video.config.videoRenderConfig
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.call.state.CallAction
 import io.getstream.video.android.core.call.state.ToggleCamera
@@ -322,26 +318,6 @@ private fun CallLobbyBodyPortrait(
                 .padding(VideoTheme.dimens.spacingM),
             isCameraEnabled = isCameraEnabled,
             isMicrophoneEnabled = isMicrophoneEnabled,
-            onRenderedContent = {
-                val videoRendererConfig = remember {
-                    videoRenderConfig {
-                        this.fallbackContent = {
-                            val userName = it.user.userNameOrId
-                            val userImage = it.user.image
-                            UserAvatarBackground(userImage = userImage, userName = userName)
-                        }
-                    }
-                }
-                VideoRenderer(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .background(VideoTheme.colors.baseSheetTertiary)
-                        .testTag("on_rendered_content"),
-                    call = call,
-                    video = it,
-                    videoRendererConfig = videoRendererConfig,
-                )
-            },
             onCallAction = onCallAction,
             lobbyControlsContent = { modifier, _ ->
                 ControlActions(
@@ -409,31 +385,6 @@ private fun CallLobbyBodyLandscape(
                         ),
                     isCameraEnabled = isCameraEnabled,
                     isMicrophoneEnabled = isMicrophoneEnabled,
-                    onRenderedContent = {
-                        Box(
-                            modifier = Modifier.fillMaxHeight(),
-                            contentAlignment = Alignment.Center,
-                        ) {
-                            val videoRendererConfig = remember {
-                                videoRenderConfig {
-                                    this.fallbackContent = {
-                                        val userName = it.user.userNameOrId
-                                        val userImage = it.user.image
-                                        UserAvatarBackground(userImage = userImage, userName = userName)
-                                    }
-                                }
-                            }
-                            VideoRenderer(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .background(VideoTheme.colors.baseSheetTertiary)
-                                    .testTag("on_rendered_content"),
-                                call = call,
-                                video = it,
-                                videoRendererConfig = videoRendererConfig,
-                            )
-                        }
-                    },
                     onCallAction = onCallAction,
                     lobbyControlsContent = { _, _ ->
                         ControlActions(

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -1299,9 +1299,11 @@ public final class io/getstream/video/android/compose/ui/components/call/lobby/C
 
 public final class io/getstream/video/android/compose/ui/components/call/lobby/ComposableSingletons$CallLobbyKt {
 	public static final field INSTANCE Lio/getstream/video/android/compose/ui/components/call/lobby/ComposableSingletons$CallLobbyKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
-	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-1$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$stream_video_android_ui_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/lobby/LobbyControlsActionsKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
@@ -53,7 +53,7 @@ import io.getstream.video.android.compose.ui.components.call.controls.ControlAct
 import io.getstream.video.android.compose.ui.components.call.controls.actions.DefaultOnCallActionHandler
 import io.getstream.video.android.compose.ui.components.call.renderer.ParticipantLabel
 import io.getstream.video.android.compose.ui.components.indicator.MicrophoneIndicator
-import io.getstream.video.android.compose.ui.components.video.DefaultVideoRendererPlaceholderContent
+import io.getstream.video.android.compose.ui.components.video.DefaultMediaTrackFallbackContent
 import io.getstream.video.android.compose.ui.components.video.VideoRenderer
 import io.getstream.video.android.compose.ui.components.video.config.videoRenderConfig
 import io.getstream.video.android.core.Call
@@ -231,7 +231,7 @@ private fun OnRenderedContent(
             },
         )
         if (!isVideoRendered) {
-            DefaultVideoRendererPlaceholderContent(
+            DefaultMediaTrackFallbackContent(
                 modifier = Modifier.fillMaxSize(),
                 call = call,
             )

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
@@ -30,6 +30,10 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -49,7 +53,9 @@ import io.getstream.video.android.compose.ui.components.call.controls.ControlAct
 import io.getstream.video.android.compose.ui.components.call.controls.actions.DefaultOnCallActionHandler
 import io.getstream.video.android.compose.ui.components.call.renderer.ParticipantLabel
 import io.getstream.video.android.compose.ui.components.indicator.MicrophoneIndicator
+import io.getstream.video.android.compose.ui.components.video.DefaultVideoRendererPlaceholderContent
 import io.getstream.video.android.compose.ui.components.video.VideoRenderer
+import io.getstream.video.android.compose.ui.components.video.config.videoRenderConfig
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.core.StreamVideo
@@ -195,15 +201,42 @@ private fun OnRenderedContent(
     video: ParticipantState.Video,
     onRendered: (View) -> Unit = {},
 ) {
-    VideoRenderer(
+    var isVideoRendered by remember { mutableStateOf(false) }
+
+    LaunchedEffect(video.track?.streamId) {
+        isVideoRendered = false
+    }
+
+    val videoRendererConfig = remember {
+        videoRenderConfig {
+            // Loading UI is shown as an overlay until the first frame is rendered.
+            fallbackContent = {}
+        }
+    }
+
+    Box(
         modifier = Modifier
             .fillMaxSize()
             .background(VideoTheme.colors.baseSheetTertiary)
             .testTag("on_rendered_content"),
-        call = call,
-        video = video,
-        onRendered = onRendered,
-    )
+    ) {
+        VideoRenderer(
+            modifier = Modifier.fillMaxSize(),
+            call = call,
+            video = video,
+            videoRendererConfig = videoRendererConfig,
+            onRendered = {
+                isVideoRendered = true
+                onRendered(it)
+            },
+        )
+        if (!isVideoRendered) {
+            DefaultVideoRendererPlaceholderContent(
+                modifier = Modifier.fillMaxSize(),
+                call = call,
+            )
+        }
+    }
 }
 
 @Composable

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -216,7 +215,7 @@ public fun VideoRenderer(
     modifier: Modifier = Modifier,
     videoScalingType: VideoScalingType = VideoScalingType.SCALE_ASPECT_FILL,
     videoFallbackContent: @Composable (Call) -> Unit = {
-        DefaultVideoRendererPlaceholderContent(
+        DefaultMediaTrackFallbackContent(
             modifier,
             call,
         )
@@ -271,7 +270,7 @@ private fun setupVideo(
 }
 
 @Composable
-internal fun DefaultVideoRendererPlaceholderContent(
+internal fun DefaultMediaTrackFallbackContent(
     modifier: Modifier,
     @Suppress("UNUSED_PARAMETER") call: Call,
 ) {
@@ -285,32 +284,6 @@ internal fun DefaultVideoRendererPlaceholderContent(
         CircularProgressIndicator(
             modifier = Modifier.size(48.dp),
             color = VideoTheme.colors.basePrimary,
-        )
-    }
-}
-
-@Composable
-internal fun DefaultMediaTrackFallbackContent(
-    modifier: Modifier,
-    call: Call,
-) {
-    Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(VideoTheme.colors.baseSheetTertiary)
-            .testTag("video_renderer_fallback_error"),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
-        Text(
-            modifier = Modifier.padding(30.dp),
-            text = stringResource(
-                id = io.getstream.video.android.ui.common.R.string.stream_video_call_rendering_failed,
-                call.sessionId,
-            ),
-            color = VideoTheme.colors.basePrimary,
-            textAlign = TextAlign.Center,
-            fontSize = 14.sp,
         )
     }
 }
@@ -403,6 +376,6 @@ private fun VideoRendererPausedPreview2() {
 private fun VideoRendererFallbackPreview() {
     StreamPreviewDataUtils.initializeStreamVideo(LocalContext.current)
     VideoTheme {
-        DefaultVideoRendererPlaceholderContent(modifier = Modifier, call = previewCall)
+        DefaultMediaTrackFallbackContent(modifier = Modifier, call = previewCall)
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/VideoRenderer.kt
@@ -26,6 +26,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.Icon
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
@@ -96,7 +98,7 @@ public fun VideoRenderer(
             return
         }
 
-        // Show avatar always behind the video.
+        // Neutral placeholder rendered behind the video while the track is loading.
         videoRendererConfig.fallbackContent.invoke(call)
 
         if (video?.paused == true) {
@@ -214,7 +216,7 @@ public fun VideoRenderer(
     modifier: Modifier = Modifier,
     videoScalingType: VideoScalingType = VideoScalingType.SCALE_ASPECT_FILL,
     videoFallbackContent: @Composable (Call) -> Unit = {
-        DefaultMediaTrackFallbackContent(
+        DefaultVideoRendererPlaceholderContent(
             modifier,
             call,
         )
@@ -269,6 +271,25 @@ private fun setupVideo(
 }
 
 @Composable
+internal fun DefaultVideoRendererPlaceholderContent(
+    modifier: Modifier,
+    @Suppress("UNUSED_PARAMETER") call: Call,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(VideoTheme.colors.baseSheetTertiary)
+            .testTag("video_renderer_fallback"),
+        contentAlignment = Alignment.Center,
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier.size(48.dp),
+            color = VideoTheme.colors.basePrimary,
+        )
+    }
+}
+
+@Composable
 internal fun DefaultMediaTrackFallbackContent(
     modifier: Modifier,
     call: Call,
@@ -277,7 +298,7 @@ internal fun DefaultMediaTrackFallbackContent(
         modifier = modifier
             .fillMaxSize()
             .background(VideoTheme.colors.baseSheetTertiary)
-            .testTag("video_renderer_fallback"),
+            .testTag("video_renderer_fallback_error"),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -382,6 +403,6 @@ private fun VideoRendererPausedPreview2() {
 private fun VideoRendererFallbackPreview() {
     StreamPreviewDataUtils.initializeStreamVideo(LocalContext.current)
     VideoTheme {
-        DefaultMediaTrackFallbackContent(modifier = Modifier, call = previewCall)
+        DefaultVideoRendererPlaceholderContent(modifier = Modifier, call = previewCall)
     }
 }

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/config/VideoRendererConfig.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/config/VideoRendererConfig.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import io.getstream.video.android.compose.ui.components.video.DefaultVideoRendererPlaceholderContent
+import io.getstream.video.android.compose.ui.components.video.DefaultMediaTrackFallbackContent
 import io.getstream.video.android.compose.ui.components.video.VideoScalingType
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.ui.common.util.StreamVideoExperimentalApi
@@ -105,7 +105,7 @@ public data class VideoRendererConfigCreationScope(
     public var videoScalingType: VideoScalingType = defaultScalingType,
     public var updateVisibility: Boolean = defaultUpdateVisibility,
     public var fallbackContent: @Composable (Call) -> Unit = {
-        DefaultVideoRendererPlaceholderContent(
+        DefaultMediaTrackFallbackContent(
             modifier = Modifier,
             call = it,
         )

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/config/VideoRendererConfig.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/video/config/VideoRendererConfig.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import io.getstream.video.android.compose.ui.components.video.DefaultMediaTrackFallbackContent
+import io.getstream.video.android.compose.ui.components.video.DefaultVideoRendererPlaceholderContent
 import io.getstream.video.android.compose.ui.components.video.VideoScalingType
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.ui.common.util.StreamVideoExperimentalApi
@@ -105,7 +105,7 @@ public data class VideoRendererConfigCreationScope(
     public var videoScalingType: VideoScalingType = defaultScalingType,
     public var updateVisibility: Boolean = defaultUpdateVisibility,
     public var fallbackContent: @Composable (Call) -> Unit = {
-        DefaultMediaTrackFallbackContent(
+        DefaultVideoRendererPlaceholderContent(
             modifier = Modifier,
             call = it,
         )


### PR DESCRIPTION
### Goal
Closes [1235](https://linear.app/stream/issue/AND-1235/fix-show-loading-spinner-in-calllobby-while-camera-warms-instead-of)
Fix [#1656](https://github.com/GetStream/stream-video-android/issues/1656): when enabling the camera in CallLobby, users briefly saw "This track failed to be loaded in the session" even though the camera was initializing normally.

The default VideoRenderer fallback was an error message rendered unconditionally behind the video layer, so it flashed whenever the track was not yet visible.

### Implementation

-  Replaced the error Text in `DefaultMediaTrackFallbackContent` with a neutral `CircularProgressIndicator` on the standard tertiary background, and use it as the single default fallbackContent for `VideoRenderer`.

- Updated `CallLobby` to show a loading overlay until onRendered fires, so the spinner is visible during camera warm-up even when a videoTrack object already exists but the first frame has not rendered yet.

- Removed the `UserAvatarBackground` from the demo-app `CallLobbyScreen` so the lobby uses the SDK default behavior.

### 🎨 UI Changes


https://github.com/user-attachments/assets/ef457462-a563-4133-9b6c-12d336c942d6



### Testing

- [] ./gradlew :stream-video-android-ui-compose:testDebugUnitTest --tests "io.getstream.video.android.compose.CallLobbyTest" — passe

- [] Manual verification on device:
1. Open Call Lobby
2. Turn camera off → avatar is shown
3. Turn camera on → spinner appears briefly, then live video
4. Confirm the old error text no longer flashes


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_