### PR TITLE
Report SFU WebSocket connection and join timeouts accurately

### DIFF
--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -12038,6 +12038,7 @@ public final class io/getstream/video/android/core/errors/VideoErrorCode : java/
 	public static final field NETWORK_FAILED Lio/getstream/video/android/core/errors/VideoErrorCode;
 	public static final field NO_ERROR_BODY Lio/getstream/video/android/core/errors/VideoErrorCode;
 	public static final field PARSER_ERROR Lio/getstream/video/android/core/errors/VideoErrorCode;
+	public static final field SFU_JOIN_RESPONSE_TIMEOUT Lio/getstream/video/android/core/errors/VideoErrorCode;
 	public static final field SOCKET_CLOSED Lio/getstream/video/android/core/errors/VideoErrorCode;
 	public static final field SOCKET_FAILURE Lio/getstream/video/android/core/errors/VideoErrorCode;
 	public static final field TOKEN_DATE_INCORRECT Lio/getstream/video/android/core/errors/VideoErrorCode;
@@ -14408,6 +14409,11 @@ public final class io/getstream/video/android/core/socket/common/StreamWebSocket
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/video/android/core/socket/common/StreamWebSocketEvent$Open : io/getstream/video/android/core/socket/common/StreamWebSocketEvent {
+	public static final field INSTANCE Lio/getstream/video/android/core/socket/common/StreamWebSocketEvent$Open;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/video/android/core/socket/common/StreamWebSocketEvent$SfuMessage : io/getstream/video/android/core/socket/common/StreamWebSocketEvent {
 	public fun <init> (Lio/getstream/video/android/core/events/SfuDataEvent;)V
 	public final fun component1 ()Lio/getstream/video/android/core/events/SfuDataEvent;
@@ -14858,6 +14864,11 @@ public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketSta
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketState$WebSocketConnected : io/getstream/video/android/core/socket/sfu/state/SfuSocketState {
+	public static final field INSTANCE Lio/getstream/video/android/core/socket/sfu/state/SfuSocketState$WebSocketConnected;
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract class io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent {
 }
 
@@ -14932,6 +14943,11 @@ public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketSta
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getError ()Lio/getstream/result/Error$NetworkError;
 	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent$WebSocketConnected : io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent {
+	public static final field INSTANCE Lio/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent$WebSocketConnected;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -14946,8 +14946,8 @@ public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketSta
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent$WebSocketConnected : io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent {
-	public static final field INSTANCE Lio/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent$WebSocketConnected;
+public final class io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent$WebSocketEstablished : io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent {
+	public static final field INSTANCE Lio/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent$WebSocketEstablished;
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -112,6 +112,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -770,22 +771,79 @@ public class Call(
         }
         session.value = localSession
 
+        if (session.value == null) {
+            return Failure(Error.GenericError("RtcSession was null during connection to sfu"))
+        }
+
         session.value?.let {
             state._connection.value = RealtimeConnection.Joined(it)
         }
 
-        when (val result = session.value?.connectInternal()) {
-            is SfuConnectionResult.Connected -> Unit
-            is SfuConnectionResult.Failed ->
-                return Failure(
-                    Error.GenericError(result.error.message ?: "RtcSession error occurred."),
-                )
-            null ->
-                return Failure(Error.GenericError("RtcSession was null during connect"))
+        // This is the SFU ws connection
+        val sfuConnectionResult = session.value!!.connectInternal()
+
+        when (sfuConnectionResult) {
+            is SfuConnectionResult.Success -> Unit
+            is SfuConnectionResult.Failure -> {
+                if (sfuConnectionResult.recoverable) {
+                    logger.w { "[_join] Recoverable SFU connection failure — awaiting reconnect outcome" }
+                    if (!didReconnectSucceed()) {
+                        logger.e { "[_join] Could not recover. Error : $sfuConnectionResult" }
+                        sendJoinErrorAnalytics(sfuConnectionResult)
+                        return Failure(
+                            Error.GenericError(
+                                sfuConnectionResult.error.message ?: "SFU connection failed",
+                            ),
+                        )
+                    }
+                } else {
+                    logger.e {
+                        "[_join] Got non recoverable error while connecting to SFU. Error : $sfuConnectionResult"
+                    }
+                    sendJoinErrorAnalytics(sfuConnectionResult)
+                    return Failure(
+                        Error.GenericError(
+                            sfuConnectionResult.error.message ?: "RtcSession error occurred.",
+                        ),
+                    )
+                }
+            }
         }
         client.state.setActiveCall(this)
         monitorSession(result.value)
         return Success(value = session.value!!)
+    }
+
+    /**
+     * Reports the SFU WebSocket join failure to analytics. Only called from the join
+     * flow ([_join]) so that reconnect-driven [RtcSession.connectInternal] failures are
+     * not counted as join errors. The retry count comes from the session's
+     * [RtcSession.sfuWsRetryCount]; the failure reason and abort code come straight from
+     * the [SfuConnectionResult.Failure] the connect attempt produced.
+     */
+    private fun sendJoinErrorAnalytics(failure: SfuConnectionResult.Failure) {
+        callAnalytics.sfuAnalytics.onSfuWsCompleted(
+            success = false,
+            retryCount = session.value?.sfuWsRetryCount?.get() ?: 0,
+            failureReason = failure.error.message,
+            failureCode = (failure.abortReason ?: AnalyticsCallAbortReason.SFU_ERROR).name,
+        )
+    }
+
+    /**
+     * Suspends until the reconnect loop triggered by a recoverable connection failure
+     * reaches a terminal state, returning `true` if the call recovered (became
+     * [RealtimeConnection.Connected]) and `false` otherwise
+     * ([RealtimeConnection.ReconnectingFailed] / [RealtimeConnection.Disconnected]).
+     */
+    private suspend fun didReconnectSucceed(): Boolean {
+        val terminal = state.connection.first {
+            it is RealtimeConnection.Connected ||
+                it is RealtimeConnection.ReconnectingFailed ||
+                it is RealtimeConnection.Disconnected
+        }
+        logger.d { "[_join] Reconnect after recoverable connection failure settled on $terminal" }
+        return terminal is RealtimeConnection.Connected
     }
 
     private fun Call.monitorSession(result: JoinCallResponse) {
@@ -1207,15 +1265,14 @@ public class Call(
             val result = newSession.connectInternal(
                 reconnectDetails,
                 currentOptions,
-                JoinAnalyticsModel(joinAnalyticsModel.retryAttempt),
             )
         ) {
-            is SfuConnectionResult.Connected -> {
+            is SfuConnectionResult.Success -> {
                 newSession.sfuTracer.trace("rejoin", reason)
                 monitorSession(joinResponse.value)
                 ReconnectOutcome.Success
             }
-            is SfuConnectionResult.Failed -> ReconnectOutcome.Failed(result.error)
+            is SfuConnectionResult.Failure -> ReconnectOutcome.Failed(result.error)
         }
     }
 
@@ -1291,14 +1348,13 @@ public class Call(
             val result = newSession.connectInternal(
                 reconnectDetails,
                 currentOptions,
-                JoinAnalyticsModel(joinAnalyticsModel.retryAttempt),
             )
             when (result) {
-                is SfuConnectionResult.Connected -> {
+                is SfuConnectionResult.Success -> {
                     monitorSession(joinResponse.value)
                     ReconnectOutcome.Success
                 }
-                is SfuConnectionResult.Failed -> ReconnectOutcome.Failed(result.error)
+                is SfuConnectionResult.Failure -> ReconnectOutcome.Failed(result.error)
             }
         } finally {
             oldSession.finalizeMigration()
@@ -2218,8 +2274,9 @@ public class Call(
     companion object {
         /** How many consecutive FAST reconnect failures are allowed before
          *  escalating to a full REJOIN. Kept small because each failed FAST
-         *  attempt can cost up to DEFAULT_SOCKET_TIMEOUT (10 s) waiting for
-         *  the WebSocket handshake to time out. */
+         *  attempt can cost up to the socket connection deadline before it gives
+         *  up: OkHttp's WebSocket-upgrade timeout, followed by the join-response
+         *  wait — both driven by StreamVideoBuilder.connectionTimeoutInMs (default 10s). */
         private const val MAX_FAST_RECONNECT_ATTEMPTS = 3
 
         /** Absolute upper bound on loop iterations across all strategies

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -2271,7 +2271,7 @@ public class Call(
          *  escalating to a full REJOIN. Kept small because each failed FAST
          *  attempt can cost up to the socket connection deadline before it gives
          *  up: OkHttp's WebSocket-upgrade timeout, followed by the join-response
-         *  wait — both driven by StreamVideoBuilder.connectionTimeoutInMs (default 10s). */
+         *  wait — both driven by StreamVideoBuilder.connectionTimeoutInMs. */
         private const val MAX_FAST_RECONNECT_ATTEMPTS = 3
 
         /** Absolute upper bound on loop iterations across all strategies

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -805,7 +805,14 @@ public class Call(
         }
         val connectedSession = session.value ?: return Failure(Error.GenericError("RtcSession was cleared during connection to sfu"))
         client.state.setActiveCall(this)
-        monitorSession(result.value)
+        // rejoin/migrate recovery swaps in a NEW session and already calls monitorSession()
+        // with the recovered join response. fastReconnect recovery — and the normal success
+        // path — keep the original session, which is not monitored anywhere else. Only
+        // (re)establish monitoring when the session is unchanged, using the response that
+        // still matches it, so we neither double-register nor monitor with a stale response.
+        if (connectedSession === localSession) {
+            monitorSession(result.value)
+        }
         return Success(value = connectedSession)
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -771,16 +771,10 @@ public class Call(
         }
         session.value = localSession
 
-        if (session.value == null) {
-            return Failure(Error.GenericError("RtcSession was null during connection to sfu"))
-        }
-
-        session.value?.let {
-            state._connection.value = RealtimeConnection.Joined(it)
-        }
+        state._connection.value = RealtimeConnection.Joined(localSession)
 
         // This is the SFU ws connection
-        val sfuConnectionResult = session.value!!.connectInternal()
+        val sfuConnectionResult = localSession.connectInternal()
 
         when (sfuConnectionResult) {
             is SfuConnectionResult.Success -> Unit
@@ -809,9 +803,10 @@ public class Call(
                 }
             }
         }
+        val connectedSession = session.value ?: return Failure(Error.GenericError("RtcSession was cleared during connection to sfu"))
         client.state.setActiveCall(this)
         monitorSession(result.value)
-        return Success(value = session.value!!)
+        return Success(value = connectedSession)
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -84,7 +84,10 @@ import java.net.ConnectException
  * @property loggingLevel Represents and wraps SDK logging levels for Stream logger, HTTP interceptor and native WebRTC logging.
  * @property notificationConfig The configurations for handling push notification.
  * @property ringNotification Overwrite the default notification logic for incoming calls.
- * @property connectionTimeoutInMs Connection timeout in seconds.
+ * @property connectionTimeoutInMs Connection timeout in milliseconds. Applies both to the
+ * coordinator/SFU OkHttp clients (HTTP and WebSocket upgrade) and to the SFU join-response
+ * wait (time allowed for the SFU to deliver its JoinCallResponse after the socket opens).
+ * Defaults to 10s.
  * @property ensureSingleInstance Verify that only 1 version of the video client exists. Prevents integration mistakes.
  * @property videoDomain URL overwrite to allow for testing against a local instance of video.
  * @property callServiceConfig Configuration for the call foreground service. See [CallServiceConfig]. (Deprecated) Use `callServiceConfigRegistry` instead.
@@ -127,7 +130,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
     private val loggingLevel: LoggingLevel = LoggingLevel(),
     private val notificationConfig: NotificationConfig = NotificationConfig(),
     private val ringNotification: ((call: Call) -> Notification?)? = null,
-    private val connectionTimeoutInMs: Long = 10_000,
+    private val connectionTimeoutInMs: Long = 5_000,
     private var ensureSingleInstance: Boolean = true,
     private val videoDomain: String = "video.stream-io-api.com",
     @Deprecated(
@@ -297,6 +300,7 @@ public class StreamVideoBuilder @JvmOverloads constructor(
             appName = appName,
             audioProcessing = audioProcessing,
             loggingLevel = loggingLevel,
+            connectionTimeoutInMs = connectionTimeoutInMs,
             leaveAfterDisconnectSeconds = leaveAfterDisconnectSeconds,
             enableCallUpdatesAfterLeave = callUpdatesAfterLeave,
             enableStatsCollection = enableStatsReporting,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoBuilder.kt
@@ -87,7 +87,7 @@ import java.net.ConnectException
  * @property connectionTimeoutInMs Connection timeout in milliseconds. Applies both to the
  * coordinator/SFU OkHttp clients (HTTP and WebSocket upgrade) and to the SFU join-response
  * wait (time allowed for the SFU to deliver its JoinCallResponse after the socket opens).
- * Defaults to 10s.
+ * Defaults to 5s.
  * @property ensureSingleInstance Verify that only 1 version of the video client exists. Prevents integration mistakes.
  * @property videoDomain URL overwrite to allow for testing against a local instance of video.
  * @property callServiceConfig Configuration for the call foreground service. See [CallServiceConfig]. (Deprecated) Use `callServiceConfigRegistry` instead.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -188,6 +188,7 @@ internal class StreamVideoClient internal constructor(
     internal val appName: String? = null,
     internal val audioProcessing: ManagedAudioProcessingFactory? = null,
     internal val loggingLevel: LoggingLevel = LoggingLevel(),
+    internal val connectionTimeoutInMs: Long = 10_000,
     internal val leaveAfterDisconnectSeconds: Long = 30,
     internal val appVersion: String? = null,
     internal val enableCallUpdatesAfterLeave: Boolean = false,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -188,7 +188,7 @@ internal class StreamVideoClient internal constructor(
     internal val appName: String? = null,
     internal val audioProcessing: ManagedAudioProcessingFactory? = null,
     internal val loggingLevel: LoggingLevel = LoggingLevel(),
-    internal val connectionTimeoutInMs: Long = 10_000,
+    internal val connectionTimeoutInMs: Long = 5_000,
     internal val leaveAfterDisconnectSeconds: Long = 30,
     internal val appVersion: String? = null,
     internal val enableCallUpdatesAfterLeave: Boolean = false,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -34,6 +34,7 @@ import io.getstream.android.video.generated.models.OwnCapability
 import io.getstream.android.video.generated.models.VideoEvent
 import io.getstream.log.StreamLog
 import io.getstream.log.taggedLogger
+import io.getstream.result.Error
 import io.getstream.result.Result
 import io.getstream.result.Result.Failure
 import io.getstream.result.Result.Success
@@ -46,7 +47,6 @@ import io.getstream.video.android.core.RealtimeConnection
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
-import io.getstream.video.android.core.analytics.call.observer.model.JoinAnalyticsModel
 import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAbortReason
 import io.getstream.video.android.core.call.connection.Publisher
 import io.getstream.video.android.core.call.connection.StreamPeerConnection
@@ -58,6 +58,7 @@ import io.getstream.video.android.core.call.utils.SessionFatalException
 import io.getstream.video.android.core.call.utils.TrackOverridesHandler
 import io.getstream.video.android.core.call.utils.stringify
 import io.getstream.video.android.core.dispatchers.DispatcherProvider
+import io.getstream.video.android.core.errors.VideoErrorCode
 import io.getstream.video.android.core.events.CallEndedSfuEvent
 import io.getstream.video.android.core.events.ChangePublishOptionsEvent
 import io.getstream.video.android.core.events.ChangePublishQualityEvent
@@ -82,7 +83,6 @@ import io.getstream.video.android.core.model.MediaTrack
 import io.getstream.video.android.core.model.StreamPeerType
 import io.getstream.video.android.core.model.VideoTrack
 import io.getstream.video.android.core.model.toPeerType
-import io.getstream.video.android.core.socket.common.SocketActions
 import io.getstream.video.android.core.socket.common.VideoParser
 import io.getstream.video.android.core.socket.common.parser2.MoshiVideoParser
 import io.getstream.video.android.core.socket.common.token.TokenRepository
@@ -124,7 +124,6 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.json.JSONArray
@@ -164,7 +163,9 @@ import stream.video.sfu.signal.UpdateMuteStatesRequest
 import stream.video.sfu.signal.UpdateMuteStatesResponse
 import stream.video.sfu.signal.UpdateSubscriptionsRequest
 import stream.video.sfu.signal.UpdateSubscriptionsResponse
+import java.net.SocketTimeoutException
 import java.util.Collections
+import java.util.concurrent.atomic.AtomicInteger
 /**
  * Keeps track of which track is being rendered at what resolution.
  * Also stores if the track is visible or not
@@ -182,7 +183,7 @@ data class TrackDimensions(
  * It handles everything webrtc related.
  * State is handled by the call state class
  *
- * @see CallState
+ * @see io.getstream.video.android.core.CallState
  *
  * Audio/video management is done by the MediaManager
  *
@@ -215,8 +216,27 @@ internal class PeerConnectionNotUsableException :
  * connected successfully or the attempt failed.
  */
 internal sealed class SfuConnectionResult {
-    object Connected : SfuConnectionResult()
-    data class Failed(val error: Exception) : SfuConnectionResult()
+    object Success : SfuConnectionResult()
+
+    /**
+     * The connection attempt failed.
+     *
+     * @param recoverable `true` when the terminal socket state is one that
+     * RtcSession's `stateJob` reacts to by triggering `Call.reconnect` (e.g.
+     * a connection timeout or a temporary socket disconnect). In that case the
+     * initial-join flow can defer to that recovery loop and await its outcome
+     * instead of treating the failure as permanent. `false` for terminal
+     * failures with no recovery (auth errors, permanent disconnects, etc.).
+     * @param abortReason the analytics abort reason derived from the disconnect
+     * state's error code, or `null` when the terminal state carried no error.
+     * The caller (the join flow) decides whether/when to report it, so that
+     * analytics are not emitted for reconnect-driven `connectInternal` calls.
+     */
+    data class Failure(
+        val error: Exception,
+        val recoverable: Boolean = false,
+        val abortReason: AnalyticsCallAbortReason? = null,
+    ) : SfuConnectionResult()
 }
 
 /**
@@ -268,7 +288,7 @@ public class RtcSession internal constructor(
             apiKey = apiKey,
             apiUrl = sfuUrl,
             wssUrl = sfuWsUrl,
-            connectionTimeoutInMs = 2000L,
+            connectionTimeoutInMs = clientImpl.connectionTimeoutInMs,
             lifecycle = lifecycle,
             onSfuApiError = { error ->
                 if (call.state.connection.value is RealtimeConnection.Disconnected) return@SfuConnectionModule
@@ -302,6 +322,14 @@ public class RtcSession internal constructor(
 ) {
     private var muteStateSyncJob: Job? = null
     private val oneBasedSessionCounter = sessionCounter + 1
+
+    /**
+     * Number of SFU WebSocket *retries* for this session. Starts at 0 and stays there
+     * for the initial connect; incremented only on reconnection attempts (any
+     * [connectInternal] call carrying [ReconnectDetails]). Reset to 0 once the socket
+     * reaches [SfuSocketState.Connected].
+     */
+    internal val sfuWsRetryCount = AtomicInteger(0)
 
     private var stateJob: Job? = null
     private var eventJob: Job? = null
@@ -689,6 +717,8 @@ public class RtcSession internal constructor(
                 _sfuSfuSocketState.value = sfuSocketState
                 when (sfuSocketState) {
                     is SfuSocketState.Connected -> {
+                        // Capture how many retries it took, then reset for the next cycle.
+                        val retryCount = sfuWsRetryCount.getAndSet(0)
                         call.state._connection.value =
                             RealtimeConnection.Connected
                         call.onSfuConnectionEstablished()
@@ -699,9 +729,10 @@ public class RtcSession internal constructor(
                         pendingTrickleEvents.forEach {
                             sendIceCandidate(it.first, it.second)
                         }
+                        // Success scenario analytics
                         call.callAnalytics.sfuAnalytics.onSfuWsCompleted(
                             success = true,
-                            retryCount = 0,
+                            retryCount = retryCount,
                         )
                     }
 
@@ -715,6 +746,8 @@ public class RtcSession internal constructor(
                     }
 
                     is SfuSocketState.Disconnected.DisconnectedTemporarily -> {
+                        // Covers generic socket drops and connection timeouts alike — the
+                        // carried error holds the exact code/reason, so no per-type branching.
                         val strategy = sfuSocketState.reconnectStrategy
                         val reason = "SFU:${sfuSocketState.error.message}:$strategy"
                         logger.w { "[stateJob] SFU sent $strategy for $sfuName" }
@@ -874,8 +907,8 @@ public class RtcSession internal constructor(
         options: List<PublishOption>? = null,
     ) {
         when (val result = connectInternal(reconnectDetails, options)) {
-            is SfuConnectionResult.Connected -> Unit
-            is SfuConnectionResult.Failed -> throw result.error
+            is SfuConnectionResult.Success -> Unit
+            is SfuConnectionResult.Failure -> throw result.error
         }
     }
 
@@ -887,7 +920,6 @@ public class RtcSession internal constructor(
     internal suspend fun connectInternal(
         reconnectDetails: ReconnectDetails? = null,
         options: List<PublishOption>? = null,
-        joinAnalyticsModel: JoinAnalyticsModel? = null,
     ): SfuConnectionResult {
         logger.i { "[connectInternal] #sfu; #track; reconnect=${reconnectDetails?.strategy}" }
         val request = buildJoinRequest(reconnectDetails, options)
@@ -898,57 +930,87 @@ public class RtcSession internal constructor(
             },
         )
         listenToSfuSocket()
+        // Only reconnection attempts count as retries; the initial connect leaves the count at 0.
+        val retryCount = if (reconnectDetails != null) {
+            sfuWsRetryCount.incrementAndGet()
+        } else {
+            sfuWsRetryCount.get()
+        }
+        logger.d {
+            "[connectInternal] SFU WS connect (retryCount=$retryCount, reconnect=${reconnectDetails?.strategy})"
+        }
         sfuConnectionModule.socketConnection.connect(request)
-        val terminalState = withTimeoutOrNull(SocketActions.DEFAULT_SOCKET_TIMEOUT) {
-            sfuConnectionModule.socketConnection.state().first {
-                it is SfuSocketState.Connected || it is SfuSocketState.Disconnected
-            }
+        val sfuSocketState = sfuConnectionModule.socketConnection.state().first {
+            it is SfuSocketState.Connected || it is SfuSocketState.Disconnected
         }
-        return when (terminalState) {
-            is SfuSocketState.Connected -> {
-                sendConnectionTimeStats(reconnectDetails?.strategy)
-                SfuConnectionResult.Connected
-            }
-            is SfuSocketState.Disconnected -> {
-                val msg = when (terminalState) {
-                    is SfuSocketState.Disconnected.DisconnectedTemporarily ->
-                        "SFU socket disconnected: ${terminalState.error.message}"
-                    is SfuSocketState.Disconnected.DisconnectedPermanently ->
-                        "SFU socket permanently disconnected: ${terminalState.error.message}"
-                    else -> "SFU socket disconnected"
-                }
-                logger.w { "[connectInternal] $msg" }
-                sfuTracer.trace("connect-failed", msg)
-                sendCallStats()
-                when (terminalState) {
-                    is SfuSocketState.Disconnected.DisconnectedTemporarily,
-                    is SfuSocketState.Disconnected.DisconnectedPermanently,
-                    -> {
-                        call.callAnalytics.sfuAnalytics.onSfuWsCompleted(
-                            success = false,
-                            retryCount = joinAnalyticsModel?.retryAttempt ?: 0,
-                            failureReason = msg,
-                            failureCode = AnalyticsCallAbortReason.SFU_ERROR.name,
-                        )
-                    }
-
-                    else -> {}
-                }
-
-                SfuConnectionResult.Failed(Exception(msg))
-            }
-            else -> {
-                sfuTracer.trace("connect-failed", "Connection timed out")
-                sendCallStats()
-                call.callAnalytics.sfuAnalytics.onSfuWsCompleted(
-                    success = false,
-                    retryCount = joinAnalyticsModel?.retryAttempt ?: 0,
-                    failureReason = "SFU connection timed out",
-                    failureCode = AnalyticsCallAbortReason.REQUEST_TIMEOUT.name,
-                )
-                SfuConnectionResult.Failed(Exception("SFU connection timed out"))
-            }
+        return if (sfuSocketState is SfuSocketState.Connected) {
+            sendConnectionTimeStats(reconnectDetails?.strategy)
+            sfuTracer.trace("sfu-connected", sfuName)
+            SfuConnectionResult.Success
+        } else {
+            // Single source of truth: the disconnect state's NetworkError carries the exact
+            // code + reason. We surface the derived message + analytics abort reason on the
+            // result but do NOT report analytics here — connectInternal also runs during
+            // reconnect, and join-error analytics must only be emitted from the join flow.
+            val networkError = (sfuSocketState as? SfuSocketState.Disconnected)?.networkErrorOrNull()
+            val msg = networkError?.message ?: "SFU socket disconnected"
+            logger.w { "[connectInternal] $msg" }
+            sfuTracer.trace("connect-failed", msg)
+            sendCallStats()
+            SfuConnectionResult.Failure(
+                error = Exception(msg),
+                recoverable = (sfuSocketState as? SfuSocketState.Disconnected)?.triggersReconnect() ?: false,
+                abortReason = networkError?.toAbortReason(),
+            )
         }
+    }
+
+    /**
+     * Whether [stateJob] reacts to this disconnect by launching a [Call.reconnect].
+     * Used by the initial-join flow to decide whether to await the recovery loop
+     * instead of failing permanently.
+     *
+     * MUST mirror the reconnect-triggering branches in [stateJob]; the exhaustive
+     * `when` (no `else`) makes a new [SfuSocketState.Disconnected] subtype a compile
+     * error here, forcing both sites to stay in sync.
+     */
+    private fun SfuSocketState.Disconnected.triggersReconnect(): Boolean = when (this) {
+        is SfuSocketState.Disconnected.DisconnectedTemporarily,
+        is SfuSocketState.Disconnected.WebSocketEventLost,
+        -> true
+
+        is SfuSocketState.Disconnected.DisconnectedByRequest,
+        is SfuSocketState.Disconnected.DisconnectedPermanently,
+        is SfuSocketState.Disconnected.NetworkDisconnected,
+        is SfuSocketState.Disconnected.Rejoin,
+        is SfuSocketState.Disconnected.Stopped,
+        -> false
+    }
+
+    /**
+     * Extracts the [Error.NetworkError] carried by a disconnect state, if any.
+     * Only [SfuSocketState.Disconnected.DisconnectedTemporarily] and
+     * [SfuSocketState.Disconnected.DisconnectedPermanently] carry one.
+     */
+    private fun SfuSocketState.Disconnected.networkErrorOrNull(): Error.NetworkError? = when (this) {
+        is SfuSocketState.Disconnected.DisconnectedTemporarily -> error
+        is SfuSocketState.Disconnected.DisconnectedPermanently -> error
+        else -> null
+    }
+
+    /**
+     * Maps a disconnect [Error.NetworkError] to the analytics abort reason. Both flavours of
+     * timeout report [AnalyticsCallAbortReason.REQUEST_TIMEOUT]:
+     *  - a missing JoinResponse after the socket opened (tagged [VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT]), and
+     *  - a transport connect/read timeout, detected via its [java.net.SocketTimeoutException] cause
+     *    (type check, not message matching).
+     * Everything else is attributed to [AnalyticsCallAbortReason.SFU_ERROR].
+     */
+    private fun Error.NetworkError.toAbortReason(): AnalyticsCallAbortReason = when {
+        serverErrorCode == VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT.code ->
+            AnalyticsCallAbortReason.REQUEST_TIMEOUT
+        cause is SocketTimeoutException -> AnalyticsCallAbortReason.REQUEST_TIMEOUT
+        else -> AnalyticsCallAbortReason.SFU_ERROR
     }
 
     private suspend fun buildJoinRequest(
@@ -1868,7 +1930,7 @@ public class RtcSession internal constructor(
     // share what size and which participants we're looking at
     suspend fun requestSubscriberIceRestart(): Result<ICERestartResponse> =
         subscriber.value?.restartIce() ?: Failure(
-            io.getstream.result.Error.ThrowableError(
+            Error.ThrowableError(
                 "Subscriber is null",
                 Exception("Subscriber is null"),
             ),
@@ -1920,7 +1982,7 @@ public class RtcSession internal constructor(
         return Triple(previousSessionId, currentSubscriptions, publisherTracks)
     }
 
-    internal suspend fun fastReconnect(reconnectDetails: ReconnectDetails?, joinAnalyticsModel: JoinAnalyticsModel? = null): FastReconnectResult {
+    internal suspend fun fastReconnect(reconnectDetails: ReconnectDetails?): FastReconnectResult {
         logger.d { "[fastReconnect] Starting fast reconnect." }
         sfuTracer.trace("fastReconnect", reconnectDetails.toString())
         val (_, _, publisherTracks) = currentSfuInfo()
@@ -1929,9 +1991,8 @@ public class RtcSession internal constructor(
         val connectResult = connectInternal(
             reconnectDetails,
             publisher.value?.currentOptions(),
-            joinAnalyticsModel,
         )
-        if (connectResult is SfuConnectionResult.Failed) {
+        if (connectResult is SfuConnectionResult.Failure) {
             return FastReconnectResult.Failed(connectResult.error)
         }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -959,7 +959,7 @@ public class RtcSession internal constructor(
             sendCallStats()
             SfuConnectionResult.Failure(
                 error = Exception(msg),
-                recoverable = (sfuSocketState as? SfuSocketState.Disconnected)?.triggersReconnect() ?: false,
+                recoverable = (sfuSocketState as? SfuSocketState.Disconnected)?.canTriggersReconnect() ?: false,
                 abortReason = networkError?.toAbortReason(),
             )
         }
@@ -974,7 +974,7 @@ public class RtcSession internal constructor(
      * `when` (no `else`) makes a new [SfuSocketState.Disconnected] subtype a compile
      * error here, forcing both sites to stay in sync.
      */
-    private fun SfuSocketState.Disconnected.triggersReconnect(): Boolean = when (this) {
+    private fun SfuSocketState.Disconnected.canTriggersReconnect(): Boolean = when (this) {
         is SfuSocketState.Disconnected.DisconnectedTemporarily,
         is SfuSocketState.Disconnected.WebSocketEventLost,
         -> true

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -163,6 +163,7 @@ import stream.video.sfu.signal.UpdateMuteStatesRequest
 import stream.video.sfu.signal.UpdateMuteStatesResponse
 import stream.video.sfu.signal.UpdateSubscriptionsRequest
 import stream.video.sfu.signal.UpdateSubscriptionsResponse
+import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
 import java.util.Collections
 import java.util.concurrent.atomic.AtomicInteger
@@ -1002,15 +1003,21 @@ public class RtcSession internal constructor(
      * Maps a disconnect [Error.NetworkError] to the analytics abort reason. Both flavours of
      * timeout report [AnalyticsCallAbortReason.REQUEST_TIMEOUT]:
      *  - a missing JoinResponse after the socket opened (tagged [VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT]), and
-     *  - a transport connect/read timeout, detected via its [java.net.SocketTimeoutException] cause
-     *    (type check, not message matching).
+     *  - a transport connect/read timeout: [java.net.SocketTimeoutException], or a bare
+     *    [java.io.InterruptedIOException] with message "timeout" (OkHttp connect/call timeout).
      * Everything else is attributed to [AnalyticsCallAbortReason.SFU_ERROR].
      */
     private fun Error.NetworkError.toAbortReason(): AnalyticsCallAbortReason = when {
         serverErrorCode == VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT.code ->
             AnalyticsCallAbortReason.REQUEST_TIMEOUT
-        cause is SocketTimeoutException -> AnalyticsCallAbortReason.REQUEST_TIMEOUT
+        cause.isTransportTimeout() -> AnalyticsCallAbortReason.REQUEST_TIMEOUT
         else -> AnalyticsCallAbortReason.SFU_ERROR
+    }
+
+    private fun Throwable?.isTransportTimeout(): Boolean = when (this) {
+        is SocketTimeoutException -> true
+        is InterruptedIOException -> message?.contains("timeout", ignoreCase = true) == true
+        else -> false
     }
 
     private suspend fun buildJoinRequest(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -124,6 +124,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.json.JSONArray
@@ -941,8 +942,23 @@ public class RtcSession internal constructor(
             "[connectInternal] SFU WS connect (retryCount=$retryCount, reconnect=${reconnectDetails?.strategy})"
         }
         sfuConnectionModule.socketConnection.connect(request)
-        val sfuSocketState = sfuConnectionModule.socketConnection.state().first {
-            it is SfuSocketState.Connected || it is SfuSocketState.Disconnected
+        val connectTimeoutMs = connectInternalSafetyTimeoutMs()
+        val sfuSocketState = withTimeoutOrNull(connectTimeoutMs) {
+            sfuConnectionModule.socketConnection.state().first {
+                it is SfuSocketState.Connected || it is SfuSocketState.Disconnected
+            }
+        }
+        if (sfuSocketState == null) {
+            val msg =
+                "SFU connection timed out waiting for socket state (${connectTimeoutMs}ms)"
+            logger.w { "[connectInternal] $msg" }
+            sfuTracer.trace("connect-failed", msg)
+            sendCallStats()
+            return SfuConnectionResult.Failure(
+                error = Exception(msg),
+                recoverable = true,
+                abortReason = AnalyticsCallAbortReason.REQUEST_TIMEOUT,
+            )
         }
         return if (sfuSocketState is SfuSocketState.Connected) {
             sendConnectionTimeStats(reconnectDetails?.strategy)
@@ -2129,5 +2145,18 @@ public class RtcSession internal constructor(
         sfuTracer.trace("leave-session", reason)
         val request = SfuRequest(leave_call_request = leaveCallRequest)
         sfuConnectionModule.socketConnection.sendEvent(SfuDataRequest(request))
+    }
+
+    /**
+     * Upper bound for [connectInternal] waiting on a terminal [SfuSocketState]. The socket
+     * layer already bounds the HTTP→WS upgrade (OkHttp) and the post-open join-response
+     * wait separately, each by [StreamVideoClient.connectionTimeoutInMs]; this adds
+     * headroom so [connectInternal] still returns if those timers never fire.
+     */
+    private fun connectInternalSafetyTimeoutMs(): Long =
+        clientImpl.connectionTimeoutInMs * 2 + CONNECT_INTERNAL_SAFETY_GRACE_MS
+
+    private companion object {
+        private const val CONNECT_INTERNAL_SAFETY_GRACE_MS = 1_000L
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/errors/VideoErrorCode.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/errors/VideoErrorCode.kt
@@ -28,6 +28,7 @@ private const val INVALID_TOKEN_ERROR_CODE = 1006
 private const val UNDEFINED_TOKEN_ERROR_CODE = 1007
 private const val UNABLE_TO_PARSE_SOCKET_EVENT_ERROR_CODE = 1008
 private const val NO_ERROR_BODY_ERROR_CODE = 1009
+private const val SFU_JOIN_RESPONSE_TIMEOUT_ERROR_CODE = 1011
 private const val VALIDATION_ERROR_ERROR_CODE = 4
 private const val AUTHENTICATION_ERROR_CODE = 5
 private const val TOKEN_EXPIRED_ERROR_CODE = 40
@@ -61,6 +62,10 @@ public enum class VideoErrorCode(public val code: Int, public val description: S
         "Socket event payload either invalid or null",
     ),
     NO_ERROR_BODY(NO_ERROR_BODY_ERROR_CODE, "No error body. See http status code"),
+    SFU_JOIN_RESPONSE_TIMEOUT(
+        SFU_JOIN_RESPONSE_TIMEOUT_ERROR_CODE,
+        "SFU connection timed out: no JoinCallResponse after the WebSocket opened",
+    ),
 
     // server error codes
     VALIDATION_ERROR(VALIDATION_ERROR_ERROR_CODE, "Validation error, check your credentials"),

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuConnectionModule.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuConnectionModule.kt
@@ -58,8 +58,8 @@ internal class SfuConnectionModule(
             .baseUrl("$apiUrl/").build()
     }
     private fun buildSfuOkHttpClient(): OkHttpClient {
-        val connectionTimeoutInMs = 10000L
-        // create a new OkHTTP client and set timeouts
+        // create a new OkHTTP client and set timeouts (driven by the builder's
+        // connectionTimeoutInMs; bounds the HTTP→WS upgrade among other things)
         val authInterceptor = CoordinatorAuthInterceptor(apiKey, tokenRepository)
         return OkHttpClient.Builder().addInterceptor(authInterceptor).addInterceptor(
             HttpLoggingInterceptor().apply {
@@ -99,6 +99,7 @@ internal class SfuConnectionModule(
         networkStateProvider = networkStateProvider,
         tokenRepository = tokenRepository,
         sfuAnalytics = sfuAnalytics,
+        joinResponseTimeoutMs = connectionTimeoutInMs,
     )
     override val socketConnection: SfuSocketConnection = _internalSocketConnection
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/common/StreamWebSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/common/StreamWebSocket.kt
@@ -46,6 +46,8 @@ internal class StreamWebSocket<V, T : GenericParser<V>>(
 
         override fun onOpen(webSocket: WebSocket, response: Response) {
             super.onOpen(webSocket, response)
+            logger.v { "[onOpen] transport WebSocket opened" }
+            eventFlow.tryEmit(StreamWebSocketEvent.Open)
         }
 
         override fun onMessage(webSocket: WebSocket, bytes: ByteString) {
@@ -67,10 +69,17 @@ internal class StreamWebSocket<V, T : GenericParser<V>>(
         }
 
         override fun onFailure(webSocket: WebSocket, t: Throwable, response: Response?) {
+            // Surface the real transport failure (e.g. "Failed to connect to /1.2.3.4:443",
+            // "timeout", SSL handshake errors)
+            // When the WS upgrade failed on an HTTP response (non-101, e.g. 401/429/5xx),
+            // OkHttp hands us that response — use its real status code; otherwise (pure
+            // transport failure) there is no HTTP response so we fall back to unknown.
             eventFlow.tryEmit(
                 StreamWebSocketEvent.Error(
-                    Error.NetworkError.fromVideoErrorCode(
-                        videoErrorCode = VideoErrorCode.SOCKET_FAILURE,
+                    Error.NetworkError(
+                        message = t.message ?: t.javaClass.simpleName,
+                        serverErrorCode = VideoErrorCode.SOCKET_FAILURE.code,
+                        statusCode = response?.code ?: Error.NetworkError.UNKNOWN_STATUS_CODE,
                         cause = t,
                     ),
                 ),

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/common/StreamWebSocketEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/common/StreamWebSocketEvent.kt
@@ -22,6 +22,13 @@ import io.getstream.video.android.core.events.SfuDataEvent
 import stream.video.sfu.models.WebsocketReconnectStrategy
 
 public sealed class StreamWebSocketEvent {
+    /**
+     * The underlying transport WebSocket connection has been opened (the HTTP→WS
+     * upgrade completed). Note this is distinct from the application-level
+     * "connected" signal, which only happens once the server delivers its
+     * handshake response (e.g. SFU [SfuDataEvent]/JoinResponse).
+     */
+    object Open : StreamWebSocketEvent() { override fun toString(): String = "Open" }
     data class Error(
         val streamError: io.getstream.result.Error,
         val reconnectStrategy: WebsocketReconnectStrategy? = null,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/coordinator/CoordinatorSocket.kt
@@ -115,6 +115,12 @@ internal open class CoordinatorSocket(
 
                         socketListenerJob = listen().onEach {
                             when (it) {
+                                is StreamWebSocketEvent.Open -> {
+                                    // Coordinator connection is considered established only
+                                    // once the ConnectedEvent arrives (a VideoMessage), so the
+                                    // raw transport-open signal is informational here.
+                                    logger.v { "[onSocketEvent] coordinator transport WS opened" }
+                                }
                                 is StreamWebSocketEvent.Error -> handleError(it)
                                 is StreamWebSocketEvent.VideoMessage -> when (
                                     val event =

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
@@ -146,7 +146,7 @@ internal open class SfuSocket(
                             socketListenerJob = listen().onEach {
                                 when (it) {
                                     is StreamWebSocketEvent.Open ->
-                                        sfuSocketStateService.onWebSocketConnected()
+                                        sfuSocketStateService.onWebSocketEstablished()
                                     is StreamWebSocketEvent.Error -> handleError(it)
                                     is StreamWebSocketEvent.SfuMessage -> when (
                                         val event =

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocket.kt
@@ -52,6 +52,7 @@ import io.getstream.video.android.core.utils.suspendDebugOnly
 import io.getstream.video.android.model.ApiKey
 import io.getstream.video.android.model.User
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
@@ -74,6 +75,12 @@ internal open class SfuSocket(
     private val lifecycleObserver: StreamLifecycleObserver,
     private val networkStateProvider: NetworkStateProvider,
     private val sfuAnalytics: SfuAnalytics,
+    /**
+     * Deadline (ms) for the SFU to deliver its JoinCallResponse after the transport
+     * WebSocket has opened. See [startJoinResponseTimeout]. Defaults to
+     * [DEFAULT_JOIN_RESPONSE_TIMEOUT_MS].
+     */
+    private val joinResponseTimeoutMs: Long = DEFAULT_JOIN_RESPONSE_TIMEOUT_MS,
 ) {
     private var streamWebSocket: StreamWebSocket<SfuDataRequest, SfuParser>? = null
     open val logger by taggedLogger(TAG)
@@ -83,6 +90,17 @@ internal open class SfuSocket(
     private val sfuSocketStateService = SfuSocketStateService()
     private var socketStateObserverJob: Job? = null
     private var socketListenerJob: Job? = null
+
+    /**
+     * Bounds how long the socket may stay in [SfuSocketState.WebSocketConnected]
+     * (transport open) waiting for the SFU's [JoinCallResponseEvent]. OkHttp already
+     * bounds the preceding [SfuSocketState.Connecting] (HTTP→WS upgrade) phase via its
+     * connect timeout, but once the socket is upgraded OkHttp no longer applies a
+     * timeout, so a silent SFU could otherwise leave us waiting forever. When this fires
+     * we surface a retryable [SfuSocketState.Disconnected.DisconnectedTemporarily] so the
+     * regular recovery path can take over instead of hanging.
+     */
+    private var joinResponseTimeoutJob: Job? = null
     private val healthMonitor = HealthMonitor(
         monitorInterval = 5000L,
         noEventIntervalThreshold = 15000L,
@@ -127,6 +145,8 @@ internal open class SfuSocket(
 
                             socketListenerJob = listen().onEach {
                                 when (it) {
+                                    is StreamWebSocketEvent.Open ->
+                                        sfuSocketStateService.onWebSocketConnected()
                                     is StreamWebSocketEvent.Error -> handleError(it)
                                     is StreamWebSocketEvent.SfuMessage -> when (
                                         val event =
@@ -153,6 +173,7 @@ internal open class SfuSocket(
                 logger.i { "[onSocketStateChanged] state: $state" }
                 when (state) {
                     is SfuSocketState.Connected -> {
+                        cancelJoinResponseTimeout()
                         healthMonitor.ack()
                         callListeners { listener -> listener.onConnected(state.event) }
                     }
@@ -162,11 +183,18 @@ internal open class SfuSocket(
                         callListeners { listener -> listener.onConnecting() }
                     }
 
+                    is SfuSocketState.WebSocketConnected -> {
+                        // Transport socket is open; now bound the wait for the SFU's
+                        // JoinCallResponse with a dedicated, shorter timer.
+                        startJoinResponseTimeout()
+                    }
+
                     is SfuSocketState.RestartConnection -> {
                         logger.w { "[onSocketStateChanged] RestartConnection is deprecated and no longer acted upon" }
                     }
 
                     is SfuSocketState.Disconnected -> {
+                        cancelJoinResponseTimeout()
                         when (state) {
                             is SfuSocketState.Disconnected.DisconnectedByRequest -> {
                                 streamWebSocket?.close(
@@ -224,6 +252,34 @@ internal open class SfuSocket(
         }
     }
 
+    /**
+     * Starts (or restarts) the join-response timeout once the transport WebSocket is
+     * open. If no [JoinCallResponseEvent] arrives within [joinResponseTimeoutMs] we
+     * push a retryable network error tagged with
+     * [VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT] so the connection resolves to
+     * [SfuSocketState.Disconnected.DisconnectedTemporarily] (carrying the precise
+     * code/reason) instead of hanging.
+     */
+    private fun startJoinResponseTimeout() {
+        joinResponseTimeoutJob?.cancel()
+        joinResponseTimeoutJob = userScope.launch {
+            delay(joinResponseTimeoutMs)
+            logger.w {
+                "[joinResponseTimeout] No JoinCallResponse within ${joinResponseTimeoutMs}ms " +
+                    "after the WebSocket opened; failing the connection attempt so recovery can take over"
+            }
+            sfuSocketStateService.onNetworkError(
+                Error.NetworkError.fromVideoErrorCode(VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT),
+                WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,
+            )
+        }
+    }
+
+    private fun cancelJoinResponseTimeout() {
+        joinResponseTimeoutJob?.cancel()
+        joinResponseTimeoutJob = null
+    }
+
     suspend fun connect(joinRequest: JoinRequest) {
         logger.d { "[connect] request: ${joinRequest.client_details}" }
         socketListenerJob?.cancel()
@@ -273,12 +329,12 @@ internal open class SfuSocket(
     private suspend fun handleError(error: StreamWebSocketEvent.Error) {
         logger.e { "[handleError] error: $error" }
         when (error.streamError) {
-            is Error.NetworkError -> onVideoNetworkError(error.streamError, error.reconnectStrategy)
+            is Error.NetworkError -> onNetworkError(error.streamError, error.reconnectStrategy)
             else -> callListeners { it.onError(error) }
         }
     }
 
-    private suspend fun onVideoNetworkError(
+    private suspend fun onNetworkError(
         error: Error.NetworkError,
         reconnectStrategy: WebsocketReconnectStrategy?,
     ) {
@@ -299,11 +355,16 @@ internal open class SfuSocket(
                 sfuSocketStateService.onUnrecoverableError(error)
             }
 
-            else -> sfuSocketStateService.onNetworkError(
-                error,
-                reconnectStrategy
-                    ?: WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_UNSPECIFIED,
-            )
+            else -> {
+                // Recoverable network errors. The error already carries the exact code + reason
+                // (the transport failure message is populated from the OkHttp throwable), so it
+                // resolves as-is to a single DisconnectedTemporarily state.
+                sfuSocketStateService.onNetworkError(
+                    error,
+                    reconnectStrategy
+                        ?: WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_UNSPECIFIED,
+                )
+            }
         }
     }
 
@@ -442,5 +503,14 @@ internal open class SfuSocket(
     companion object {
         private const val TAG = "Video:SfuSocket"
         private const val DEFAULT_CONNECTION_TIMEOUT = 2000L
+
+        /**
+         * Fallback deadline for the SFU to deliver its JoinCallResponse *after* the
+         * transport WebSocket has opened, used when no value is supplied. In production
+         * this is driven by StreamVideoBuilder.connectionTimeoutInMs (same value as the
+         * OkHttp connect timeout). The WS upgrade is bounded separately by OkHttp; this
+         * only bounds the post-open handshake wait that OkHttp does not cover.
+         */
+        private const val DEFAULT_JOIN_RESPONSE_TIMEOUT_MS = 5_000L
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketConnection.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketConnection.kt
@@ -67,6 +67,11 @@ class SfuSocketConnection internal constructor(
     private val tokenProvider: TokenProvider,
     private val tokenRepository: TokenRepository,
     private val sfuAnalytics: SfuAnalytics,
+    /**
+     * Deadline (ms) for the SFU to deliver its JoinCallResponse after the transport
+     * WebSocket has opened. Defaults to [DEFAULT_SFU_SOCKET_TIMEOUT].
+     */
+    private val joinResponseTimeoutMs: Long = DEFAULT_SFU_SOCKET_TIMEOUT,
 ) : SocketListener<SfuDataEvent, JoinCallResponseEvent>(),
     SocketActions<SfuDataRequest, SfuDataEvent, StreamWebSocketEvent.Error, SfuSocketState, SfuToken, JoinRequest> {
 
@@ -112,6 +117,7 @@ class SfuSocketConnection internal constructor(
         networkStateProvider = networkStateProvider,
         userScope = scope as? UserScope ?: UserScope(ClientScope()),
         sfuAnalytics = sfuAnalytics,
+        joinResponseTimeoutMs = joinResponseTimeoutMs,
     ).also {
         it.addListener(this)
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateService.kt
@@ -64,9 +64,9 @@ internal class SfuSocketStateService(initialState: SfuSocketState = SfuSocketSta
      * Notify that the transport WebSocket has opened, but before the SFU
      * JoinCallResponse has been received.
      */
-    suspend fun onWebSocketConnected() {
-        logger.v { "[onWebSocketConnected] no args" }
-        stateMachine.sendEvent(SfuSocketStateEvent.WebSocketConnected)
+    suspend fun onWebSocketEstablished() {
+        logger.v { "[onWebSocketEstablished] no args" }
+        stateMachine.sendEvent(SfuSocketStateEvent.WebSocketEstablished)
     }
 
     /**
@@ -173,7 +173,7 @@ internal class SfuSocketStateService(initialState: SfuSocketState = SfuSocketSta
                 onEvent<SfuSocketStateEvent.Connect> {
                     SfuSocketState.Connecting(it.connectionConf, it.connectionType)
                 }
-                onEvent<SfuSocketStateEvent.WebSocketConnected> { SfuSocketState.WebSocketConnected }
+                onEvent<SfuSocketStateEvent.WebSocketEstablished> { SfuSocketState.WebSocketConnected }
                 onEvent<SfuSocketStateEvent.ConnectionEstablished> {
                     SfuSocketState.Connected(
                         it.connectedEvent,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateService.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateService.kt
@@ -61,6 +61,15 @@ internal class SfuSocketStateService(initialState: SfuSocketState = SfuSocketSta
     }
 
     /**
+     * Notify that the transport WebSocket has opened, but before the SFU
+     * JoinCallResponse has been received.
+     */
+    suspend fun onWebSocketConnected() {
+        logger.v { "[onWebSocketConnected] no args" }
+        stateMachine.sendEvent(SfuSocketStateEvent.WebSocketConnected)
+    }
+
+    /**
      * Notify the WebSocket connection has been established.
      *
      * @param connectedEvent The [ConnectedEvent] received within the WebSocket connection.
@@ -161,6 +170,35 @@ internal class SfuSocketStateService(initialState: SfuSocketState = SfuSocketSta
             }
 
             state<SfuSocketState.Connecting> {
+                onEvent<SfuSocketStateEvent.Connect> {
+                    SfuSocketState.Connecting(it.connectionConf, it.connectionType)
+                }
+                onEvent<SfuSocketStateEvent.WebSocketConnected> { SfuSocketState.WebSocketConnected }
+                onEvent<SfuSocketStateEvent.ConnectionEstablished> {
+                    SfuSocketState.Connected(
+                        it.connectedEvent,
+                    )
+                }
+                onEvent<SfuSocketStateEvent.WebSocketEventLost> { SfuSocketState.Disconnected.WebSocketEventLost }
+                onEvent<SfuSocketStateEvent.NetworkNotAvailable> { SfuSocketState.Disconnected.NetworkDisconnected }
+                onEvent<SfuSocketStateEvent.UnrecoverableError> {
+                    SfuSocketState.Disconnected.DisconnectedPermanently(
+                        it.error,
+                    )
+                }
+                onEvent<SfuSocketStateEvent.NetworkError> {
+                    SfuSocketState.Disconnected.DisconnectedTemporarily(
+                        it.error,
+                        it.reconnectStrategy,
+                    )
+                }
+                onEvent<SfuSocketStateEvent.RequiredDisconnection> {
+                    SfuSocketState.Disconnected.DisconnectedByRequest
+                }
+                onEvent<SfuSocketStateEvent.Stop> { SfuSocketState.Disconnected.Stopped }
+            }
+
+            state<SfuSocketState.WebSocketConnected> {
                 onEvent<SfuSocketStateEvent.Connect> {
                     SfuSocketState.Connecting(it.connectionConf, it.connectionType)
                 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/state/SfuSocketState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/state/SfuSocketState.kt
@@ -44,7 +44,17 @@ public sealed class SfuSocketState {
     ) : SfuSocketState()
 
     /**
-     * State of socket when the connection is established.
+     * State of socket when the transport WebSocket is open (HTTP→WS upgrade done)
+     * but the SFU has not yet delivered its [JoinCallResponseEvent]. This is the
+     * window bounded by the join-response timeout: the OkHttp client bounds the
+     * preceding [Connecting] (upgrade) phase, while this phase is bounded
+     * separately so a slow/silent SFU is detected without hanging.
+     */
+    object WebSocketConnected : SfuSocketState() { override fun toString() = "WebSocketConnected" }
+
+    /**
+     * State of socket when the connection is established (the SFU delivered its
+     * [JoinCallResponseEvent]).
      */
     data class Connected(val event: JoinCallResponseEvent) : SfuSocketState()
 
@@ -76,7 +86,12 @@ public sealed class SfuSocketState {
         object DisconnectedByRequest : Disconnected() { override fun toString() = "Disconnected.ByRequest" }
 
         /**
-         * State of socket when a [Error] happens.
+         * State of socket when a recoverable [Error] happens (a temporary socket
+         * disconnect that should be retried). The carried [error] holds the exact
+         * [Error.NetworkError.serverErrorCode] and message, so failures such as a missing
+         * JoinResponse
+         * (see [io.getstream.video.android.core.errors.VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT])
+         * are attributed precisely without needing a separate state type.
          */
         data class DisconnectedTemporarily(
             val error: Error.NetworkError,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent.kt
@@ -32,6 +32,12 @@ public sealed class SfuSocketStateEvent {
     ) : SfuSocketStateEvent()
 
     /**
+     * Event to notify that the transport WebSocket has opened (HTTP→WS upgrade
+     * completed), but before the SFU JoinCallResponse has been received.
+     */
+    object WebSocketConnected : SfuSocketStateEvent() { override fun toString() = "WebSocketConnected" }
+
+    /**
      * Event to notify the connection was established.
      */
     data class ConnectionEstablished(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/socket/sfu/state/SfuSocketStateEvent.kt
@@ -33,9 +33,11 @@ public sealed class SfuSocketStateEvent {
 
     /**
      * Event to notify that the transport WebSocket has opened (HTTP→WS upgrade
-     * completed), but before the SFU JoinCallResponse has been received.
+     * completed), but before the SFU JoinCallResponse has been received. Mirrors
+     * [ConnectionEstablished]: this drives the socket into
+     * [io.getstream.video.android.core.socket.sfu.state.SfuSocketState.WebSocketConnected].
      */
-    object WebSocketConnected : SfuSocketStateEvent() { override fun toString() = "WebSocketConnected" }
+    object WebSocketEstablished : SfuSocketStateEvent() { override fun toString() = "WebSocketEstablished" }
 
     /**
      * Event to notify the connection was established.

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/FastReconnectIceRestartTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/FastReconnectIceRestartTest.kt
@@ -165,7 +165,7 @@ class FastReconnectIceRestartTest {
         session.publisher.value = pub
         session.subscriber.value = sub
 
-        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Connected
+        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Success
 
         val result = session.fastReconnect(null)
 
@@ -185,7 +185,7 @@ class FastReconnectIceRestartTest {
         session.publisher.value = pub
         session.subscriber.value = sub
 
-        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Connected
+        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Success
 
         val result = session.fastReconnect(null)
 
@@ -204,7 +204,7 @@ class FastReconnectIceRestartTest {
         session.publisher.value = pub
         session.subscriber.value = sub
 
-        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Connected
+        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Success
 
         val result = session.fastReconnect(null)
 
@@ -223,7 +223,7 @@ class FastReconnectIceRestartTest {
         session.publisher.value = pub
         session.subscriber.value = sub
 
-        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Connected
+        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Success
 
         val result = session.fastReconnect(null)
 
@@ -243,7 +243,7 @@ class FastReconnectIceRestartTest {
         session.subscriber.value = sub
 
         val error = Exception("SFU connection timed out")
-        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Failed(error)
+        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Failure(error)
 
         val result = session.fastReconnect(null)
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.rtc
+
+import com.google.common.truth.Truth.assertThat
+import io.getstream.android.video.generated.models.JoinCallResponse
+import io.getstream.result.Result.Failure
+import io.getstream.result.Result.Success
+import io.getstream.video.android.core.Call
+import io.getstream.video.android.core.RealtimeConnection
+import io.getstream.video.android.core.StreamVideo
+import io.getstream.video.android.core.StreamVideoClient
+import io.getstream.video.android.core.analytics.call.observer.model.JoinAnalyticsModel
+import io.getstream.video.android.core.analytics.call.observer.model.JoinReason
+import io.getstream.video.android.core.base.DispatcherRule
+import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectionResult
+import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
+import io.getstream.video.android.core.internal.network.NetworkStateProvider
+import io.getstream.video.android.model.User
+import io.mockk.MockKAnnotations
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import io.mockk.spyk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Tests the initial-join handling of a recoverable SFU connection failure
+ * (e.g. a connection timeout) in [Call._join].
+ *
+ * On a recoverable failure the RtcSession's stateJob has already triggered
+ * [Call.reconnect], so `_join` must defer to that single recovery loop and await
+ * its terminal outcome instead of declaring a permanent failure. A non-recoverable
+ * failure must fail immediately.
+ */
+class JoinRecoverableFailureTest {
+
+    @get:Rule
+    val dispatcherRule = DispatcherRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    @RelaxedMockK
+    private lateinit var mockClientImpl: StreamVideoClient
+
+    @RelaxedMockK
+    private lateinit var mockSession: RtcSession
+
+    private lateinit var mockStreamVideo: StreamVideo
+    private lateinit var mockJoinResponse: JoinCallResponse
+    private lateinit var call: Call
+
+    @Before
+    fun setup() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        mockStreamVideo = mockk(relaxed = true)
+        StreamVideo.install(mockStreamVideo)
+
+        val mockNetworkStateProvider = mockk<NetworkStateProvider>(relaxed = true)
+        every { mockNetworkStateProvider.isConnected() } returns true
+        val mockCoordinatorModule = mockk<CoordinatorConnectionModule>(relaxed = true)
+        every { mockCoordinatorModule.networkStateProvider } returns mockNetworkStateProvider
+
+        every { mockClientImpl.coordinatorConnectionModule } returns mockCoordinatorModule
+        every { mockClientImpl.scope } returns testScope as CoroutineScope
+        every { mockClientImpl.leaveAfterDisconnectSeconds } returns 120L
+        every { mockClientImpl.apiKey } returns "test-api-key"
+        coEvery { mockClientImpl.getCachedLocation() } returns Success("test-location")
+
+        mockJoinResponse = mockk(relaxed = true)
+
+        call = spyk(
+            Call(
+                client = mockClientImpl,
+                type = "default",
+                id = "test-call",
+                user = User(id = "test-user", role = "user"),
+            ),
+        )
+
+        // _join builds the JoinCallResponse via joinRequest; stub it out.
+        coEvery {
+            call.joinRequest(any(), any(), any(), any(), any(), any(), any(), any())
+        } returns Success(mockJoinResponse)
+
+        // Inject our mocked RtcSession instead of constructing a real one.
+        Call.testInstanceProvider.rtcSessionCreator = { mockSession }
+    }
+
+    @After
+    fun tearDown() {
+        Call.testInstanceProvider.rtcSessionCreator = null
+        StreamVideo.removeClient()
+        unmockkAll()
+    }
+
+    @Test
+    fun `recoverable failure returns failure when reconnect is exhausted`() = runTest(
+        testDispatcher,
+    ) {
+        coEvery { mockSession.connectInternal(any(), any()) } returns
+            SfuConnectionResult.Failure(Exception("SFU connection timed out"), recoverable = true)
+
+        val deferred = async {
+            call._join(joinAnalyticsModel = JoinAnalyticsModel(0, JoinReason.FirstAttempt))
+        }
+        advanceUntilIdle()
+        assertThat(deferred.isCompleted).isFalse()
+
+        // The reconnect loop gives up.
+        call.state._connection.value = RealtimeConnection.ReconnectingFailed
+        advanceUntilIdle()
+
+        assertThat(deferred.await()).isInstanceOf(Failure::class.java)
+    }
+
+    @Test
+    fun `non-recoverable failure fails immediately without awaiting reconnect`() = runTest(
+        testDispatcher,
+    ) {
+        coEvery { mockSession.connectInternal(any(), any()) } returns
+            SfuConnectionResult.Failure(Exception("permanent auth error"), recoverable = false)
+
+        val result = call._join(joinAnalyticsModel = JoinAnalyticsModel(0, JoinReason.FirstAttempt))
+
+        assertThat(result).isInstanceOf(Failure::class.java)
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -28,6 +28,7 @@ import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
+import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAbortReason
 import io.getstream.video.android.core.call.RtcSession
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.connection.Publisher
@@ -72,6 +73,7 @@ import stream.video.sfu.models.PublishOption
 import stream.video.sfu.models.TrackType
 import stream.video.sfu.models.VideoDimension
 import stream.video.sfu.models.WebsocketReconnectStrategy
+import java.io.InterruptedIOException
 
 class RtcSessionTest2 {
 
@@ -296,6 +298,68 @@ class RtcSessionTest2 {
             // A timeout is recoverable — the stateJob triggers a reconnect, so the
             // join flow should await it rather than failing permanently.
             assertTrue("Expected recoverable=true for a timeout", result.recoverable)
+            assertEquals(
+                AnalyticsCallAbortReason.REQUEST_TIMEOUT,
+                (result as SfuConnectionResult.Failure).abortReason,
+            )
+        }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `connectInternal maps OkHttp InterruptedIOException timeout to REQUEST_TIMEOUT abort reason`() =
+        runTest(testDispatcher) {
+            val sfuSocketStateFlow = MutableStateFlow<SfuSocketState>(
+                SfuSocketState.Disconnected.Stopped,
+            )
+            val mockSocketConnection = mockk<SfuSocketConnection>(relaxed = true)
+            every { mockSocketConnection.state() } returns sfuSocketStateFlow
+            coEvery { mockSocketConnection.connect(any()) } coAnswers {
+                sfuSocketStateFlow.value =
+                    SfuSocketState.Disconnected.DisconnectedTemporarily(
+                        Error.NetworkError(
+                            message = "timeout",
+                            serverErrorCode = VideoErrorCode.SOCKET_FAILURE.code,
+                            statusCode = -1,
+                            cause = InterruptedIOException("timeout"),
+                        ),
+                        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_UNSPECIFIED,
+                    )
+            }
+            val sfuSocketModule = mockk<SfuConnectionModule>(relaxed = true)
+            every { sfuSocketModule.socketConnection } returns mockSocketConnection
+
+            val rtcSession = spyk(
+                RtcSession(
+                    client = mockStreamVideo,
+                    powerManager = mockPowerManager,
+                    call = mockCall,
+                    sessionId = "test-session-id",
+                    apiKey = "test-api-key",
+                    lifecycle = mockLifecycle,
+                    sfuUrl = "https://test-sfu.stream.com",
+                    sfuWsUrl = "wss://test-sfu.stream.com",
+                    sfuToken = "fake-sfu-token",
+                    sfuName = "test-sfu-edge",
+                    clientImpl = mockVideoClient,
+                    coroutineScope = testScope,
+                    remoteIceServers = emptyList(),
+                    sfuConnectionModuleProvider = { sfuSocketModule },
+                    sfuAnalytics = SfuAnalytics.getFakeSfuAnalytics(),
+                ),
+            )
+            coJustRun { rtcSession.sendCallStats(any(), any(), any()) }
+
+            val result = rtcSession.connectInternal()
+
+            assertTrue(
+                "Expected SfuConnectionResult.Failure but got $result",
+                result is SfuConnectionResult.Failure,
+            )
+            assertEquals(
+                AnalyticsCallAbortReason.REQUEST_TIMEOUT,
+                (result as SfuConnectionResult.Failure).abortReason,
+            )
+            assertTrue("Expected recoverable=true for a transport timeout", result.recoverable)
         }
 
     @Suppress("DEPRECATION")

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -38,6 +38,7 @@ import io.getstream.video.android.core.events.JoinCallResponseEvent
 import io.getstream.video.android.core.events.SubscriberOfferEvent
 import io.getstream.video.android.core.internal.module.SfuConnectionModule
 import io.getstream.video.android.core.model.IceServer
+import io.getstream.video.android.core.socket.common.ConnectionConf
 import io.getstream.video.android.core.socket.sfu.SfuSocketConnection
 import io.getstream.video.android.core.socket.sfu.state.SfuSocketState
 import io.mockk.MockKAnnotations
@@ -56,12 +57,14 @@ import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
+import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
@@ -247,9 +250,8 @@ class RtcSessionTest2 {
             )
             val mockSocketConnection = mockk<SfuSocketConnection>(relaxed = true)
             every { mockSocketConnection.state() } returns sfuSocketStateFlow
-            // connectInternal no longer owns a timer; the socket layer bounds the join
-            // handshake and surfaces a timeout as a DisconnectedTemporarily whose error
-            // carries the precise SFU_JOIN_RESPONSE_TIMEOUT code/reason.
+            // The socket layer surfaces timeouts as DisconnectedTemporarily; connectInternal
+            // also has a safety timeout if the state machine never reaches a terminal state.
             coEvery { mockSocketConnection.connect(any()) } coAnswers {
                 sfuSocketStateFlow.value =
                     SfuSocketState.Disconnected.DisconnectedTemporarily(
@@ -301,6 +303,65 @@ class RtcSessionTest2 {
             assertEquals(
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
                 (result as SfuConnectionResult.Failure).abortReason,
+            )
+        }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `connectInternal safety timeout fires when socket stays non-terminal`() =
+        runTest(testDispatcher) {
+            val sfuSocketStateFlow = MutableStateFlow<SfuSocketState>(
+                SfuSocketState.Disconnected.Stopped,
+            )
+            val mockSocketConnection = mockk<SfuSocketConnection>(relaxed = true)
+            every { mockSocketConnection.state() } returns sfuSocketStateFlow
+            coEvery { mockSocketConnection.connect(any()) } coAnswers {
+                sfuSocketStateFlow.value = SfuSocketState.Connecting(
+                    mockk<ConnectionConf.SfuConnectionConf>(relaxed = true),
+                )
+            }
+            val sfuSocketModule = mockk<SfuConnectionModule>(relaxed = true)
+            every { sfuSocketModule.socketConnection } returns mockSocketConnection
+            every { mockVideoClient.connectionTimeoutInMs } returns 50L
+
+            val rtcSession = spyk(
+                RtcSession(
+                    client = mockStreamVideo,
+                    powerManager = mockPowerManager,
+                    call = mockCall,
+                    sessionId = "test-session-id",
+                    apiKey = "test-api-key",
+                    lifecycle = mockLifecycle,
+                    sfuUrl = "https://test-sfu.stream.com",
+                    sfuWsUrl = "wss://test-sfu.stream.com",
+                    sfuToken = "fake-sfu-token",
+                    sfuName = "test-sfu-edge",
+                    clientImpl = mockVideoClient,
+                    coroutineScope = testScope,
+                    remoteIceServers = emptyList(),
+                    sfuConnectionModuleProvider = { sfuSocketModule },
+                    sfuAnalytics = SfuAnalytics.getFakeSfuAnalytics(),
+                ),
+            )
+            coJustRun { rtcSession.sendCallStats(any(), any(), any()) }
+
+            val resultDeferred = async { rtcSession.connectInternal() }
+            // Safety timeout = 2 * 50ms + 1000ms grace
+            advanceTimeBy(1_101L)
+            val result = resultDeferred.await()
+
+            assertTrue(
+                "Expected SfuConnectionResult.Failure but got $result",
+                result is SfuConnectionResult.Failure,
+            )
+            assertTrue(
+                "Expected safety-timeout message",
+                (result as SfuConnectionResult.Failure).error.message!!.contains("timed out"),
+            )
+            assertTrue("Expected recoverable=true for a safety timeout", result.recoverable)
+            assertEquals(
+                AnalyticsCallAbortReason.REQUEST_TIMEOUT,
+                result.abortReason,
             )
         }
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -19,6 +19,8 @@ package io.getstream.video.android.core.rtc
 import android.os.PowerManager
 import androidx.lifecycle.Lifecycle
 import io.getstream.android.video.generated.models.OwnCapability
+import io.getstream.result.Error
+import io.getstream.result.Result
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.CallState
 import io.getstream.video.android.core.MediaManagerImpl
@@ -29,6 +31,7 @@ import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
 import io.getstream.video.android.core.call.RtcSession
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.connection.Publisher
+import io.getstream.video.android.core.errors.VideoErrorCode
 import io.getstream.video.android.core.events.ICETrickleEvent
 import io.getstream.video.android.core.events.JoinCallResponseEvent
 import io.getstream.video.android.core.events.SubscriberOfferEvent
@@ -48,6 +51,7 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
@@ -234,7 +238,69 @@ class RtcSessionTest2 {
 
     @Suppress("DEPRECATION")
     @Test
-    fun `connectInternal returns Failed when socket connection times out`() =
+    fun `connectInternal returns Failed when the socket reports a connection timeout`() =
+        runTest(testDispatcher) {
+            val sfuSocketStateFlow = MutableStateFlow<SfuSocketState>(
+                SfuSocketState.Disconnected.Stopped,
+            )
+            val mockSocketConnection = mockk<SfuSocketConnection>(relaxed = true)
+            every { mockSocketConnection.state() } returns sfuSocketStateFlow
+            // connectInternal no longer owns a timer; the socket layer bounds the join
+            // handshake and surfaces a timeout as a DisconnectedTemporarily whose error
+            // carries the precise SFU_JOIN_RESPONSE_TIMEOUT code/reason.
+            coEvery { mockSocketConnection.connect(any()) } coAnswers {
+                sfuSocketStateFlow.value =
+                    SfuSocketState.Disconnected.DisconnectedTemporarily(
+                        Error.NetworkError(
+                            message = VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT.description,
+                            serverErrorCode = VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT.code,
+                            statusCode = -1,
+                        ),
+                        WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,
+                    )
+            }
+            val sfuSocketModule = mockk<SfuConnectionModule>(relaxed = true)
+            every { sfuSocketModule.socketConnection } returns mockSocketConnection
+
+            val rtcSession = spyk(
+                RtcSession(
+                    client = mockStreamVideo,
+                    powerManager = mockPowerManager,
+                    call = mockCall,
+                    sessionId = "test-session-id",
+                    apiKey = "test-api-key",
+                    lifecycle = mockLifecycle,
+                    sfuUrl = "https://test-sfu.stream.com",
+                    sfuWsUrl = "wss://test-sfu.stream.com",
+                    sfuToken = "fake-sfu-token",
+                    sfuName = "test-sfu-edge",
+                    clientImpl = mockVideoClient,
+                    coroutineScope = testScope,
+                    remoteIceServers = emptyList(),
+                    sfuConnectionModuleProvider = { sfuSocketModule },
+                    sfuAnalytics = SfuAnalytics.getFakeSfuAnalytics(),
+                ),
+            )
+            coJustRun { rtcSession.sendCallStats(any(), any(), any()) }
+
+            val result = rtcSession.connectInternal()
+
+            assertTrue(
+                "Expected SfuConnectionResult.Failure but got $result",
+                result is SfuConnectionResult.Failure,
+            )
+            assertTrue(
+                "Expected timeout message",
+                (result as SfuConnectionResult.Failure).error.message!!.contains("timed out"),
+            )
+            // A timeout is recoverable — the stateJob triggers a reconnect, so the
+            // join flow should await it rather than failing permanently.
+            assertTrue("Expected recoverable=true for a timeout", result.recoverable)
+        }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `connectInternal returns non-recoverable Failed on a permanent disconnect`() =
         runTest(testDispatcher) {
             val sfuSocketStateFlow = MutableStateFlow<SfuSocketState>(
                 SfuSocketState.Disconnected.Stopped,
@@ -242,8 +308,12 @@ class RtcSessionTest2 {
             val mockSocketConnection = mockk<SfuSocketConnection>(relaxed = true)
             every { mockSocketConnection.state() } returns sfuSocketStateFlow
             coEvery { mockSocketConnection.connect(any()) } coAnswers {
-                sfuSocketStateFlow.value = SfuSocketState.Connecting(
-                    connectionConf = mockk(relaxed = true),
+                sfuSocketStateFlow.value = SfuSocketState.Disconnected.DisconnectedPermanently(
+                    Error.NetworkError(
+                        message = "permanent auth error",
+                        serverErrorCode = 0,
+                        statusCode = -1,
+                    ),
                 )
             }
             val sfuSocketModule = mockk<SfuConnectionModule>(relaxed = true)
@@ -273,12 +343,12 @@ class RtcSessionTest2 {
             val result = rtcSession.connectInternal()
 
             assertTrue(
-                "Expected SfuConnectionResult.Failed but got $result",
-                result is SfuConnectionResult.Failed,
+                "Expected SfuConnectionResult.Failure but got $result",
+                result is SfuConnectionResult.Failure,
             )
-            assertTrue(
-                "Expected timeout message",
-                (result as SfuConnectionResult.Failed).error.message!!.contains("timed out"),
+            assertFalse(
+                "Expected recoverable=false for a permanent disconnect",
+                (result as SfuConnectionResult.Failure).recoverable,
             )
         }
 
@@ -330,7 +400,7 @@ class RtcSessionTest2 {
 
             val result = rtcSession.connectInternal(reconnectDetails = reconnectDetails)
 
-            assertEquals(SfuConnectionResult.Connected, result)
+            assertEquals(SfuConnectionResult.Success, result)
             coVerify {
                 mockSocketConnection.connect(
                     match { request ->

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateServiceTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateServiceTest.kt
@@ -40,7 +40,7 @@ class SfuSocketStateServiceTest {
         assertThat(service.currentState).isInstanceOf(SfuSocketState.Connecting::class.java)
 
         // Transport WebSocket opened, but no JoinResponse yet.
-        service.onWebSocketConnected()
+        service.onWebSocketEstablished()
         assertThat(service.currentState).isEqualTo(SfuSocketState.WebSocketConnected)
 
         // JoinResponse delivered by the SFU.
@@ -77,7 +77,7 @@ class SfuSocketStateServiceTest {
         runTest {
             val service = SfuSocketStateService()
             service.onConnect(conf)
-            service.onWebSocketConnected()
+            service.onWebSocketEstablished()
             assertThat(service.currentState).isEqualTo(SfuSocketState.WebSocketConnected)
 
             // The join-response timer fires after the WebSocket opened.
@@ -100,7 +100,7 @@ class SfuSocketStateServiceTest {
     fun `timeout disconnect can reconnect via Connect`() = runTest {
         val service = SfuSocketStateService()
         service.onConnect(conf)
-        service.onWebSocketConnected()
+        service.onWebSocketEstablished()
         service.onNetworkError(
             Error.NetworkError.fromVideoErrorCode(VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT),
             WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateServiceTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/socket/sfu/SfuSocketStateServiceTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.socket.sfu
+
+import com.google.common.truth.Truth.assertThat
+import io.getstream.result.Error
+import io.getstream.video.android.core.errors.VideoErrorCode
+import io.getstream.video.android.core.events.JoinCallResponseEvent
+import io.getstream.video.android.core.socket.common.ConnectionConf
+import io.getstream.video.android.core.socket.common.fromVideoErrorCode
+import io.getstream.video.android.core.socket.sfu.state.SfuSocketState
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import stream.video.sfu.models.WebsocketReconnectStrategy
+
+class SfuSocketStateServiceTest {
+
+    private val conf = mockk<ConnectionConf.SfuConnectionConf>(relaxed = true)
+
+    @Test
+    fun `connecting then websocket open then join response reaches Connected`() = runTest {
+        val service = SfuSocketStateService()
+
+        service.onConnect(conf)
+        assertThat(service.currentState).isInstanceOf(SfuSocketState.Connecting::class.java)
+
+        // Transport WebSocket opened, but no JoinResponse yet.
+        service.onWebSocketConnected()
+        assertThat(service.currentState).isEqualTo(SfuSocketState.WebSocketConnected)
+
+        // JoinResponse delivered by the SFU.
+        service.onConnectionEstablished(mockk<JoinCallResponseEvent>(relaxed = true))
+        assertThat(service.currentState).isInstanceOf(SfuSocketState.Connected::class.java)
+    }
+
+    @Test
+    fun `transport failure while Connecting moves to DisconnectedTemporarily carrying its code`() =
+        runTest {
+            val service = SfuSocketStateService()
+            service.onConnect(conf)
+            assertThat(service.currentState).isInstanceOf(SfuSocketState.Connecting::class.java)
+
+            // OkHttp failed the WebSocket upgrade before it opened — the error is passed
+            // through as-is, carrying its own code/reason.
+            service.onNetworkError(
+                Error.NetworkError.fromVideoErrorCode(VideoErrorCode.SOCKET_FAILURE),
+                WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,
+            )
+
+            val state = service.currentState
+            assertThat(
+                state,
+            ).isInstanceOf(SfuSocketState.Disconnected.DisconnectedTemporarily::class.java)
+            assertThat(
+                (state as SfuSocketState.Disconnected.DisconnectedTemporarily).error.serverErrorCode,
+            )
+                .isEqualTo(VideoErrorCode.SOCKET_FAILURE.code)
+        }
+
+    @Test
+    fun `join-response timeout while WebSocketConnected moves to DisconnectedTemporarily with join-response code`() =
+        runTest {
+            val service = SfuSocketStateService()
+            service.onConnect(conf)
+            service.onWebSocketConnected()
+            assertThat(service.currentState).isEqualTo(SfuSocketState.WebSocketConnected)
+
+            // The join-response timer fires after the WebSocket opened.
+            service.onNetworkError(
+                Error.NetworkError.fromVideoErrorCode(VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT),
+                WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,
+            )
+
+            val state = service.currentState
+            assertThat(
+                state,
+            ).isInstanceOf(SfuSocketState.Disconnected.DisconnectedTemporarily::class.java)
+            assertThat(
+                (state as SfuSocketState.Disconnected.DisconnectedTemporarily).error.serverErrorCode,
+            )
+                .isEqualTo(VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT.code)
+        }
+
+    @Test
+    fun `timeout disconnect can reconnect via Connect`() = runTest {
+        val service = SfuSocketStateService()
+        service.onConnect(conf)
+        service.onWebSocketConnected()
+        service.onNetworkError(
+            Error.NetworkError.fromVideoErrorCode(VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT),
+            WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_FAST,
+        )
+        assertThat(service.currentState)
+            .isInstanceOf(SfuSocketState.Disconnected.DisconnectedTemporarily::class.java)
+
+        service.onConnect(conf)
+        assertThat(service.currentState).isInstanceOf(SfuSocketState.Connecting::class.java)
+    }
+
+    @Test
+    fun `join response can still arrive directly from Connecting`() = runTest {
+        val service = SfuSocketStateService()
+        service.onConnect(conf)
+
+        service.onConnectionEstablished(mockk<JoinCallResponseEvent>(relaxed = true))
+        assertThat(service.currentState).isInstanceOf(SfuSocketState.Connected::class.java)
+    }
+}


### PR DESCRIPTION
### Goal
Fixes [AN-1294](https://linear.app/stream/issue/AND-1294/fix-the-timeout-based-logic-of-sfu-ws-connection)

 This PR reworks SFU socket connect/timeout handling so every outcome is attributed precisely.

Issues this PR solves:

1. **Connect could hang on a silent SFU.** Once the transport WebSocket was upgraded, OkHttp no longer applied a timeout, so if the SFU never sent its `JoinCallResponse` we could wait indefinitely. There was no separate deadline for the post-open handshake.
2. **A successful-but-slow connect / socket timeout was wrongly surfaced as a hard join failure to the app.** There were effectively two competing timeouts (OkHttp's, plus a `withTimeoutOrNull` inside `connectInternal`) and the terminal state wasn't interpreted consistently.
3. **Opaque error messages.** Transport failures surfaced as `SOCKET_FAILURE`'s generic *"See stack trace in logs…"* instead of the real reason (e.g. `Failed to connect to /1.2.3.4:443`, `timeout`, SSL handshake errors), and the HTTP status code from a failed WS upgrade (401/429/5xx) was discarded.
6. **Join-error analytics were emitted during reconnects.** `connectInternal` reported join failures even when it ran as part of the internal reconnect loop, double-counting/false-positive join errors.
7. **Retry count was inaccurate.** There was no per-session notion of how many SFU WS retries an attempt actually took.
7. **`connectionTimeoutInMs` from `StreamVideoBuilder` was ignored** by the SFU socket path (a hardcoded 10s was used, and the post-open handshake had no configurable bound).

### Implementation

- **Two-phase connect with a new `WebSocketConnected` state.** The transport open (HTTP→WS upgrade) is bounded by OkHttp's connect timeout; a new `SfuSocketState.WebSocketConnected` marks "socket open, awaiting `JoinCallResponse`". `StreamWebSocket` now emits a `StreamWebSocketEvent.Open` on `onOpen` to drive this transition (coordinator socket treats it as informational).
- **Dedicated join-response timer.** While in `WebSocketConnected`, a timer (`joinResponseTimeoutMs`) bounds the wait for `JoinCallResponse`; on expiry it pushes a retryable `NetworkError` tagged `VideoErrorCode.SFU_JOIN_RESPONSE_TIMEOUT` → resolves to `DisconnectedTemporarily` instead of hanging.
- **Single recoverable path.** Removed the extra `withTimeoutOrNull` in `connectInternal`; all recoverable errors flow through one `DisconnectedTemporarily(error)` whose `NetworkError` carries the exact code + reason. `connectInternal` classifies the terminal state via `triggersReconnect()`/`networkErrorOrNull()`.
- **Real error surfaced.** `StreamWebSocket.onFailure` now builds `Error.NetworkError` directly with the throwable's message and the HTTP `response.code` when the upgrade failed on an HTTP response (falls back to unknown for pure transport failures).
- **Accurate timeout analytics.** `toAbortReason()` maps both the join-response timeout (by error code) and the transport connect timeout (by `SocketTimeoutException` cause — a type check, not string matching) to `REQUEST_TIMEOUT`; everything else stays `SFU_ERROR`.
- **Join-only analytics.** Join-error analytics moved out of `connectInternal` into `Call._join` via `sendJoinErrorAnalytics(...)`, so reconnect-driven connects don't report join errors. `SfuConnectionResult.Failure` now carries `recoverable` + `abortReason`; on a recoverable failure the join flow awaits the reconnect outcome (`didReconnectSucceed()`).
- **Per-session retry counter.** `RtcSession.sfuWsRetryCount` increments only on actual retries (a `connectInternal` with `reconnectDetails`), resets to 0 on `Connected`, and is passed to `onSfuWsCompleted`.
- **Configurable timeout.** `StreamVideoBuilder.connectionTimeoutInMs` now drives both the SFU OkHttp client and the join-response deadline.
- Renamed `SfuConnectionResult.Connected/Failed` → `Success/Failure`; renamed `awaitReconnectOutcome()` → `didReconnectSucceed()`.

### Testing

- [x] `./gradlew :stream-video-android-core:testDebugUnitTest --tests "io.getstream.video.android.core.socket.sfu.*" --tests "io.getstream.video.android.core.rtc.*"` — pass
- [x] `./gradlew :stream-video-android-core:compileDebugKotlin` — pass
- [x] `./gradlew :stream-video-android-core:spotlessApply` — clean
- Manual: reproduced an SFU connect timeout via Charles proxy and verified the connection resolves to a retryable disconnect and the reconnect loop takes over (no hang).

New/updated tests: `SfuSocketStateServiceTest` (new `WebSocketConnected`/join-response transitions), `JoinRecoverableFailureTest` (recoverable-vs-permanent join handling), `RtcSessionTest2` (`connectInternal` terminal-state classification), `FastReconnectIceRestartTest` (result rename).

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes (N/A — no UI changes)
- [x] Affected documentation updated (KDocs)
- [ ] Tutorial starter kit updated (N/A)
- [ ] Examples/guides starter kits updated (`stream-video-examples`) (N/A)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [x] Check the SDK Size Comparison table in the CI logs

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer handling for WebSocket connection stages, including a new “WebSocket connected” state before the final join response arrives.
  * Introduced support for timeout-based recovery when the join response does not arrive in time.

* **Bug Fixes**
  * Improved reconnect behavior for recoverable connection failures.
  * Added better error reporting for SFU join timeouts and transport failures.

* **Documentation**
  * Updated connection timeout guidance and defaults for a more predictable setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->