### PR TITLE
Add participantLabelContent slot to CallLobby

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ On CallContent make sure to pass onBackPressed to CallAppBar in order to make th
 ### ⬆️ Improved
 
 ### ✅ Added
+Add `participantLabelContent` slot to `CallLobby` so the lobby participant label can be hidden (`{}`) or fully customized. Brings the Compose API in line with React's `VideoPreview` slot overrides.
 
 ### ⚠️ Changed
+Deprecate the `CallLobby` overload that takes `labelPosition: Alignment`. Migrate to the new `participantLabelContent` slot; pass `{}` to hide the label or supply a composable to customize content and positioning.
 
 ### ❌ Removed
 

--- a/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
+++ b/stream-video-android-ui-compose/api/stream-video-android-ui-compose.api
@@ -1295,6 +1295,7 @@ public final class io/getstream/video/android/compose/ui/components/call/diagnos
 
 public final class io/getstream/video/android/compose/ui/components/call/lobby/CallLobbyKt {
 	public static final fun CallLobby (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;Lio/getstream/video/android/model/User;Landroidx/compose/ui/Alignment;ZZLio/getstream/video/android/core/ParticipantState$Video;Lio/getstream/video/android/compose/permission/VideoPermissionsState;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V
+	public static final fun CallLobby (Landroidx/compose/ui/Modifier;Lio/getstream/video/android/core/Call;Lio/getstream/video/android/model/User;ZZLio/getstream/video/android/core/ParticipantState$Video;Lio/getstream/video/android/compose/permission/VideoPermissionsState;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/video/android/compose/ui/components/call/lobby/ComposableSingletons$CallLobbyKt {

--- a/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
+++ b/stream-video-android-ui-compose/src/main/kotlin/io/getstream/video/android/compose/ui/components/call/lobby/CallLobby.kt
@@ -20,6 +20,7 @@ import android.content.res.Configuration
 import android.view.View
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -74,11 +75,13 @@ import io.getstream.video.android.ui.common.R
  * @param modifier Modifier for styling.
  * @param call The call includes states and will be rendered with participants.
  * @param user A user to display their name and avatar image on the preview.
- * @param labelPosition The position of the user audio state label.
  * @param video A participant video to render on the preview renderer.
  * @param permissions Android permissions that should be required to render a video call properly.
  * @param onRenderedContent A video renderer, which renders a local video track before joining a call.
  * @param onDisabledContent Content is shown that a local camera is disabled. It displays user avatar by default.
+ * @param participantLabelContent Slot for the participant label overlaid on the preview. Defaults to a
+ * label showing the user's name and microphone state at [Alignment.BottomStart]. Pass `{}` to hide the
+ * label entirely, or override to provide custom positioning and content (use [BoxScope.align] inside).
  * @param onCallAction Handler when the user triggers a Call Control Action.
  * @param lobbyControlsContent Content is shown that allows users to trigger different actions to control a preview call.
  * @param onRendered An interface that will be invoked when the video is rendered.
@@ -88,7 +91,108 @@ public fun CallLobby(
     modifier: Modifier = Modifier,
     call: Call,
     user: User = StreamVideo.instance().user,
-    labelPosition: Alignment = Alignment.BottomStart,
+    isCameraEnabled: Boolean = if (LocalInspectionMode.current) {
+        true
+    } else {
+        call.camera.isEnabled.value
+    },
+    isMicrophoneEnabled: Boolean = if (LocalInspectionMode.current) {
+        true
+    } else {
+        call.microphone.isEnabled.value
+    },
+    video: ParticipantState.Video = ParticipantState.Video(
+        sessionId = call.sessionId,
+        track = VideoTrack(
+            streamId = call.sessionId,
+            video = if (LocalInspectionMode.current) {
+                org.webrtc.VideoTrack(1000L)
+            } else {
+                call.camera.mediaManager.videoTrack
+            },
+        ),
+        enabled = isCameraEnabled,
+        paused = false,
+    ),
+    permissions: VideoPermissionsState = rememberCallPermissionsState(call = call),
+    onRendered: (View) -> Unit = {},
+    onRenderedContent: @Composable (video: ParticipantState.Video) -> Unit = {
+        OnRenderedContent(call = call, video = it, onRendered = onRendered)
+    },
+    onDisabledContent: @Composable () -> Unit = {
+        OnDisabledContent(user = user)
+    },
+    participantLabelContent: @Composable BoxScope.() -> Unit = {
+        DefaultParticipantLabel(
+            user = user,
+            isMicrophoneEnabled = isMicrophoneEnabled,
+            labelPosition = Alignment.BottomStart,
+        )
+    },
+    onCallAction: (CallAction) -> Unit = {
+        DefaultOnCallActionHandler.onCallAction(call, it)
+    },
+    lobbyControlsContent: @Composable (modifier: Modifier, call: Call) -> Unit = { modifier, call ->
+        ControlActions(
+            modifier = modifier,
+            call = call,
+            actions = buildDefaultLobbyControlActions(
+                call = call,
+                onCallAction = onCallAction,
+                isCameraEnabled = isCameraEnabled,
+                isMicrophoneEnabled = isMicrophoneEnabled,
+            ),
+        )
+    },
+) {
+    DefaultPermissionHandler(videoPermission = permissions)
+
+    MediaPiPLifecycle(call = call, PictureInPictureConfiguration(false, false))
+    val configuration = LocalConfiguration.current
+    val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
+    val screenHeightDp = configuration.screenHeightDp
+
+    val boxModifier = Modifier
+        .responsiveHeight(isPortrait, screenHeightDp)
+        .fillMaxWidth()
+        .clip(RoundedCornerShape(12.dp))
+
+    Column(modifier = modifier) {
+        Box(
+            modifier = boxModifier,
+        ) {
+            if (isCameraEnabled) {
+                onRenderedContent.invoke(video)
+            } else {
+                onDisabledContent.invoke()
+            }
+
+            participantLabelContent()
+        }
+
+        Spacer(modifier = Modifier.height(VideoTheme.dimens.spacingM))
+
+        lobbyControlsContent.invoke(Modifier.align(Alignment.Start), call)
+    }
+}
+
+@Deprecated(
+    message = "Use CallLobby with the participantLabelContent slot for full control over the lobby " +
+        "label. Pass `{}` to hide it, or override to customize content and position.",
+    replaceWith = ReplaceWith(
+        "CallLobby(modifier = modifier, call = call, user = user, " +
+            "isCameraEnabled = isCameraEnabled, isMicrophoneEnabled = isMicrophoneEnabled, " +
+            "video = video, permissions = permissions, onRendered = onRendered, " +
+            "onRenderedContent = onRenderedContent, onDisabledContent = onDisabledContent, " +
+            "onCallAction = onCallAction, lobbyControlsContent = lobbyControlsContent)",
+    ),
+)
+@Composable
+public fun CallLobby(
+    modifier: Modifier = Modifier,
+    call: Call,
+    user: User = StreamVideo.instance().user,
+    labelPosition: Alignment,
     isCameraEnabled: Boolean = if (LocalInspectionMode.current) {
         true
     } else {
@@ -136,54 +240,55 @@ public fun CallLobby(
         )
     },
 ) {
-    DefaultPermissionHandler(videoPermission = permissions)
-
-    MediaPiPLifecycle(call = call, PictureInPictureConfiguration(false, false))
-    val configuration = LocalConfiguration.current
-    val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
-    val screenHeightDp = configuration.screenHeightDp
-
-    val boxModifier = Modifier
-        .responsiveHeight(isPortrait, screenHeightDp)
-        .fillMaxWidth()
-        .clip(RoundedCornerShape(12.dp))
-
-    Column(modifier = modifier) {
-        Box(
-            modifier = boxModifier,
-        ) {
-            if (isCameraEnabled) {
-                onRenderedContent.invoke(video)
-            } else {
-                onDisabledContent.invoke()
-            }
-
-            val nameLabel = if (user.id == StreamVideo.instance().user.id) {
-                stringResource(id = R.string.stream_video_myself)
-            } else {
-                user.userNameOrId
-            }
-
-            ParticipantLabel(
-                nameLabel = nameLabel,
+    CallLobby(
+        modifier = modifier,
+        call = call,
+        user = user,
+        isCameraEnabled = isCameraEnabled,
+        isMicrophoneEnabled = isMicrophoneEnabled,
+        video = video,
+        permissions = permissions,
+        onRendered = onRendered,
+        onRenderedContent = onRenderedContent,
+        onDisabledContent = onDisabledContent,
+        participantLabelContent = {
+            DefaultParticipantLabel(
+                user = user,
+                isMicrophoneEnabled = isMicrophoneEnabled,
                 labelPosition = labelPosition,
-                hasAudio = isMicrophoneEnabled,
-                soundIndicatorContent = {
-                    MicrophoneIndicator(
-                        modifier = Modifier
-                            .padding(horizontal = VideoTheme.dimens.spacingM)
-                            .testTag("Stream_UserMicrophone_Enabled_$isMicrophoneEnabled"),
-                        isMicrophoneEnabled = isMicrophoneEnabled,
-                    )
-                },
-                isSpeaking = false,
             )
-        }
+        },
+        onCallAction = onCallAction,
+        lobbyControlsContent = lobbyControlsContent,
+    )
+}
 
-        Spacer(modifier = Modifier.height(VideoTheme.dimens.spacingM))
-
-        lobbyControlsContent.invoke(Modifier.align(Alignment.Start), call)
+@Composable
+private fun BoxScope.DefaultParticipantLabel(
+    user: User,
+    isMicrophoneEnabled: Boolean,
+    labelPosition: Alignment,
+) {
+    val nameLabel = if (user.id == StreamVideo.instance().user.id) {
+        stringResource(id = R.string.stream_video_myself)
+    } else {
+        user.userNameOrId
     }
+
+    ParticipantLabel(
+        nameLabel = nameLabel,
+        labelPosition = labelPosition,
+        hasAudio = isMicrophoneEnabled,
+        soundIndicatorContent = {
+            MicrophoneIndicator(
+                modifier = Modifier
+                    .padding(horizontal = VideoTheme.dimens.spacingM)
+                    .testTag("Stream_UserMicrophone_Enabled_$isMicrophoneEnabled"),
+                isMicrophoneEnabled = isMicrophoneEnabled,
+            )
+        },
+        isSpeaking = false,
+    )
 }
 
 @Composable


### PR DESCRIPTION
### Goal

Closes [AND-1246](https://linear.app/stream/issue/AND-1246/make-participantlabel-optional-in-calllobby-composable-of-android-sdk)
The `CallLobby` composable renders `ParticipantLabel` unconditionally with no way to hide or override it. iOS (`LobbyView`) and React (`VideoPreview`) do not render a participant label on the local preview, so Android was the outlier. Customer feedback asked to make this optional.

### Implementation

- Add a new `CallLobby` overload taking `participantLabelContent: @Composable BoxScope.() -> Unit` in place of `labelPosition: Alignment`. The default reproduces today's rendering (name + microphone indicator at `BottomStart`). Pass `{}` to hide it, or override to supply custom content and positioning (use `BoxScope.align` inside).
- Deprecate the previous overload (with `labelPosition`); it now delegates to the new one. `labelPosition` is required on the deprecated overload so source-level overload resolution remains unambiguous — callers that did not pass `labelPosition` migrate silently to the new overload with no visual change.
- Extract `DefaultParticipantLabel` so both overloads share the same default rendering.
- Regenerate `.api` and update `CHANGELOG.md`.

Mirrors React `VideoPreview`'s slot-based overrides (`DisabledVideoPreview`, `NoCameraPreview`, `StartingCameraPreview`).

```kotlin
// Hide the label
CallLobby(call = call, participantLabelContent = {})

// Custom label at top-end
CallLobby(
    call = call,
    participantLabelContent = {
        MyLabel(modifier = Modifier.align(Alignment.TopEnd))
    },
)
```

### 🎨 UI Changes

No visual change at defaults — existing call sites do not pass `labelPosition` and resolve to the new overload, whose default slot reproduces prior rendering.

### Testing

`./gradlew :stream-video-android-ui-compose:spotlessApply :stream-video-android-ui-compose:apiDump` passes locally. The existing `CallLobbyTest` paparazzi snapshot should remain unchanged (default slot = prior rendering). Manual verification: pass `participantLabelContent = {}` and confirm the label is hidden; supply a custom slot and confirm placement.

### ☑️Contributor Checklist

#### General
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes

### ☑️Reviewer Checklist
- [ ] Compose sample runs & works
- [ ] New feature tested and works (`participantLabelContent = {}` hides the label; custom slot positions correctly)
- [ ] Default rendering unchanged (existing call sites resolve to the new overload)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced `CallLobby` with improved participant label customization. The label can now be hidden entirely or fully customized through a new composable content block.

* **Documentation**
  * Updated changelog with migration guidance for the participant label customization changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->