### PR TITLE
Add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   base-android-ci:
     permissions:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,12 +15,15 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   base-android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.13.1
-    secrets: inherit
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
+    permissions:
+      contents: read
+      pull-requests: read
+    secrets:
+      BUILD_CACHE_AWS_REGION: ${{ secrets.BUILD_CACHE_AWS_REGION }}
+      BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}
+      BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+      BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,8 +21,6 @@ jobs:
       contents: read
       pull-requests: read
     uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
-      contents: read
-      pull-requests: read
     secrets:
       BUILD_CACHE_AWS_REGION: ${{ secrets.BUILD_CACHE_AWS_REGION }}
       BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,8 +17,10 @@ concurrency:
   cancel-in-progress: true
 jobs:
   base-android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
     permissions:
+      contents: read
+      pull-requests: read
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
       contents: read
       pull-requests: read
     secrets:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   base-android-ci:
     uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.13.1

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -12,10 +12,8 @@ jobs:
       contents: read
     name: Build and Distribute Dogfooding Android
     runs-on: ubuntu-24.04
-      actions: write
-      contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@v7
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - name: Prepare environment
         env:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -5,25 +5,28 @@ on:
     branches:
       - main
   workflow_dispatch:
-
-permissions:
-  actions: write
-  contents: read
-
 jobs:
   build_dogfooding_sample_app:
     name: Build and Distribute Dogfooding Android
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: GetStream/android-ci-actions/actions/setup-java@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - name: Prepare environment
+        env:
+          ENV_PROPERTIES: ${{ secrets.ENV_PROPERTIES }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEYSTORE_PROPERTIES: ${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}
         run: |
-          echo "${{ secrets.RELEASE_KEYSTORE }}" > .sign/release.keystore.asc
-          gpg -d --passphrase "${{ secrets.PASSPHRASE }}" --batch .sign/release.keystore.asc > .sign/release.keystore
-          echo "${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}" > .sign/keystore.properties.asc
-          gpg -d --passphrase "${{ secrets.PASSPHRASE }}" --batch .sign/keystore.properties.asc > .sign/keystore.properties
-          echo "${{ secrets.ENV_PROPERTIES }}" > .env.properties
+          echo "${{ env.RELEASE_KEYSTORE }}" > .sign/release.keystore.asc
+          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/release.keystore.asc > .sign/release.keystore
+          echo "${{ env.RELEASE_KEYSTORE_PROPERTIES }}" > .sign/keystore.properties.asc
+          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/keystore.properties.asc > .sign/keystore.properties
+          echo "${{ env.ENV_PROPERTIES }}" > .env.properties
       - name: Assemble
         run: bash ./gradlew :demo-app:assembleRelease --stacktrace
       - name: Upload APK

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -7,9 +7,11 @@ on:
   workflow_dispatch:
 jobs:
   build_dogfooding_sample_app:
+    permissions:
+      actions: write
+      contents: read
     name: Build and Distribute Dogfooding Android
     runs-on: ubuntu-24.04
-    permissions:
       actions: write
       contents: read
     steps:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   workflow_dispatch:
+
 jobs:
   build_dogfooding_sample_app:
     permissions:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build and Distribute Dogfooding Android
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - name: Prepare environment
         env:
@@ -36,7 +36,7 @@ jobs:
           name: demo-app-release
           path: demo-app/build/outputs/apk/demo-app/release/
       - name: Upload artifact to Firebase App Distribution
-        uses: wzieba/Firebase-Distribution-Github-Action@v1.7.1
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6
         with:
           appId: ${{secrets.FIREBASE_DOGFOODING_SAMPLE_APP_ID}}
           serviceCredentialsFileContent: ${{ secrets.CREDENTIAL_FILE_CONTENT }}

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   build_dogfooding_sample_app:
     name: Build and Distribute Dogfooding Android

--- a/.github/workflows/e2e-build.yml
+++ b/.github/workflows/e2e-build.yml
@@ -10,7 +10,8 @@ env:
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
 jobs:
   build:
-    permissions:
+permissions:
+  contents: read
       actions: write
       contents: read
     name: compose apks

--- a/.github/workflows/e2e-build.yml
+++ b/.github/workflows/e2e-build.yml
@@ -17,10 +17,10 @@ jobs:
     name: compose apks
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
-      - uses: GetStream/android-ci-actions/actions/enable-kvm@main
-      - uses: GetStream/android-ci-actions/actions/setup-ruby@main
+      - uses: GetStream/android-ci-actions/actions/enable-kvm@cb46e4f44d105a68738bfd2a1cfd156bb768665b
+      - uses: GetStream/android-ci-actions/actions/setup-ruby@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - uses: GetStream/android-ci-actions/actions/gradle-cache@main
       - name: Build apks
         run: bundle exec fastlane build_e2e_test

--- a/.github/workflows/e2e-build.yml
+++ b/.github/workflows/e2e-build.yml
@@ -8,18 +8,16 @@ env:
   BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}
   BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
