### PR TITLE
Improve trace timestamp accuracy under concurrent event recording

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/trace/TraceRecord.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/trace/TraceRecord.kt
@@ -17,7 +17,6 @@
 package io.getstream.video.android.core.trace
 
 import io.getstream.video.android.core.internal.InternalStreamVideoApi
-import java.util.Collections
 
 /**
  * A single trace item captured by [Tracer].
@@ -51,7 +50,7 @@ fun TraceRecord.serialize(): Array<Any?> = arrayOf(tag, id, data, timestamp)
 @InternalStreamVideoApi
 class Tracer(private val id: String?) {
 
-    private val buffer: MutableList<TraceRecord> = Collections.synchronizedList(mutableListOf())
+    private val buffer: MutableList<TraceRecord> = mutableListOf()
     private var enabled: Boolean = true
 
     /**
@@ -76,16 +75,18 @@ class Tracer(private val id: String?) {
      * The lambda form matches the original TypeScript API and can be stored or passed
      * around as a function reference.
      */
-    fun trace(tag: String, data: Any?) = synchronized(buffer) {
-        if (!enabled) return@synchronized
-        buffer.add(
-            TraceRecord(
-                tag = tag,
-                id = id,
-                data = data,
-                timestamp = System.currentTimeMillis(),
-            ),
+    fun trace(tag: String, data: Any?) {
+        val record = TraceRecord(
+            tag = tag,
+            id = id,
+            data = data,
+            timestamp = System.currentTimeMillis(),
         )
+
+        synchronized(buffer) {
+            if (!enabled) return
+            buffer.add(record)
+        }
     }
 
     /**

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/trace/TraceRecordTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/trace/TraceRecordTest.kt
@@ -21,6 +21,11 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 class TraceRecordTest {
     @Test
@@ -75,5 +80,125 @@ class TraceRecordTest {
         assertEquals(3, afterRollback.snapshot.size)
         assertEquals("tag1", afterRollback.snapshot[0].tag)
         assertEquals("data1", afterRollback.snapshot[0].data)
+    }
+
+    /**
+     * Many threads hammer [Tracer.trace] at once. The buffer must remain consistent and no
+     * exception (e.g. ConcurrentModificationException) may escape. Every emitted record must be
+     * accounted for in the drained snapshot.
+     */
+    @Test
+    fun `concurrent trace calls do not throw and record every entry`() {
+        val tracer = Tracer("concurrent-trace")
+        val threadCount = 8
+        val perThread = 2_000
+        val pool = Executors.newFixedThreadPool(threadCount)
+        val start = CountDownLatch(1)
+        val errors = CopyOnWriteArrayList<Throwable>()
+
+        val futures = (0 until threadCount).map { t ->
+            pool.submit {
+                try {
+                    start.await()
+                    repeat(perThread) { i -> tracer.trace("thread-$t", i) }
+                } catch (e: Throwable) {
+                    errors.add(e)
+                }
+            }
+        }
+        start.countDown() // release all threads at once to maximise contention
+        futures.forEach { it.get() }
+        pool.shutdown()
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS))
+
+        assertTrue("Unexpected errors during concurrent trace: $errors", errors.isEmpty())
+        val snapshot = tracer.take().snapshot
+        assertEquals(threadCount * perThread, snapshot.size)
+    }
+
+    /**
+     * Draining via [Tracer.take] (which iterates the buffer internally) while other threads keep
+     * appending must not throw ConcurrentModificationException. This guards the locking contract:
+     * iteration and mutation are serialised by the same monitor.
+     */
+    @Test
+    fun `take while concurrently tracing never throws`() {
+        val tracer = Tracer("concurrent-take")
+        val pool = Executors.newFixedThreadPool(4)
+        val running = AtomicBoolean(true)
+        val errors = CopyOnWriteArrayList<Throwable>()
+
+        val writers = (0 until 3).map { t ->
+            pool.submit {
+                try {
+                    while (running.get()) tracer.trace("writer-$t", t)
+                } catch (e: Throwable) {
+                    errors.add(e)
+                }
+            }
+        }
+        val reader = pool.submit {
+            try {
+                repeat(1_000) {
+                    // Force iteration of the drained slice as well as the internal copy.
+                    tracer.take().snapshot.forEach { _ -> }
+                }
+            } catch (e: Throwable) {
+                errors.add(e)
+            }
+        }
+
+        reader.get()
+        running.set(false)
+        writers.forEach { it.get() }
+        pool.shutdown()
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS))
+
+        assertTrue("Unexpected errors during concurrent take: $errors", errors.isEmpty())
+    }
+
+    /**
+     * Drives [Tracer.trace] from many threads. Buffer order is ignored; instead records are grouped
+     * by producer (tag) and ordered by the per-thread call index in `data`. Because the timestamp
+     * is stamped at call time and each thread calls sequentially, every producer's timestamps must
+     * be non-decreasing along its own call order — regardless of lock contention or buffer
+     * interleaving. Asserted as `>=` because call-time [System.currentTimeMillis] ties at
+     * millisecond resolution.
+     */
+    @Test
+    fun `concurrent traces keep per-thread timestamps non-decreasing in call order`() {
+        val tracer = Tracer("fifo-concurrent")
+        val threadCount = 8
+        val perThread = 2_000
+        val pool = Executors.newFixedThreadPool(threadCount)
+        val start = CountDownLatch(1)
+
+        val futures = (0 until threadCount).map { t ->
+            pool.submit {
+                start.await() // release together to maximise contention
+                repeat(perThread) { i -> tracer.trace("thread-$t", i) }
+            }
+        }
+        start.countDown()
+        futures.forEach { it.get() }
+        pool.shutdown()
+        assertTrue(pool.awaitTermination(10, TimeUnit.SECONDS))
+
+        val snapshot = tracer.take().snapshot
+        assertEquals(threadCount * perThread, snapshot.size) // nothing lost
+
+        val byThread = snapshot.groupBy { it.tag }
+        assertEquals(threadCount, byThread.size)
+        byThread.forEach { (tag, records) ->
+            val inCallOrder = records.sortedBy { it.data as Int }
+            assertEquals(perThread, inCallOrder.size)
+            for (i in 1 until inCallOrder.size) {
+                assertTrue(
+                    "timestamp regressed for $tag at call $i: " +
+                        "${inCallOrder[i - 1].timestamp} > ${inCallOrder[i].timestamp}",
+                    inCallOrder[i].timestamp >= inCallOrder[i - 1].timestamp,
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
### Goal

Close #AND-1265

Improve the accuracy of trace timestamps by recording the timestamp when the trace event is created rather than when it is inserted into the tracer buffer.

Previously, timestamps were generated inside the synchronized buffer section. Under contention, a thread could wait to acquire the lock before recording its timestamp, causing the recorded time to reflect lock acquisition order rather than the actual time the event occurred.

By capturing the timestamp before acquiring the buffer lock, trace records more accurately represent when the underlying event was observed by the SDK.

### Implementation

* Moved TraceRecord creation outside the synchronized buffer section.
* Capture System.currentTimeMillis() before attempting to acquire the tracer lock.
* Preserve the existing synchronization strategy for buffer mutations.
* No changes to trace serialization, buffering, rollback behavior, or upload logic.

Before:

* Timestamp represented when the tracer accepted the event into the buffer.

After:

* Timestamp represents when the event was observed and trace() was invoked.

This change improves the temporal accuracy of analytics and debugging traces when multiple threads are recording events concurrently.

### 🎨 UI Changes

None

### Testing

Visit [Stream Demo App's Dashboard](https://beta.dashboard.getstream.io/organization/1181507/1270131/video/call-viewer/default:4df9f018-4c33-4a6f-9bee-d7124a7920c6/30e84ffa-26c6-4626-a136-d5248f0bce26/) to see the tracer events