### PR TITLE
Recover initial join when connect safety-timeout leaves no reconnect

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/StreamVideoInitHelper.kt
@@ -406,7 +406,7 @@ object StreamVideoInitHelper {
             apiKey = apiKey,
             user = user,
             token = token,
-            connectionTimeoutInMs = 12_000L,
+            connectionTimeoutInMs = 5_000L,
             loggingLevel = loggingLevel,
             ensureSingleInstance = false,
             localCoordinatorAddress = localCoordinatorAddress,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -780,7 +780,31 @@ public class Call(
             is SfuConnectionResult.Success -> Unit
             is SfuConnectionResult.Failure -> {
                 if (sfuConnectionResult.recoverable) {
-                    logger.w { "[_join] Recoverable SFU connection failure — awaiting reconnect outcome" }
+                    // When the failure came from a socket state stateJob reacts to, a
+                    // Call.reconnect is already being launched, so we just await its outcome.
+                    // Otherwise (e.g. the connect safety-timeout, which left the socket in a
+                    // state stateJob ignores) nothing would start recovery and
+                    // didReconnectSucceed() would block forever — so trigger a REJOIN ourselves.
+                    if (!sfuConnectionResult.reconnectTriggered) {
+                        // REJOIN (not FAST) on purpose: reaching here means the initial join
+                        // never completed (the connect safety-timeout is the only source of
+                        // recoverable + !reconnectTriggered). There is no established SFU
+                        // session or negotiated media path to resume, so a FAST resume would
+                        // likely hit PARTICIPANT_NOT_FOUND and burn attempts before the loop
+                        // escalates. A full REJOIN re-fetches credentials and starts a clean
+                        // join, which is the only thing that can actually succeed here.
+                        logger.w {
+                            "[_join] Recoverable SFU connection failure with no recovery started — triggering REJOIN"
+                        }
+                        scope.launch {
+                            reconnect(
+                                WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_REJOIN,
+                                "join-recoverable-connect-failure",
+                            )
+                        }
+                    } else {
+                        logger.w { "[_join] Recoverable SFU connection failure — awaiting recovery outcome" }
+                    }
                     if (!didReconnectSucceed()) {
                         logger.e { "[_join] Could not recover. Error : $sfuConnectionResult" }
                         sendJoinErrorAnalytics(sfuConnectionResult)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -67,7 +67,7 @@ import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAb
 import io.getstream.video.android.core.audio.StreamAudioDevice
 import io.getstream.video.android.core.call.FastReconnectResult
 import io.getstream.video.android.core.call.RtcSession
-import io.getstream.video.android.core.call.SfuConnectException
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.audio.InputAudioFilter
 import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
@@ -194,6 +194,10 @@ public class Call(
     internal var nonFastReconnectAttempts = 0
     internal val clientImpl = client as StreamVideoClient
     internal val scopeProvider: ScopeProvider = ScopeProviderImpl(clientImpl.scope)
+
+    // Unit-test only hook for replacing RtcSession construction.
+    // TODO(v2): replace this with a proper dependency injection boundary.
+    internal var unitTestRtcSessionFactory: (() -> RtcSession)? = null
 
     // Atomic controls
     private var atomicLeave = AtomicUnitCall()
@@ -748,8 +752,8 @@ public class Call(
         val sfuWsUrl = result.value.credentials.server.wsEndpoint
         val sfuName = result.value.credentials.server.edgeName
         val iceServers = result.value.credentials.iceServers.map { it.toIceServer() }
-        val localSession = if (testInstanceProvider.rtcSessionCreator != null) {
-            testInstanceProvider.rtcSessionCreator!!.invoke()
+        val localSession = if (unitTestRtcSessionFactory != null) {
+            unitTestRtcSessionFactory!!.invoke()
         } else {
             RtcSession(
                 sessionId = this.sessionId,
@@ -780,13 +784,8 @@ public class Call(
         when (sfuConnectionResult) {
             is SfuConnectionResult.Success -> Unit
             is SfuConnectionResult.Failure -> {
-                if (sfuConnectionResult.recoverable) {
-                    // A recoverable socket disconnect means stateJob is already launching
-                    // Call.reconnect, so we just await its outcome. A connect safety-timeout
-                    // instead tore down a stuck socket into a state stateJob ignores, so
-                    // nothing would start recovery and didReconnectSucceed() would block
-                    // forever — trigger a REJOIN ourselves for that case.
-                    if (sfuConnectionResult.error is SfuConnectException.Timeout) {
+                when (sfuConnectionResult.cause) {
+                    SfuConnectFailureCause.SocketStateObservationTimeout -> {
                         // REJOIN (not FAST) on purpose: a connect timeout means the initial
                         // join never completed. There is no established SFU session or
                         // negotiated media path to resume, so a FAST resume would likely hit
@@ -794,7 +793,7 @@ public class Call(
                         // A full REJOIN re-fetches credentials and starts a clean join, which
                         // is the only thing that can actually succeed here.
                         logger.w {
-                            "[_join] Recoverable SFU connect timeout with no recovery started — triggering REJOIN"
+                            "[_join] SFU socket state observation timed out with no recovery started — triggering REJOIN"
                         }
                         scope.launch {
                             reconnect(
@@ -802,9 +801,26 @@ public class Call(
                                 "join-recoverable-connect-failure",
                             )
                         }
-                    } else {
-                        logger.w { "[_join] Recoverable SFU connection failure — awaiting recovery outcome" }
                     }
+
+                    SfuConnectFailureCause.RecoverableSocketFailure -> {
+                        logger.w { "[_join] Recoverable SFU socket failure — awaiting recovery outcome" }
+                    }
+
+                    SfuConnectFailureCause.TerminalSocketFailure -> {
+                        logger.e {
+                            "[_join] Got terminal error while connecting to SFU. Error : $sfuConnectionResult"
+                        }
+                        sendJoinErrorAnalytics(sfuConnectionResult)
+                        return Failure(
+                            Error.GenericError(
+                                sfuConnectionResult.error.message ?: "RtcSession error occurred.",
+                            ),
+                        )
+                    }
+                }
+
+                if (sfuConnectionResult.cause != SfuConnectFailureCause.TerminalSocketFailure) {
                     if (!didReconnectSucceed()) {
                         logger.e { "[_join] Could not recover. Error : $sfuConnectionResult" }
                         sendJoinErrorAnalytics(sfuConnectionResult)
@@ -814,16 +830,6 @@ public class Call(
                             ),
                         )
                     }
-                } else {
-                    logger.e {
-                        "[_join] Got non recoverable error while connecting to SFU. Error : $sfuConnectionResult"
-                    }
-                    sendJoinErrorAnalytics(sfuConnectionResult)
-                    return Failure(
-                        Error.GenericError(
-                            sfuConnectionResult.error.message ?: "RtcSession error occurred.",
-                        ),
-                    )
                 }
             }
         }
@@ -2320,7 +2326,6 @@ public class Call(
 
         internal class TestInstanceProvider {
             var mediaManagerCreator: (() -> MediaManagerImpl)? = null
-            var rtcSessionCreator: (() -> RtcSession)? = null
         }
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -67,6 +67,7 @@ import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAb
 import io.getstream.video.android.core.audio.StreamAudioDevice
 import io.getstream.video.android.core.call.FastReconnectResult
 import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectException
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.audio.InputAudioFilter
 import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
@@ -780,21 +781,20 @@ public class Call(
             is SfuConnectionResult.Success -> Unit
             is SfuConnectionResult.Failure -> {
                 if (sfuConnectionResult.recoverable) {
-                    // When the failure came from a socket state stateJob reacts to, a
-                    // Call.reconnect is already being launched, so we just await its outcome.
-                    // Otherwise (e.g. the connect safety-timeout, which left the socket in a
-                    // state stateJob ignores) nothing would start recovery and
-                    // didReconnectSucceed() would block forever — so trigger a REJOIN ourselves.
-                    if (!sfuConnectionResult.reconnectTriggered) {
-                        // REJOIN (not FAST) on purpose: reaching here means the initial join
-                        // never completed (the connect safety-timeout is the only source of
-                        // recoverable + !reconnectTriggered). There is no established SFU
-                        // session or negotiated media path to resume, so a FAST resume would
-                        // likely hit PARTICIPANT_NOT_FOUND and burn attempts before the loop
-                        // escalates. A full REJOIN re-fetches credentials and starts a clean
-                        // join, which is the only thing that can actually succeed here.
+                    // A recoverable socket disconnect means stateJob is already launching
+                    // Call.reconnect, so we just await its outcome. A connect safety-timeout
+                    // instead tore down a stuck socket into a state stateJob ignores, so
+                    // nothing would start recovery and didReconnectSucceed() would block
+                    // forever — trigger a REJOIN ourselves for that case.
+                    if (sfuConnectionResult.error is SfuConnectException.Timeout) {
+                        // REJOIN (not FAST) on purpose: a connect timeout means the initial
+                        // join never completed. There is no established SFU session or
+                        // negotiated media path to resume, so a FAST resume would likely hit
+                        // PARTICIPANT_NOT_FOUND and burn attempts before the loop escalates.
+                        // A full REJOIN re-fetches credentials and starts a clean join, which
+                        // is the only thing that can actually succeed here.
                         logger.w {
-                            "[_join] Recoverable SFU connection failure with no recovery started — triggering REJOIN"
+                            "[_join] Recoverable SFU connect timeout with no recovery started — triggering REJOIN"
                         }
                         scope.launch {
                             reconnect(

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -223,12 +223,16 @@ internal sealed class SfuConnectionResult {
     /**
      * The connection attempt failed.
      *
-     * @param recoverable `true` when the terminal socket state is one that
-     * RtcSession's `stateJob` reacts to by triggering `Call.reconnect` (e.g.
-     * a connection timeout or a temporary socket disconnect). In that case the
-     * initial-join flow can defer to that recovery loop and await its outcome
-     * instead of treating the failure as permanent. `false` for terminal
-     * failures with no recovery (auth errors, permanent disconnects, etc.).
+     * @param recoverable `true` when the failure can be recovered from, so the
+     * initial-join flow can await a recovery loop instead of treating it as
+     * permanent. `false` for terminal failures with no recovery (auth errors,
+     * permanent disconnects, etc.).
+     * @param reconnectTriggered `true` when the terminal socket state is one that
+     * RtcSession's `stateJob` reacts to by launching `Call.reconnect`, so a recovery
+     * loop is already being started and the caller must not start its own. `false`
+     * when nothing will drive recovery on its own (e.g. the connect safety-timeout,
+     * which disconnects the socket into a state `stateJob` ignores) — in that case
+     * the initial-join flow must trigger `Call.reconnect` itself.
      * @param abortReason the analytics abort reason derived from the disconnect
      * state's error code, or `null` when the terminal state carried no error.
      * The caller (the join flow) decides whether/when to report it, so that
@@ -237,6 +241,7 @@ internal sealed class SfuConnectionResult {
     data class Failure(
         val error: Exception,
         val recoverable: Boolean = false,
+        val reconnectTriggered: Boolean = false,
         val abortReason: AnalyticsCallAbortReason? = null,
     ) : SfuConnectionResult()
 }
@@ -949,14 +954,28 @@ public class RtcSession internal constructor(
             }
         }
         if (sfuSocketState == null) {
+            // Safety net: the socket never reached a terminal state (Connected or
+            // Disconnected) within the timeout. This happens when the socket layer's own
+            // timers fail to fire and it gets stuck in a non-terminal state — e.g. the
+            // HTTP→WS upgrade stalls (proxy/captive portal drops packets silently, half-open
+            // TCP after a network handoff) so OkHttp never opens or errors the socket, or the
+            // WS opens but the SFU never sends the JoinResponse and the join-response wait
+            // never completes. Without this branch, `.first { }` would suspend forever.
             val msg =
                 "SFU connection timed out waiting for socket state (${connectTimeoutMs}ms)"
             logger.w { "[connectInternal] $msg" }
             sfuTracer.trace("connect-failed", msg)
+            // The socket never reached a terminal state, so the connect attempt is still
+            // in flight. Tear it down before returning so a late Connected/JoinResponse
+            // can't resurface through stateJob and resurrect this abandoned session.
+            sfuConnectionModule.socketConnection.disconnect()
             sendCallStats()
             return SfuConnectionResult.Failure(
                 error = Exception(msg),
                 recoverable = true,
+                // We disconnected the socket into a state stateJob ignores, so no
+                // recovery loop will start on its own — the caller must trigger it.
+                reconnectTriggered = false,
                 abortReason = AnalyticsCallAbortReason.REQUEST_TIMEOUT,
             )
         }
@@ -974,9 +993,14 @@ public class RtcSession internal constructor(
             logger.w { "[connectInternal] $msg" }
             sfuTracer.trace("connect-failed", msg)
             sendCallStats()
+            // These are the exact states stateJob reacts to, so if this is recoverable
+            // a Call.reconnect is already being launched — the caller must not start another.
+            val triggersReconnect =
+                (sfuSocketState as? SfuSocketState.Disconnected)?.triggersStateJobReconnect() ?: false
             SfuConnectionResult.Failure(
                 error = Exception(msg),
-                recoverable = (sfuSocketState as? SfuSocketState.Disconnected)?.canTriggersReconnect() ?: false,
+                recoverable = triggersReconnect,
+                reconnectTriggered = triggersReconnect,
                 abortReason = networkError?.toAbortReason(),
             )
         }
@@ -991,7 +1015,7 @@ public class RtcSession internal constructor(
      * `when` (no `else`) makes a new [SfuSocketState.Disconnected] subtype a compile
      * error here, forcing both sites to stay in sync.
      */
-    private fun SfuSocketState.Disconnected.canTriggersReconnect(): Boolean = when (this) {
+    private fun SfuSocketState.Disconnected.triggersStateJobReconnect(): Boolean = when (this) {
         is SfuSocketState.Disconnected.DisconnectedTemporarily,
         is SfuSocketState.Disconnected.WebSocketEventLost,
         -> true

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -223,14 +223,10 @@ internal sealed class SfuConnectionResult {
     /**
      * The connection attempt failed.
      *
-     * @param error the typed cause of the failure (see [SfuConnectException]).
-     * Callers branch on its concrete type to decide how to recover — e.g. a
-     * [SfuConnectException.Timeout] means the safety-timeout tore down a stuck
-     * socket and no recovery loop was started, so the caller must start one.
-     * @param recoverable `true` when the failure can be recovered from, so the
-     * initial-join flow can await a recovery loop instead of treating it as
-     * permanent. `false` for terminal failures with no recovery (auth errors,
-     * permanent disconnects, etc.).
+     * @param cause the classified failure cause. Callers can use it to decide
+     * whether to start recovery, await recovery already started by `stateJob`,
+     * or fail immediately.
+     * @param cause See [SfuConnectFailureCause]
      * @param abortReason the analytics abort reason derived from the disconnect
      * state's error code, or `null` when the terminal state carried no error.
      * The caller (the join flow) decides whether/when to report it, so that
@@ -238,31 +234,9 @@ internal sealed class SfuConnectionResult {
      */
     data class Failure(
         val error: Exception,
-        val recoverable: Boolean = false,
+        val cause: SfuConnectFailureCause,
         val abortReason: AnalyticsCallAbortReason? = null,
     ) : SfuConnectionResult()
-}
-
-/**
- * Typed causes carried by [SfuConnectionResult.Failure], so callers of
- * [RtcSession.connectInternal] can branch on the failure kind instead of parsing
- * the message text.
- */
-internal sealed class SfuConnectException(message: String) : Exception(message) {
-    /**
-     * The connect attempt never reached a terminal socket state within the safety
-     * timeout, so [RtcSession.connectInternal] tore the in-flight socket down.
-     * That leaves the socket in a state `stateJob` ignores, so no recovery loop is
-     * started on its own — the initial-join flow must start one itself.
-     */
-    class Timeout(message: String) : SfuConnectException(message)
-
-    /**
-     * The SFU socket reached a terminal [SfuSocketState.Disconnected] state. When
-     * the failure is recoverable, `stateJob` is already launching `Call.reconnect`,
-     * so the initial-join flow only needs to await the outcome.
-     */
-    class Disconnected(message: String) : SfuConnectException(message)
 }
 
 /**
@@ -989,11 +963,9 @@ public class RtcSession internal constructor(
             // can't resurface through stateJob and resurrect this abandoned session.
             sfuConnectionModule.socketConnection.disconnect()
             sendCallStats()
-            // Typed as Timeout: we disconnected the socket into a state stateJob ignores,
-            // so no recovery loop starts on its own — the caller must start it.
             return SfuConnectionResult.Failure(
-                error = SfuConnectException.Timeout(msg),
-                recoverable = true,
+                error = Exception(msg),
+                cause = SfuConnectFailureCause.SocketStateObservationTimeout,
                 abortReason = AnalyticsCallAbortReason.REQUEST_TIMEOUT,
             )
         }
@@ -1011,13 +983,14 @@ public class RtcSession internal constructor(
             logger.w { "[connectInternal] $msg" }
             sfuTracer.trace("connect-failed", msg)
             sendCallStats()
-            // Recoverable only when the terminal state is one stateJob reacts to; in that
-            // case a Call.reconnect is already being launched, so the join flow just awaits.
-            val recoverable =
-                (sfuSocketState as? SfuSocketState.Disconnected)?.isRecoverable() ?: false
+            val cause = if ((sfuSocketState as? SfuSocketState.Disconnected)?.isRecoverable() == true) {
+                SfuConnectFailureCause.RecoverableSocketFailure
+            } else {
+                SfuConnectFailureCause.TerminalSocketFailure
+            }
             SfuConnectionResult.Failure(
-                error = SfuConnectException.Disconnected(msg),
-                recoverable = recoverable,
+                error = Exception(msg),
+                cause = cause,
                 abortReason = networkError?.toAbortReason(),
             )
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -223,16 +223,14 @@ internal sealed class SfuConnectionResult {
     /**
      * The connection attempt failed.
      *
+     * @param error the typed cause of the failure (see [SfuConnectException]).
+     * Callers branch on its concrete type to decide how to recover — e.g. a
+     * [SfuConnectException.Timeout] means the safety-timeout tore down a stuck
+     * socket and no recovery loop was started, so the caller must start one.
      * @param recoverable `true` when the failure can be recovered from, so the
      * initial-join flow can await a recovery loop instead of treating it as
      * permanent. `false` for terminal failures with no recovery (auth errors,
      * permanent disconnects, etc.).
-     * @param reconnectTriggered `true` when the terminal socket state is one that
-     * RtcSession's `stateJob` reacts to by launching `Call.reconnect`, so a recovery
-     * loop is already being started and the caller must not start its own. `false`
-     * when nothing will drive recovery on its own (e.g. the connect safety-timeout,
-     * which disconnects the socket into a state `stateJob` ignores) — in that case
-     * the initial-join flow must trigger `Call.reconnect` itself.
      * @param abortReason the analytics abort reason derived from the disconnect
      * state's error code, or `null` when the terminal state carried no error.
      * The caller (the join flow) decides whether/when to report it, so that
@@ -241,9 +239,30 @@ internal sealed class SfuConnectionResult {
     data class Failure(
         val error: Exception,
         val recoverable: Boolean = false,
-        val reconnectTriggered: Boolean = false,
         val abortReason: AnalyticsCallAbortReason? = null,
     ) : SfuConnectionResult()
+}
+
+/**
+ * Typed causes carried by [SfuConnectionResult.Failure], so callers of
+ * [RtcSession.connectInternal] can branch on the failure kind instead of parsing
+ * the message text.
+ */
+internal sealed class SfuConnectException(message: String) : Exception(message) {
+    /**
+     * The connect attempt never reached a terminal socket state within the safety
+     * timeout, so [RtcSession.connectInternal] tore the in-flight socket down.
+     * That leaves the socket in a state `stateJob` ignores, so no recovery loop is
+     * started on its own — the initial-join flow must start one itself.
+     */
+    class Timeout(message: String) : SfuConnectException(message)
+
+    /**
+     * The SFU socket reached a terminal [SfuSocketState.Disconnected] state. When
+     * the failure is recoverable, `stateJob` is already launching `Call.reconnect`,
+     * so the initial-join flow only needs to await the outcome.
+     */
+    class Disconnected(message: String) : SfuConnectException(message)
 }
 
 /**
@@ -970,12 +989,11 @@ public class RtcSession internal constructor(
             // can't resurface through stateJob and resurrect this abandoned session.
             sfuConnectionModule.socketConnection.disconnect()
             sendCallStats()
+            // Typed as Timeout: we disconnected the socket into a state stateJob ignores,
+            // so no recovery loop starts on its own — the caller must start it.
             return SfuConnectionResult.Failure(
-                error = Exception(msg),
+                error = SfuConnectException.Timeout(msg),
                 recoverable = true,
-                // We disconnected the socket into a state stateJob ignores, so no
-                // recovery loop will start on its own — the caller must trigger it.
-                reconnectTriggered = false,
                 abortReason = AnalyticsCallAbortReason.REQUEST_TIMEOUT,
             )
         }
@@ -993,14 +1011,13 @@ public class RtcSession internal constructor(
             logger.w { "[connectInternal] $msg" }
             sfuTracer.trace("connect-failed", msg)
             sendCallStats()
-            // These are the exact states stateJob reacts to, so if this is recoverable
-            // a Call.reconnect is already being launched — the caller must not start another.
-            val triggersReconnect =
-                (sfuSocketState as? SfuSocketState.Disconnected)?.triggersStateJobReconnect() ?: false
+            // Recoverable only when the terminal state is one stateJob reacts to; in that
+            // case a Call.reconnect is already being launched, so the join flow just awaits.
+            val recoverable =
+                (sfuSocketState as? SfuSocketState.Disconnected)?.isRecoverable() ?: false
             SfuConnectionResult.Failure(
-                error = Exception(msg),
-                recoverable = triggersReconnect,
-                reconnectTriggered = triggersReconnect,
+                error = SfuConnectException.Disconnected(msg),
+                recoverable = recoverable,
                 abortReason = networkError?.toAbortReason(),
             )
         }
@@ -1015,7 +1032,7 @@ public class RtcSession internal constructor(
      * `when` (no `else`) makes a new [SfuSocketState.Disconnected] subtype a compile
      * error here, forcing both sites to stay in sync.
      */
-    private fun SfuSocketState.Disconnected.triggersStateJobReconnect(): Boolean = when (this) {
+    private fun SfuSocketState.Disconnected.isRecoverable(): Boolean = when (this) {
         is SfuSocketState.Disconnected.DisconnectedTemporarily,
         is SfuSocketState.Disconnected.WebSocketEventLost,
         -> true

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/SfuConnectFailureCause.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/SfuConnectFailureCause.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call
+
+/**
+ * Typed cause of a failed SFU connect attempt. This reports what happened at
+ * the socket/session boundary; callers decide how to recover from each cause.
+ */
+internal sealed interface SfuConnectFailureCause {
+    /**
+     * [RtcSession.connectInternal] stopped waiting for the socket to reach a terminal state.
+     */
+    data object SocketStateObservationTimeout : SfuConnectFailureCause
+
+    /**
+     * The socket failure is already being recovered by [RtcSession.stateJob].
+     */
+    data object RecoverableSocketFailure : SfuConnectFailureCause
+
+    /**
+     * The socket failure should fail immediately without recovery.
+     */
+    data object TerminalSocketFailure : SfuConnectFailureCause
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
@@ -22,9 +22,12 @@ import io.getstream.android.video.generated.models.VideoEvent
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
 import io.getstream.video.android.core.base.TestBase
+import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.errors.VideoErrorCode
 import io.getstream.video.android.model.User
 import io.getstream.video.android.model.UserType
+import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -139,7 +142,6 @@ class ClientAndAuthTest : TestBase() {
     fun `guest user can join a call`() = runTest {
         // Mock WebRTC components — real peer connections cannot run in Robolectric/unit tests.
         Call.testInstanceProvider.mediaManagerCreator = { mockk(relaxed = true) }
-        Call.testInstanceProvider.rtcSessionCreator = { mockk(relaxed = true) }
 
         // Step 1: create the call as an authenticated user.
         val authClient = StreamVideoBuilder(
@@ -181,6 +183,9 @@ class ClientAndAuthTest : TestBase() {
 
         val guestCall = guestClient.call("default", callId)
         guestCall.peerConnectionFactory = mockedPCFactory
+        val rtcSession = mockk<RtcSession>(relaxed = true)
+        coEvery { rtcSession.connectInternal(any(), any()) } returns SfuConnectionResult.Success
+        guestCall.unitTestRtcSessionFactory = { rtcSession }
 
         val joinResult = guestCall.join()
         assertSuccess(joinResult)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/OrphanedTracksTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/OrphanedTracksTest.kt
@@ -18,6 +18,10 @@ package io.getstream.video.android.core
 
 import com.google.common.truth.Truth.assertThat
 import io.getstream.video.android.core.base.IntegrationTestBase
+import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectionResult
+import io.mockk.coEvery
+import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -41,6 +45,13 @@ private inline fun <R> Call.use(block: (Call) -> R): R {
     }
 }
 
+private fun StreamVideo.mockSuccessfulJoinCall(type: String, id: String): Call =
+    call(type, id).apply {
+        val rtcSession = mockk<RtcSession>(relaxed = true)
+        coEvery { rtcSession.connectInternal(any(), any()) } returns SfuConnectionResult.Success
+        unitTestRtcSessionFactory = { rtcSession }
+    }
+
 /**
  * Integration tests for the orphaned tracks mechanism.
  *
@@ -57,7 +68,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `track arriving before participant is stored as orphaned and reconciled on participant join`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -89,7 +100,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `multiple tracks for same participant are all reconciled`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -123,8 +134,8 @@ class OrphanedTracksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `orphaned tracks for different participants don't interfere`() = runTest {
-        val call = client.call("livestream", randomUUID())
+    fun `orphaned tracks for different participants don't interfere`() = runTest { // noob
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -174,7 +185,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `TrackPublishedEvent with participant info creates participant and reconciles tracks`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -205,7 +216,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `TrackUnpublishedEvent with participant info updates participant state`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -246,7 +257,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `track arriving after participant is attached immediately`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -286,8 +297,8 @@ class OrphanedTracksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `orphaned tracks are cleaned up when WebRTC stream is removed`() = runTest {
-        val call = client.call("livestream", randomUUID())
+    fun `orphaned tracks are cleaned up when WebRTC stream is removed`() = runTest { // noob
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestBase.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestBase.kt
@@ -115,7 +115,6 @@ open class IntegrationTestBase(val connectCoordinatorWS: Boolean = true) : TestB
             }
             // always mock the peer connection factory, it can't work in unit tests
             Call.testInstanceProvider.mediaManagerCreator = { mockk(relaxed = true) }
-            Call.testInstanceProvider.rtcSessionCreator = { mockk(relaxed = true) }
             // Connect to the WS if needed
             if (connectCoordinatorWS) {
                 // wait for the connection/ avoids race conditions in tests

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/FastReconnectIceRestartTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/FastReconnectIceRestartTest.kt
@@ -29,6 +29,7 @@ import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
 import io.getstream.video.android.core.call.FastReconnectResult
 import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.connection.Publisher
 import io.getstream.video.android.core.call.connection.Subscriber
@@ -243,7 +244,10 @@ class FastReconnectIceRestartTest {
         session.subscriber.value = sub
 
         val error = Exception("SFU connection timed out")
-        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Failure(error)
+        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Failure(
+            error,
+            cause = SfuConnectFailureCause.TerminalSocketFailure,
+        )
 
         val result = session.fastReconnect(null)
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
@@ -28,6 +28,7 @@ import io.getstream.video.android.core.analytics.call.observer.model.JoinAnalyti
 import io.getstream.video.android.core.analytics.call.observer.model.JoinReason
 import io.getstream.video.android.core.base.DispatcherRule
 import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectException
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
@@ -56,12 +57,13 @@ import stream.video.sfu.models.WebsocketReconnectStrategy
  * Tests the initial-join handling of a recoverable SFU connection failure
  * (e.g. a connection timeout) in [Call._join].
  *
- * A recoverable failure carries [SfuConnectionResult.Failure.reconnectTriggered]:
- * - `true` — the RtcSession's stateJob is already launching [Call.reconnect], so
- *   `_join` defers to that single recovery loop and awaits its terminal outcome.
- * - `false` — nothing will start recovery on its own (e.g. the connect safety-timeout
- *   disconnected the socket into a state stateJob ignores), so `_join` must trigger
- *   the reconnect itself before awaiting.
+ * A recoverable failure's [SfuConnectionResult.Failure.error] type decides the path:
+ * - [SfuConnectException.Disconnected] — the RtcSession's stateJob is already launching
+ *   [Call.reconnect], so `_join` defers to that single recovery loop and awaits its
+ *   terminal outcome.
+ * - [SfuConnectException.Timeout] — nothing will start recovery on its own (the connect
+ *   safety-timeout tore the socket down into a state stateJob ignores), so `_join` must
+ *   start the reconnect itself before awaiting.
  *
  * A non-recoverable failure must fail immediately.
  */
@@ -129,14 +131,13 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `recoverable failure with reconnect already triggered awaits the existing loop`() = runTest(
+    fun `recoverable socket disconnect awaits the existing reconnect loop`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
             SfuConnectionResult.Failure(
-                Exception("SFU connection timed out"),
+                SfuConnectException.Disconnected("SFU socket disconnected"),
                 recoverable = true,
-                reconnectTriggered = true,
             )
 
         val deferred = async {
@@ -156,14 +157,13 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `recoverable failure with no reconnect triggered starts a REJOIN itself`() = runTest(
+    fun `recoverable connect timeout starts a REJOIN itself`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
             SfuConnectionResult.Failure(
-                Exception("SFU connection timed out"),
+                SfuConnectException.Timeout("SFU connection timed out"),
                 recoverable = true,
-                reconnectTriggered = false,
             )
         // Stub the loop so we only assert it is invoked, not run it for real.
         coEvery { call.reconnect(any(), any()) } returns Unit

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
@@ -34,6 +34,7 @@ import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.getstream.video.android.model.User
 import io.mockk.MockKAnnotations
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.impl.annotations.RelaxedMockK
 import io.mockk.mockk
@@ -49,15 +50,20 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
+import stream.video.sfu.models.WebsocketReconnectStrategy
 
 /**
  * Tests the initial-join handling of a recoverable SFU connection failure
  * (e.g. a connection timeout) in [Call._join].
  *
- * On a recoverable failure the RtcSession's stateJob has already triggered
- * [Call.reconnect], so `_join` must defer to that single recovery loop and await
- * its terminal outcome instead of declaring a permanent failure. A non-recoverable
- * failure must fail immediately.
+ * A recoverable failure carries [SfuConnectionResult.Failure.reconnectTriggered]:
+ * - `true` — the RtcSession's stateJob is already launching [Call.reconnect], so
+ *   `_join` defers to that single recovery loop and awaits its terminal outcome.
+ * - `false` — nothing will start recovery on its own (e.g. the connect safety-timeout
+ *   disconnected the socket into a state stateJob ignores), so `_join` must trigger
+ *   the reconnect itself before awaiting.
+ *
+ * A non-recoverable failure must fail immediately.
  */
 class JoinRecoverableFailureTest {
 
@@ -123,11 +129,15 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `recoverable failure returns failure when reconnect is exhausted`() = runTest(
+    fun `recoverable failure with reconnect already triggered awaits the existing loop`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
-            SfuConnectionResult.Failure(Exception("SFU connection timed out"), recoverable = true)
+            SfuConnectionResult.Failure(
+                Exception("SFU connection timed out"),
+                recoverable = true,
+                reconnectTriggered = true,
+            )
 
         val deferred = async {
             call._join(joinAnalyticsModel = JoinAnalyticsModel(0, JoinReason.FirstAttempt))
@@ -135,7 +145,43 @@ class JoinRecoverableFailureTest {
         advanceUntilIdle()
         assertThat(deferred.isCompleted).isFalse()
 
+        // stateJob owns the loop here; _join must not start its own.
+        coVerify(exactly = 0) { call.reconnect(any(), any()) }
+
         // The reconnect loop gives up.
+        call.state._connection.value = RealtimeConnection.ReconnectingFailed
+        advanceUntilIdle()
+
+        assertThat(deferred.await()).isInstanceOf(Failure::class.java)
+    }
+
+    @Test
+    fun `recoverable failure with no reconnect triggered starts a REJOIN itself`() = runTest(
+        testDispatcher,
+    ) {
+        coEvery { mockSession.connectInternal(any(), any()) } returns
+            SfuConnectionResult.Failure(
+                Exception("SFU connection timed out"),
+                recoverable = true,
+                reconnectTriggered = false,
+            )
+        // Stub the loop so we only assert it is invoked, not run it for real.
+        coEvery { call.reconnect(any(), any()) } returns Unit
+
+        val deferred = async {
+            call._join(joinAnalyticsModel = JoinAnalyticsModel(0, JoinReason.FirstAttempt))
+        }
+        advanceUntilIdle()
+
+        // Nothing else would drive recovery, so _join must trigger a REJOIN.
+        coVerify {
+            call.reconnect(
+                WebsocketReconnectStrategy.WEBSOCKET_RECONNECT_STRATEGY_REJOIN,
+                any(),
+            )
+        }
+        assertThat(deferred.isCompleted).isFalse()
+
         call.state._connection.value = RealtimeConnection.ReconnectingFailed
         advanceUntilIdle()
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
@@ -28,7 +28,7 @@ import io.getstream.video.android.core.analytics.call.observer.model.JoinAnalyti
 import io.getstream.video.android.core.analytics.call.observer.model.JoinReason
 import io.getstream.video.android.core.base.DispatcherRule
 import io.getstream.video.android.core.call.RtcSession
-import io.getstream.video.android.core.call.SfuConnectException
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
@@ -54,18 +54,14 @@ import org.junit.Test
 import stream.video.sfu.models.WebsocketReconnectStrategy
 
 /**
- * Tests the initial-join handling of a recoverable SFU connection failure
- * (e.g. a connection timeout) in [Call._join].
+ * Tests the initial-join handling of failed SFU connect attempts in [Call._join].
  *
- * A recoverable failure's [SfuConnectionResult.Failure.error] type decides the path:
- * - [SfuConnectException.Disconnected] — the RtcSession's stateJob is already launching
- *   [Call.reconnect], so `_join` defers to that single recovery loop and awaits its
- *   terminal outcome.
- * - [SfuConnectException.Timeout] — nothing will start recovery on its own (the connect
- *   safety-timeout tore the socket down into a state stateJob ignores), so `_join` must
- *   start the reconnect itself before awaiting.
- *
- * A non-recoverable failure must fail immediately.
+ * The failure cause decides how `_join` orchestrates recovery:
+ * - [SfuConnectFailureCause.SocketStateObservationTimeout] starts a REJOIN
+ *   because no reconnect loop was started by stateJob.
+ * - [SfuConnectFailureCause.RecoverableSocketFailure] waits for the reconnect
+ *   loop already started by stateJob.
+ * - [SfuConnectFailureCause.TerminalSocketFailure] fails immediately.
  */
 class JoinRecoverableFailureTest {
 
@@ -119,25 +115,24 @@ class JoinRecoverableFailureTest {
             call.joinRequest(any(), any(), any(), any(), any(), any(), any(), any())
         } returns Success(mockJoinResponse)
 
-        // Inject our mocked RtcSession instead of constructing a real one.
-        Call.testInstanceProvider.rtcSessionCreator = { mockSession }
+        // Inject our mocked RtcSession into this Call instead of constructing a real one.
+        call.unitTestRtcSessionFactory = { mockSession }
     }
 
     @After
     fun tearDown() {
-        Call.testInstanceProvider.rtcSessionCreator = null
         StreamVideo.removeClient()
         unmockkAll()
     }
 
     @Test
-    fun `recoverable socket disconnect awaits the existing reconnect loop`() = runTest(
+    fun `recoverable socket failure awaits the existing reconnect loop`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
             SfuConnectionResult.Failure(
-                SfuConnectException.Disconnected("SFU socket disconnected"),
-                recoverable = true,
+                Exception("SFU socket disconnected"),
+                cause = SfuConnectFailureCause.RecoverableSocketFailure,
             )
 
         val deferred = async {
@@ -157,13 +152,13 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `recoverable connect timeout starts a REJOIN itself`() = runTest(
+    fun `socket state observation timeout starts a REJOIN itself`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
             SfuConnectionResult.Failure(
-                SfuConnectException.Timeout("SFU connection timed out"),
-                recoverable = true,
+                Exception("SFU connection timed out"),
+                cause = SfuConnectFailureCause.SocketStateObservationTimeout,
             )
         // Stub the loop so we only assert it is invoked, not run it for real.
         coEvery { call.reconnect(any(), any()) } returns Unit
@@ -189,11 +184,14 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `non-recoverable failure fails immediately without awaiting reconnect`() = runTest(
+    fun `terminal socket failure fails immediately without awaiting reconnect`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
-            SfuConnectionResult.Failure(Exception("permanent auth error"), recoverable = false)
+            SfuConnectionResult.Failure(
+                Exception("permanent auth error"),
+                cause = SfuConnectFailureCause.TerminalSocketFailure,
+            )
 
         val result = call._join(joinAnalyticsModel = JoinAnalyticsModel(0, JoinReason.FirstAttempt))
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -363,6 +363,9 @@ class RtcSessionTest2 {
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
                 result.abortReason,
             )
+            // The abandoned, still-in-flight socket must be torn down so a late
+            // Connected can't resurface through stateJob and resurrect the session.
+            coVerify { mockSocketConnection.disconnect() }
         }
 
     @Suppress("DEPRECATION")

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -29,7 +29,7 @@ import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
 import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAbortReason
 import io.getstream.video.android.core.call.RtcSession
-import io.getstream.video.android.core.call.SfuConnectException
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.connection.Publisher
 import io.getstream.video.android.core.errors.VideoErrorCode
@@ -53,7 +53,6 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
@@ -297,18 +296,19 @@ class RtcSessionTest2 {
                 "Expected timeout message",
                 (result as SfuConnectionResult.Failure).error.message!!.contains("timed out"),
             )
-            // A timeout is recoverable — the stateJob triggers a reconnect, so the
-            // join flow should await it rather than failing permanently.
-            assertTrue("Expected recoverable=true for a timeout", result.recoverable)
+            assertEquals(
+                SfuConnectFailureCause.RecoverableSocketFailure,
+                result.cause,
+            )
             assertEquals(
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
-                (result as SfuConnectionResult.Failure).abortReason,
+                result.abortReason,
             )
         }
 
     @Suppress("DEPRECATION")
     @Test
-    fun `connectInternal safety timeout fires when socket stays non-terminal`() =
+    fun `connectInternal socket state observation timeout fires when socket stays non-terminal`() =
         runTest(testDispatcher) {
             val sfuSocketStateFlow = MutableStateFlow<SfuSocketState>(
                 SfuSocketState.Disconnected.Stopped,
@@ -346,7 +346,7 @@ class RtcSessionTest2 {
             coJustRun { rtcSession.sendCallStats(any(), any(), any()) }
 
             val resultDeferred = async { rtcSession.connectInternal() }
-            // Safety timeout = 2 * 50ms + 1000ms grace
+            // Socket state observation timeout = 2 * 50ms + 1000ms grace
             advanceTimeBy(1_101L)
             val result = resultDeferred.await()
 
@@ -355,15 +355,12 @@ class RtcSessionTest2 {
                 result is SfuConnectionResult.Failure,
             )
             assertTrue(
-                "Expected safety-timeout message",
+                "Expected socket state observation timeout message",
                 (result as SfuConnectionResult.Failure).error.message!!.contains("timed out"),
             )
-            assertTrue("Expected recoverable=true for a safety timeout", result.recoverable)
-            // A Timeout-typed error is what makes _join self-trigger a REJOIN for this path,
-            // since stateJob ignores the state the stuck socket was torn down into.
-            assertTrue(
-                "Expected a SfuConnectException.Timeout error for a safety timeout",
-                result.error is SfuConnectException.Timeout,
+            assertEquals(
+                SfuConnectFailureCause.SocketStateObservationTimeout,
+                result.cause,
             )
             assertEquals(
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
@@ -429,7 +426,10 @@ class RtcSessionTest2 {
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
                 (result as SfuConnectionResult.Failure).abortReason,
             )
-            assertTrue("Expected recoverable=true for a transport timeout", result.recoverable)
+            assertEquals(
+                SfuConnectFailureCause.RecoverableSocketFailure,
+                result.cause,
+            )
         }
 
     @Suppress("DEPRECATION")
@@ -480,9 +480,9 @@ class RtcSessionTest2 {
                 "Expected SfuConnectionResult.Failure but got $result",
                 result is SfuConnectionResult.Failure,
             )
-            assertFalse(
-                "Expected recoverable=false for a permanent disconnect",
-                (result as SfuConnectionResult.Failure).recoverable,
+            assertEquals(
+                SfuConnectFailureCause.TerminalSocketFailure,
+                (result as SfuConnectionResult.Failure).cause,
             )
         }
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -20,7 +20,6 @@ import android.os.PowerManager
 import androidx.lifecycle.Lifecycle
 import io.getstream.android.video.generated.models.OwnCapability
 import io.getstream.result.Error
-import io.getstream.result.Result
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.CallState
 import io.getstream.video.android.core.MediaManagerImpl
@@ -30,6 +29,7 @@ import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
 import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAbortReason
 import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectException
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.connection.Publisher
 import io.getstream.video.android.core.errors.VideoErrorCode
@@ -359,6 +359,12 @@ class RtcSessionTest2 {
                 (result as SfuConnectionResult.Failure).error.message!!.contains("timed out"),
             )
             assertTrue("Expected recoverable=true for a safety timeout", result.recoverable)
+            // A Timeout-typed error is what makes _join self-trigger a REJOIN for this path,
+            // since stateJob ignores the state the stuck socket was torn down into.
+            assertTrue(
+                "Expected a SfuConnectException.Timeout error for a safety timeout",
+                result.error is SfuConnectException.Timeout,
+            )
             assertEquals(
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
                 result.abortReason,


### PR DESCRIPTION
### Goal

Follow-up to #1740 and [AN-1294](https://linear.app/stream/issue/AND-1294/fix-the-timeout-based-logic-of-sfu-ws-connection) That PR added a safety-timeout to `RtcSession.connectInternal` so the SFU connect wait can no longer suspend forever. But there is still a gap on the **initial join** path: when the safety-timeout fires, the socket is left in a **non-terminal** state that `stateJob` does not react to, so no `Call.reconnect` is ever launched. `_join` then calls `didReconnectSucceed()` and waits for a recovery loop that will never start — blocking indefinitely.

This PR closes that gap and makes the abandoned connect attempt safe to leave behind.

### Implementation

- **`SfuConnectionResult.Failure.reconnectTriggered`** — new flag that tells the join flow whether a recovery loop has already been launched by `stateJob`:
  - `true` for terminal disconnect states `stateJob` reacts to (a `Call.reconnect` is already in flight — the caller must not start another).
  - `false` for the connect safety-timeout, which leaves the socket in a state `stateJob` ignores (nothing will drive recovery on its own).
- **Tear down the abandoned socket on safety-timeout** — the connect attempt is still in flight when the safety-timeout fires, so `connectInternal` now calls `socketConnection.disconnect()` before returning. This prevents a late `Connected`/`JoinResponse` from an abandoned attempt resurfacing through `stateJob` and resurrecting a dead session ("zombie socket").
- **`Call._join` self-triggers recovery** — on a recoverable failure with `reconnectTriggered == false`, `_join` now launches a `REJOIN` itself before awaiting the outcome (a full REJOIN, not FAST, because the initial join never completed — there is no negotiated media path to resume, so FAST would just burn attempts on `PARTICIPANT_NOT_FOUND`). When `reconnectTriggered == true` it defers to the existing loop as before.
- **Rename** `SfuSocketState.Disconnected.canTriggersReconnect()` → `triggersStateJobReconnect()` for clarity (it describes which states `stateJob` acts on).
- **demo-app** — align `connectionTimeoutInMs` with the SDK default (`5_000L`) instead of the hardcoded `12_000L`.

### Testing

- [x] `./gradlew :stream-video-android-core:testDebugUnitTest --tests "*.JoinRecoverableFailureTest" --tests "*.RtcSessionTest2"` — passing
- [x] `./gradlew :stream-video-android-core:spotlessApply :demo-app:spotlessApply` — clean

New/updated unit tests:
- `JoinRecoverableFailureTest`
  - `recoverable failure with reconnect already triggered awaits the existing loop` — asserts `_join` does **not** start its own `reconnect` when `reconnectTriggered == true`.
  - `recoverable failure with no reconnect triggered starts a REJOIN itself` — asserts `_join` launches a `REJOIN` when `reconnectTriggered == false`.
- `RtcSessionTest2` — safety-timeout test now verifies the abandoned socket is `disconnect()`-ed.

Manual: reproduced a silent connect hang (OkHttp `callTimeout`/`readTimeout` set to `0` locally + Charles breakpoint on the SFU WS upgrade). Confirmed the safety-timeout fires, the socket is torn down, `_join` self-triggers a REJOIN, and the flow ends in a bounded failure instead of hanging.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs on `SfuConnectionResult.Failure`)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_No UI change — skipping._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video connection recovery when the initial websocket join fails, including clearer handling of whether a reconnect is already in progress.
  * Tightened timeout handling so stalled connections are cleanly disconnected and can’t later re-activate an abandoned session.
  * Reduced the initial connection timeout for faster failure detection.
* **Tests**
  * Updated recovery tests to cover both automatic reconnect and caller-initiated rejoin flows.
  * Added coverage for disconnect behavior when the safety timeout is reached.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->