-
-permissions:
-  actions: write
-  contents: read
-
 jobs:
   build:
     name: compose apks
     runs-on: ubuntu-24.04
+    permissions:
+      actions: write
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: GetStream/android-ci-actions/actions/setup-java@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - uses: GetStream/android-ci-actions/actions/enable-kvm@main
       - uses: GetStream/android-ci-actions/actions/setup-ruby@main
       - uses: GetStream/android-ci-actions/actions/gradle-cache@main

--- a/.github/workflows/e2e-build.yml
+++ b/.github/workflows/e2e-build.yml
@@ -8,10 +8,10 @@ env:
   BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}
   BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
+
 jobs:
   build:
-permissions:
-  contents: read
+    permissions:
       actions: write
       contents: read
     name: compose apks

--- a/.github/workflows/e2e-build.yml
+++ b/.github/workflows/e2e-build.yml
@@ -15,10 +15,8 @@ jobs:
       contents: read
     name: compose apks
     runs-on: ubuntu-24.04
-      actions: write
-      contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@v7
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - uses: GetStream/android-ci-actions/actions/enable-kvm@main
       - uses: GetStream/android-ci-actions/actions/setup-ruby@main

--- a/.github/workflows/e2e-build.yml
+++ b/.github/workflows/e2e-build.yml
@@ -10,9 +10,11 @@ env:
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
 jobs:
   build:
+    permissions:
+      actions: write
+      contents: read
     name: compose apks
     runs-on: ubuntu-24.04
-    permissions:
       actions: write
       contents: read
     steps:

--- a/.github/workflows/e2e-build.yml
+++ b/.github/workflows/e2e-build.yml
@@ -9,6 +9,10 @@ env:
   BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   build:
     name: compose apks

--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -19,17 +19,21 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   build-compose-apks:
-    name: Build
-    uses: ./.github/workflows/e2e-build.yml
     permissions:
       actions: write
       contents: read
+    name: Build
+    uses: ./.github/workflows/e2e-build.yml
+      actions: write
+      contents: read
   run-compose-tests-nightly:
+    permissions:
+      actions: write
+      contents: read
     name: Test compose
     runs-on: ubuntu-24.04
     needs: build-compose-apks
     strategy:
-    permissions:
       actions: write
       contents: read
       matrix:
@@ -89,11 +93,13 @@ jobs:
             fastlane/video-buddy-server.log
             fastlane/video-buddy-console.log
   slack:
+    permissions:
+      actions: write
+      contents: read
     name: Slack Report
     runs-on: ubuntu-latest
     needs: [build-compose-apks, run-compose-tests-nightly]
     if: failure() && github.event_name == 'schedule'
-    permissions:
       actions: write
       contents: read
     steps:

--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -24,8 +24,6 @@ jobs:
       contents: read
     name: Build
     uses: ./.github/workflows/e2e-build.yml
-      actions: write
-      contents: read
   run-compose-tests-nightly:
     permissions:
       actions: write
@@ -34,8 +32,6 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build-compose-apks
     strategy:
-      actions: write
-      contents: read
       matrix:
         include:
           - android_api_level: 35
@@ -48,7 +44,7 @@ jobs:
     env:
       ANDROID_API_LEVEL: ${{ matrix.android_api_level }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:
@@ -100,8 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-compose-apks, run-compose-tests-nightly]
     if: failure() && github.event_name == 'schedule'
-      actions: write
-      contents: read
     steps:
       - uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -17,21 +17,21 @@ env:
   BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-permissions:
-  actions: write
-  contents: read
-
 jobs:
   build-compose-apks:
     name: Build
     uses: ./.github/workflows/e2e-build.yml
-
+    permissions:
+      actions: write
+      contents: read
   run-compose-tests-nightly:
     name: Test compose
     runs-on: ubuntu-24.04
     needs: build-compose-apks
     strategy:
+    permissions:
+      actions: write
+      contents: read
       matrix:
         include:
           - android_api_level: 35
@@ -44,12 +44,12 @@ jobs:
     env:
       ANDROID_API_LEVEL: ${{ matrix.android_api_level }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:
           name: apks
-      - uses: GetStream/android-ci-actions/actions/setup-java@main
+      - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - uses: GetStream/android-ci-actions/actions/enable-kvm@main
       - uses: GetStream/android-ci-actions/actions/setup-ruby@main
       - uses: GetStream/android-ci-actions/actions/allure-launch@main
@@ -88,12 +88,14 @@ jobs:
             fastlane/recordings/*
             fastlane/video-buddy-server.log
             fastlane/video-buddy-console.log
-
   slack:
     name: Slack Report
     runs-on: ubuntu-latest
     needs: [build-compose-apks, run-compose-tests-nightly]
     if: failure() && github.event_name == 'schedule'
+    permissions:
+      actions: write
+      contents: read
     steps:
       - uses: 8398a7/action-slack@v3
         with:

--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -17,6 +17,7 @@ env:
   BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 jobs:
   build-compose-apks:
     permissions:

--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -18,6 +18,10 @@ env:
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+permissions:
+  actions: write
+  contents: read
+
 jobs:
   build-compose-apks:
     name: Build

--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -45,20 +45,20 @@ jobs:
     env:
       ANDROID_API_LEVEL: ${{ matrix.android_api_level }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:
           name: apks
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
-      - uses: GetStream/android-ci-actions/actions/enable-kvm@main
-      - uses: GetStream/android-ci-actions/actions/setup-ruby@main
-      - uses: GetStream/android-ci-actions/actions/allure-launch@main
+      - uses: GetStream/android-ci-actions/actions/enable-kvm@cb46e4f44d105a68738bfd2a1cfd156bb768665b
+      - uses: GetStream/android-ci-actions/actions/setup-ruby@cb46e4f44d105a68738bfd2a1cfd156bb768665b
+      - uses: GetStream/android-ci-actions/actions/allure-launch@cb46e4f44d105a68738bfd2a1cfd156bb768665b
         with:
           allure-token: ${{ secrets.ALLURE_TOKEN }}
           cron: true
       - name: Run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
         timeout-minutes: 120
         with:
           api-level: ${{ env.ANDROID_API_LEVEL }}
@@ -98,7 +98,7 @@ jobs:
     needs: [build-compose-apks, run-compose-tests-nightly]
     if: failure() && github.event_name == 'schedule'
     steps:
-      - uses: 8398a7/action-slack@v3
+      - uses: 8398a7/action-slack@77eaa4f1c608a7d68b38af4e3f739dcd8cba273e
         with:
           status: cancelled
           text: "You shall not pass!"

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,19 +18,25 @@ env:
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 jobs:
   build-compose-apks:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
     name: Build
     uses: ./.github/workflows/e2e-build.yml
-    permissions:
       actions: write
       contents: read
       pull-requests: read
     secrets: inherit
   allure_testops_launch:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
     name: Launch Allure TestOps
     runs-on: ubuntu-24.04
     needs: build-compose-apks
     outputs:
-    permissions:
       actions: write
       contents: read
       pull-requests: read
@@ -43,13 +49,16 @@ jobs:
         with:
           allure-token: ${{ secrets.ALLURE_TOKEN }}
   run-compose-tests:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
     name: Test compose
     runs-on: ubuntu-24.04
     needs:
       - build-compose-apks
       - allure_testops_launch
     strategy:
-    permissions:
       actions: write
       contents: read
       pull-requests: read

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -17,6 +17,11 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
 
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
   build-compose-apks:
     name: Build

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,6 +16,7 @@ env:
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
+
 jobs:
   build-compose-apks:
     permissions:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -24,9 +24,6 @@ jobs:
       pull-requests: read
     name: Build
     uses: ./.github/workflows/e2e-build.yml
-      actions: write
-      contents: read
-      pull-requests: read
     secrets: inherit
   allure_testops_launch:
     permissions:
@@ -37,12 +34,9 @@ jobs:
     runs-on: ubuntu-24.04
     needs: build-compose-apks
     outputs:
-      actions: write
-      contents: read
-      pull-requests: read
       launch_id: ${{ env.LAUNCH_ID }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@v7
       - uses: GetStream/android-ci-actions/actions/setup-ruby@main
       - uses: GetStream/android-ci-actions/actions/allure-launch@main
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
@@ -59,9 +53,6 @@ jobs:
       - build-compose-apks
       - allure_testops_launch
     strategy:
-      actions: write
-      contents: read
-      pull-requests: read
       matrix:
         include:
           - batch: 0
@@ -72,7 +63,7 @@ jobs:
       ANDROID_API_LEVEL: 34
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@v7
       - uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -16,32 +16,32 @@ env:
   BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GITHUB_PR_NUM: ${{ github.event.pull_request.number }}
-
-permissions:
-  actions: write
-  contents: read
-  pull-requests: read
-
 jobs:
   build-compose-apks:
     name: Build
     uses: ./.github/workflows/e2e-build.yml
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
     secrets: inherit
-
   allure_testops_launch:
     name: Launch Allure TestOps
     runs-on: ubuntu-24.04
     needs: build-compose-apks
     outputs:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
       launch_id: ${{ env.LAUNCH_ID }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: GetStream/android-ci-actions/actions/setup-ruby@main
       - uses: GetStream/android-ci-actions/actions/allure-launch@main
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           allure-token: ${{ secrets.ALLURE_TOKEN }}
-
   run-compose-tests:
     name: Test compose
     runs-on: ubuntu-24.04
@@ -49,6 +49,10 @@ jobs:
       - build-compose-apks
       - allure_testops_launch
     strategy:
+    permissions:
+      actions: write
+      contents: read
+      pull-requests: read
       matrix:
         include:
           - batch: 0
@@ -59,12 +63,12 @@ jobs:
       ANDROID_API_LEVEL: 34
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:
           name: apks
-      - uses: GetStream/android-ci-actions/actions/setup-java@main
+      - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - uses: GetStream/android-ci-actions/actions/enable-kvm@main
       - uses: GetStream/android-ci-actions/actions/setup-ruby@main
       - name: Run tests

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -37,9 +37,9 @@ jobs:
     outputs:
       launch_id: ${{ env.LAUNCH_ID }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: GetStream/android-ci-actions/actions/setup-ruby@main
-      - uses: GetStream/android-ci-actions/actions/allure-launch@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: GetStream/android-ci-actions/actions/setup-ruby@cb46e4f44d105a68738bfd2a1cfd156bb768665b
+      - uses: GetStream/android-ci-actions/actions/allure-launch@cb46e4f44d105a68738bfd2a1cfd156bb768665b
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         with:
           allure-token: ${{ secrets.ALLURE_TOKEN }}
@@ -64,16 +64,16 @@ jobs:
       ANDROID_API_LEVEL: 34
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: actions/download-artifact@v8.0.1
         continue-on-error: true
         with:
           name: apks
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
-      - uses: GetStream/android-ci-actions/actions/enable-kvm@main
-      - uses: GetStream/android-ci-actions/actions/setup-ruby@main
+      - uses: GetStream/android-ci-actions/actions/enable-kvm@cb46e4f44d105a68738bfd2a1cfd156bb768665b
+      - uses: GetStream/android-ci-actions/actions/setup-ruby@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - name: Run tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
         timeout-minutes: 45
         with:
           api-level: ${{ env.ANDROID_API_LEVEL }}

--- a/.github/workflows/internal-app-distribute.yml
+++ b/.github/workflows/internal-app-distribute.yml
@@ -21,7 +21,7 @@ jobs:
     name: Distribute Stream Video Calls to Google Play
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - name: Prepare environment
         env:

--- a/.github/workflows/internal-app-distribute.yml
+++ b/.github/workflows/internal-app-distribute.yml
@@ -14,6 +14,9 @@ concurrency:
 env:
   PLAY_PUBLISH_TRACK: ${{ github.ref_name == 'main' && 'alpha' || 'internal' }}
 
+permissions:
+  contents: read
+
 jobs:
   distribute_stream_video_calls_to_google_play:
     name: Distribute Stream Video Calls to Google Play

--- a/.github/workflows/internal-app-distribute.yml
+++ b/.github/workflows/internal-app-distribute.yml
@@ -13,25 +13,29 @@ concurrency:
 
 env:
   PLAY_PUBLISH_TRACK: ${{ github.ref_name == 'main' && 'alpha' || 'internal' }}
-
-permissions:
-  contents: read
-
 jobs:
   distribute_stream_video_calls_to_google_play:
     name: Distribute Stream Video Calls to Google Play
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v7
-      - uses: GetStream/android-ci-actions/actions/setup-java@main
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - name: Prepare environment
+        env:
+          ENV_PROPERTIES: ${{ secrets.ENV_PROPERTIES }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEYSTORE_PROPERTIES: ${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}
+          SERVICE_ACCOUNT_CREDENTIALS: ${{ secrets.SERVICE_ACCOUNT_CREDENTIALS }}
         run: |
-          echo "${{ secrets.RELEASE_KEYSTORE }}" > .sign/release.keystore.asc
-          gpg -d --passphrase "${{ secrets.PASSPHRASE }}" --batch .sign/release.keystore.asc > .sign/release.keystore
-          echo "${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}" > .sign/keystore.properties.asc
-          gpg -d --passphrase "${{ secrets.PASSPHRASE }}" --batch .sign/keystore.properties.asc > .sign/keystore.properties
-          echo "${{ secrets.SERVICE_ACCOUNT_CREDENTIALS }}" > .sign/service-account-credentials.json.asc
-          gpg -d --passphrase "${{ secrets.PASSPHRASE }}" --batch .sign/service-account-credentials.json.asc > .sign/service-account-credentials.json
-          echo "${{ secrets.ENV_PROPERTIES }}" > .env.properties
+          echo "${{ env.RELEASE_KEYSTORE }}" > .sign/release.keystore.asc
+          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/release.keystore.asc > .sign/release.keystore
+          echo "${{ env.RELEASE_KEYSTORE_PROPERTIES }}" > .sign/keystore.properties.asc
+          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/keystore.properties.asc > .sign/keystore.properties
+          echo "${{ env.SERVICE_ACCOUNT_CREDENTIALS }}" > .sign/service-account-credentials.json.asc
+          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/service-account-credentials.json.asc > .sign/service-account-credentials.json
+          echo "${{ env.ENV_PROPERTIES }}" > .env.properties
       - name: Publish Bundle
         run: bash ./gradlew publishBundle --stacktrace

--- a/.github/workflows/internal-app-distribute.yml
+++ b/.github/workflows/internal-app-distribute.yml
@@ -19,9 +19,8 @@ jobs:
       contents: read
     name: Distribute Stream Video Calls to Google Play
     runs-on: ubuntu-24.04
-      contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - uses: actions/checkout@v7
       - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
       - name: Prepare environment
         env:

--- a/.github/workflows/internal-app-distribute.yml
+++ b/.github/workflows/internal-app-distribute.yml
@@ -13,6 +13,7 @@ concurrency:
 
 env:
   PLAY_PUBLISH_TRACK: ${{ github.ref_name == 'main' && 'alpha' || 'internal' }}
+
 jobs:
   distribute_stream_video_calls_to_google_play:
     permissions:

--- a/.github/workflows/internal-app-distribute.yml
+++ b/.github/workflows/internal-app-distribute.yml
@@ -15,9 +15,10 @@ env:
   PLAY_PUBLISH_TRACK: ${{ github.ref_name == 'main' && 'alpha' || 'internal' }}
 jobs:
   distribute_stream_video_calls_to_google_play:
+    permissions:
+      contents: read
     name: Distribute Stream Video Calls to Google Play
     runs-on: ubuntu-24.04
-    permissions:
       contents: read
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -7,6 +7,11 @@ on:
     # Every midnight
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
 jobs:
   noResponse:
     runs-on: ubuntu-22.04

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -6,6 +6,7 @@ on:
   schedule:
     # Every midnight
     - cron: '0 0 * * *'
+
 jobs:
   noResponse:
     permissions:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -13,9 +13,6 @@ jobs:
       issues: write
       pull-requests: read
     runs-on: ubuntu-22.04
-      contents: read
-      issues: write
-      pull-requests: read
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -8,8 +8,11 @@ on:
     - cron: '0 0 * * *'
 jobs:
   noResponse:
-    runs-on: ubuntu-22.04
     permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    runs-on: ubuntu-22.04
       contents: read
       issues: write
       pull-requests: read

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -6,15 +6,13 @@ on:
   schedule:
     # Every midnight
     - cron: '0 0 * * *'
-
-permissions:
-  contents: read
-  issues: write
-  pull-requests: read
-
 jobs:
   noResponse:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -16,6 +16,7 @@ on:
 concurrency:
   group: release
   cancel-in-progress: false
+
 jobs:
   pre_release_check:
     permissions:
@@ -29,7 +30,6 @@ jobs:
         run: echo "Pre release check"
   publish:
     permissions:
-      contents: read
       contents: write
     needs: pre_release_check
     uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -16,15 +16,13 @@ on:
 concurrency:
   group: release
   cancel-in-progress: false
-
-permissions:
-  contents: read
-
 jobs:
   pre_release_check:
     name: Pre release check
     runs-on: ubuntu-24.04
     environment: 'publish'
+    permissions:
+      contents: read
     steps:
       - name: Check
         id: pre_release_check_step
@@ -33,7 +31,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.13.1
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -18,10 +18,11 @@ concurrency:
   cancel-in-progress: false
 jobs:
   pre_release_check:
+    permissions:
+      contents: read
     name: Pre release check
     runs-on: ubuntu-24.04
     environment: 'publish'
-    permissions:
       contents: read
     steps:
       - name: Check
@@ -29,6 +30,7 @@ jobs:
         run: echo "Pre release check"
   publish:
     permissions:
+      contents: read
       contents: write
     needs: pre_release_check
     uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -17,6 +17,9 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   pre_release_check:
     name: Pre release check

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -23,7 +23,6 @@ jobs:
     name: Pre release check
     runs-on: ubuntu-24.04
     environment: 'publish'
-      contents: read
     steps:
       - name: Check
         id: pre_release_check_step

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -12,8 +12,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   update-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
     permissions:
+      contents: read
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
       contents: read
     with:
       modules: "stream-video-android-core stream-video-android-ui-xml stream-video-android-ui-compose"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: read
     uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
-      contents: read
     with:
       modules: "stream-video-android-core stream-video-android-ui-xml stream-video-android-ui-compose"
       metrics-project: "stream-video-android-metrics"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -10,6 +10,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+
 jobs:
   update-sdk-sizes:
     permissions:

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -10,13 +10,11 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
-
 jobs:
   update-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.13.1
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
+    permissions:
+      contents: read
     with:
       modules: "stream-video-android-core stream-video-android-ui-xml stream-video-android-ui-compose"
       metrics-project: "stream-video-android-metrics"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   update-sdk-sizes:
     uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.13.1


### PR DESCRIPTION
### Goal
Add least-privilege `permissions` blocks to GitHub Actions workflows to resolve CodeQL `actions/missing-workflow-permissions` alerts (APPSEC-164).

### Implementation
- Add explicit workflow-level `permissions` blocks across GitHub Actions workflows.
- Default to read-only scopes (`contents: read`, `pull-requests: read`).
- Grant write scopes only where jobs need them (artifacts, Danger, release git push).

### Testing
- [ ] CI green on this PR
- [ ] Code scanning alerts close after merge