### PR TITLE
Replace SfuConnectException with SfuConnectFailureCause code

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -67,7 +67,7 @@ import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAb
 import io.getstream.video.android.core.audio.StreamAudioDevice
 import io.getstream.video.android.core.call.FastReconnectResult
 import io.getstream.video.android.core.call.RtcSession
-import io.getstream.video.android.core.call.SfuConnectException
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.audio.InputAudioFilter
 import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
@@ -780,13 +780,8 @@ public class Call(
         when (sfuConnectionResult) {
             is SfuConnectionResult.Success -> Unit
             is SfuConnectionResult.Failure -> {
-                if (sfuConnectionResult.recoverable) {
-                    // A recoverable socket disconnect means stateJob is already launching
-                    // Call.reconnect, so we just await its outcome. A connect safety-timeout
-                    // instead tore down a stuck socket into a state stateJob ignores, so
-                    // nothing would start recovery and didReconnectSucceed() would block
-                    // forever — trigger a REJOIN ourselves for that case.
-                    if (sfuConnectionResult.error is SfuConnectException.Timeout) {
+                when (sfuConnectionResult.cause) {
+                    SfuConnectFailureCause.SocketStateObservationTimeout -> {
                         // REJOIN (not FAST) on purpose: a connect timeout means the initial
                         // join never completed. There is no established SFU session or
                         // negotiated media path to resume, so a FAST resume would likely hit
@@ -794,7 +789,7 @@ public class Call(
                         // A full REJOIN re-fetches credentials and starts a clean join, which
                         // is the only thing that can actually succeed here.
                         logger.w {
-                            "[_join] Recoverable SFU connect timeout with no recovery started — triggering REJOIN"
+                            "[_join] SFU socket state observation timed out with no recovery started — triggering REJOIN"
                         }
                         scope.launch {
                             reconnect(
@@ -802,9 +797,26 @@ public class Call(
                                 "join-recoverable-connect-failure",
                             )
                         }
-                    } else {
-                        logger.w { "[_join] Recoverable SFU connection failure — awaiting recovery outcome" }
                     }
+
+                    SfuConnectFailureCause.RecoverableSocketFailure -> {
+                        logger.w { "[_join] Recoverable SFU socket failure — awaiting recovery outcome" }
+                    }
+
+                    SfuConnectFailureCause.TerminalSocketFailure -> {
+                        logger.e {
+                            "[_join] Got terminal error while connecting to SFU. Error : $sfuConnectionResult"
+                        }
+                        sendJoinErrorAnalytics(sfuConnectionResult)
+                        return Failure(
+                            Error.GenericError(
+                                sfuConnectionResult.error.message ?: "RtcSession error occurred.",
+                            ),
+                        )
+                    }
+                }
+
+                if (sfuConnectionResult.cause != SfuConnectFailureCause.TerminalSocketFailure) {
                     if (!didReconnectSucceed()) {
                         logger.e { "[_join] Could not recover. Error : $sfuConnectionResult" }
                         sendJoinErrorAnalytics(sfuConnectionResult)
@@ -814,16 +826,6 @@ public class Call(
                             ),
                         )
                     }
-                } else {
-                    logger.e {
-                        "[_join] Got non recoverable error while connecting to SFU. Error : $sfuConnectionResult"
-                    }
-                    sendJoinErrorAnalytics(sfuConnectionResult)
-                    return Failure(
-                        Error.GenericError(
-                            sfuConnectionResult.error.message ?: "RtcSession error occurred.",
-                        ),
-                    )
                 }
             }
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -195,6 +195,10 @@ public class Call(
     internal val clientImpl = client as StreamVideoClient
     internal val scopeProvider: ScopeProvider = ScopeProviderImpl(clientImpl.scope)
 
+    // Unit-test only hook for replacing RtcSession construction.
+    // TODO(v2): replace this with a proper dependency injection boundary.
+    internal var unitTestRtcSessionFactory: (() -> RtcSession)? = null
+
     // Atomic controls
     private var atomicLeave = AtomicUnitCall()
 
@@ -748,8 +752,8 @@ public class Call(
         val sfuWsUrl = result.value.credentials.server.wsEndpoint
         val sfuName = result.value.credentials.server.edgeName
         val iceServers = result.value.credentials.iceServers.map { it.toIceServer() }
-        val localSession = if (testInstanceProvider.rtcSessionCreator != null) {
-            testInstanceProvider.rtcSessionCreator!!.invoke()
+        val localSession = if (unitTestRtcSessionFactory != null) {
+            unitTestRtcSessionFactory!!.invoke()
         } else {
             RtcSession(
                 sessionId = this.sessionId,
@@ -2322,7 +2326,6 @@ public class Call(
 
         internal class TestInstanceProvider {
             var mediaManagerCreator: (() -> MediaManagerImpl)? = null
-            var rtcSessionCreator: (() -> RtcSession)? = null
         }
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -223,14 +223,9 @@ internal sealed class SfuConnectionResult {
     /**
      * The connection attempt failed.
      *
-     * @param error the typed cause of the failure (see [SfuConnectException]).
-     * Callers branch on its concrete type to decide how to recover — e.g. a
-     * [SfuConnectException.Timeout] means the safety-timeout tore down a stuck
-     * socket and no recovery loop was started, so the caller must start one.
-     * @param recoverable `true` when the failure can be recovered from, so the
-     * initial-join flow can await a recovery loop instead of treating it as
-     * permanent. `false` for terminal failures with no recovery (auth errors,
-     * permanent disconnects, etc.).
+     * @param cause the classified failure cause. Callers can use it to decide
+     * whether to start recovery, await recovery already started by `stateJob`,
+     * or fail immediately.
      * @param abortReason the analytics abort reason derived from the disconnect
      * state's error code, or `null` when the terminal state carried no error.
      * The caller (the join flow) decides whether/when to report it, so that
@@ -238,31 +233,9 @@ internal sealed class SfuConnectionResult {
      */
     data class Failure(
         val error: Exception,
-        val recoverable: Boolean = false,
+        val cause: SfuConnectFailureCause,
         val abortReason: AnalyticsCallAbortReason? = null,
     ) : SfuConnectionResult()
-}
-
-/**
- * Typed causes carried by [SfuConnectionResult.Failure], so callers of
- * [RtcSession.connectInternal] can branch on the failure kind instead of parsing
- * the message text.
- */
-internal sealed class SfuConnectException(message: String) : Exception(message) {
-    /**
-     * The connect attempt never reached a terminal socket state within the safety
-     * timeout, so [RtcSession.connectInternal] tore the in-flight socket down.
-     * That leaves the socket in a state `stateJob` ignores, so no recovery loop is
-     * started on its own — the initial-join flow must start one itself.
-     */
-    class Timeout(message: String) : SfuConnectException(message)
-
-    /**
-     * The SFU socket reached a terminal [SfuSocketState.Disconnected] state. When
-     * the failure is recoverable, `stateJob` is already launching `Call.reconnect`,
-     * so the initial-join flow only needs to await the outcome.
-     */
-    class Disconnected(message: String) : SfuConnectException(message)
 }
 
 /**
@@ -989,11 +962,9 @@ public class RtcSession internal constructor(
             // can't resurface through stateJob and resurrect this abandoned session.
             sfuConnectionModule.socketConnection.disconnect()
             sendCallStats()
-            // Typed as Timeout: we disconnected the socket into a state stateJob ignores,
-            // so no recovery loop starts on its own — the caller must start it.
             return SfuConnectionResult.Failure(
-                error = SfuConnectException.Timeout(msg),
-                recoverable = true,
+                error = Exception(msg),
+                cause = SfuConnectFailureCause.SocketStateObservationTimeout,
                 abortReason = AnalyticsCallAbortReason.REQUEST_TIMEOUT,
             )
         }
@@ -1011,13 +982,14 @@ public class RtcSession internal constructor(
             logger.w { "[connectInternal] $msg" }
             sfuTracer.trace("connect-failed", msg)
             sendCallStats()
-            // Recoverable only when the terminal state is one stateJob reacts to; in that
-            // case a Call.reconnect is already being launched, so the join flow just awaits.
-            val recoverable =
-                (sfuSocketState as? SfuSocketState.Disconnected)?.isRecoverable() ?: false
+            val cause = if ((sfuSocketState as? SfuSocketState.Disconnected)?.isRecoverable() == true) {
+                SfuConnectFailureCause.RecoverableSocketFailure
+            } else {
+                SfuConnectFailureCause.TerminalSocketFailure
+            }
             SfuConnectionResult.Failure(
-                error = SfuConnectException.Disconnected(msg),
-                recoverable = recoverable,
+                error = Exception(msg),
+                cause = cause,
                 abortReason = networkError?.toAbortReason(),
             )
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -226,6 +226,7 @@ internal sealed class SfuConnectionResult {
      * @param cause the classified failure cause. Callers can use it to decide
      * whether to start recovery, await recovery already started by `stateJob`,
      * or fail immediately.
+     * @param cause See [SfuConnectFailureCause]
      * @param abortReason the analytics abort reason derived from the disconnect
      * state's error code, or `null` when the terminal state carried no error.
      * The caller (the join flow) decides whether/when to report it, so that

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/SfuConnectFailureCause.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/SfuConnectFailureCause.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call
+
+/**
+ * Typed cause of a failed SFU connect attempt. This reports what happened at
+ * the socket/session boundary; callers decide how to recover from each cause.
+ */
+internal sealed interface SfuConnectFailureCause {
+    data object SocketStateObservationTimeout : SfuConnectFailureCause
+    data object RecoverableSocketFailure : SfuConnectFailureCause
+    data object TerminalSocketFailure : SfuConnectFailureCause
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/SfuConnectFailureCause.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/SfuConnectFailureCause.kt
@@ -21,7 +21,18 @@ package io.getstream.video.android.core.call
  * the socket/session boundary; callers decide how to recover from each cause.
  */
 internal sealed interface SfuConnectFailureCause {
+    /**
+     * [RtcSession.connectInternal] stopped waiting for the socket to reach a terminal state.
+     */
     data object SocketStateObservationTimeout : SfuConnectFailureCause
+
+    /**
+     * The socket failure is already being recovered by [RtcSession.stateJob].
+     */
     data object RecoverableSocketFailure : SfuConnectFailureCause
+
+    /**
+     * The socket failure should fail immediately without recovery.
+     */
     data object TerminalSocketFailure : SfuConnectFailureCause
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/ClientAndAuthTest.kt
@@ -22,9 +22,12 @@ import io.getstream.android.video.generated.models.VideoEvent
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
 import io.getstream.video.android.core.base.TestBase
+import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.errors.VideoErrorCode
 import io.getstream.video.android.model.User
 import io.getstream.video.android.model.UserType
+import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -139,7 +142,6 @@ class ClientAndAuthTest : TestBase() {
     fun `guest user can join a call`() = runTest {
         // Mock WebRTC components — real peer connections cannot run in Robolectric/unit tests.
         Call.testInstanceProvider.mediaManagerCreator = { mockk(relaxed = true) }
-        Call.testInstanceProvider.rtcSessionCreator = { mockk(relaxed = true) }
 
         // Step 1: create the call as an authenticated user.
         val authClient = StreamVideoBuilder(
@@ -181,6 +183,9 @@ class ClientAndAuthTest : TestBase() {
 
         val guestCall = guestClient.call("default", callId)
         guestCall.peerConnectionFactory = mockedPCFactory
+        val rtcSession = mockk<RtcSession>(relaxed = true)
+        coEvery { rtcSession.connectInternal(any(), any()) } returns SfuConnectionResult.Success
+        guestCall.unitTestRtcSessionFactory = { rtcSession }
 
         val joinResult = guestCall.join()
         assertSuccess(joinResult)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/OrphanedTracksTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/OrphanedTracksTest.kt
@@ -18,6 +18,10 @@ package io.getstream.video.android.core
 
 import com.google.common.truth.Truth.assertThat
 import io.getstream.video.android.core.base.IntegrationTestBase
+import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectionResult
+import io.mockk.coEvery
+import io.mockk.mockk
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -41,6 +45,13 @@ private inline fun <R> Call.use(block: (Call) -> R): R {
     }
 }
 
+private fun StreamVideo.mockSuccessfulJoinCall(type: String, id: String): Call =
+    call(type, id).apply {
+        val rtcSession = mockk<RtcSession>(relaxed = true)
+        coEvery { rtcSession.connectInternal(any(), any()) } returns SfuConnectionResult.Success
+        unitTestRtcSessionFactory = { rtcSession }
+    }
+
 /**
  * Integration tests for the orphaned tracks mechanism.
  *
@@ -57,7 +68,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `track arriving before participant is stored as orphaned and reconciled on participant join`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -89,7 +100,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `multiple tracks for same participant are all reconciled`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -123,8 +134,8 @@ class OrphanedTracksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `orphaned tracks for different participants don't interfere`() = runTest {
-        val call = client.call("livestream", randomUUID())
+    fun `orphaned tracks for different participants don't interfere`() = runTest { // noob
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -174,7 +185,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `TrackPublishedEvent with participant info creates participant and reconciles tracks`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -205,7 +216,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `TrackUnpublishedEvent with participant info updates participant state`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -246,7 +257,7 @@ class OrphanedTracksTest : IntegrationTestBase() {
 
     @Test
     fun `track arriving after participant is attached immediately`() = runTest {
-        val call = client.call("livestream", randomUUID())
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()
@@ -286,8 +297,8 @@ class OrphanedTracksTest : IntegrationTestBase() {
     }
 
     @Test
-    fun `orphaned tracks are cleaned up when WebRTC stream is removed`() = runTest {
-        val call = client.call("livestream", randomUUID())
+    fun `orphaned tracks are cleaned up when WebRTC stream is removed`() = runTest { // noob
+        val call = client.mockSuccessfulJoinCall("livestream", randomUUID())
         call.use {
             call.create()
             call.join()

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestBase.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/base/IntegrationTestBase.kt
@@ -115,7 +115,6 @@ open class IntegrationTestBase(val connectCoordinatorWS: Boolean = true) : TestB
             }
             // always mock the peer connection factory, it can't work in unit tests
             Call.testInstanceProvider.mediaManagerCreator = { mockk(relaxed = true) }
-            Call.testInstanceProvider.rtcSessionCreator = { mockk(relaxed = true) }
             // Connect to the WS if needed
             if (connectCoordinatorWS) {
                 // wait for the connection/ avoids race conditions in tests

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/FastReconnectIceRestartTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/FastReconnectIceRestartTest.kt
@@ -29,6 +29,7 @@ import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
 import io.getstream.video.android.core.call.FastReconnectResult
 import io.getstream.video.android.core.call.RtcSession
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.connection.Publisher
 import io.getstream.video.android.core.call.connection.Subscriber
@@ -243,7 +244,10 @@ class FastReconnectIceRestartTest {
         session.subscriber.value = sub
 
         val error = Exception("SFU connection timed out")
-        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Failure(error)
+        coEvery { session.connectInternal(any(), any()) } returns SfuConnectionResult.Failure(
+            error,
+            cause = SfuConnectFailureCause.TerminalSocketFailure,
+        )
 
         val result = session.fastReconnect(null)
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
@@ -28,7 +28,7 @@ import io.getstream.video.android.core.analytics.call.observer.model.JoinAnalyti
 import io.getstream.video.android.core.analytics.call.observer.model.JoinReason
 import io.getstream.video.android.core.base.DispatcherRule
 import io.getstream.video.android.core.call.RtcSession
-import io.getstream.video.android.core.call.SfuConnectException
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
@@ -54,18 +54,14 @@ import org.junit.Test
 import stream.video.sfu.models.WebsocketReconnectStrategy
 
 /**
- * Tests the initial-join handling of a recoverable SFU connection failure
- * (e.g. a connection timeout) in [Call._join].
+ * Tests the initial-join handling of failed SFU connect attempts in [Call._join].
  *
- * A recoverable failure's [SfuConnectionResult.Failure.error] type decides the path:
- * - [SfuConnectException.Disconnected] — the RtcSession's stateJob is already launching
- *   [Call.reconnect], so `_join` defers to that single recovery loop and awaits its
- *   terminal outcome.
- * - [SfuConnectException.Timeout] — nothing will start recovery on its own (the connect
- *   safety-timeout tore the socket down into a state stateJob ignores), so `_join` must
- *   start the reconnect itself before awaiting.
- *
- * A non-recoverable failure must fail immediately.
+ * The failure cause decides how `_join` orchestrates recovery:
+ * - [SfuConnectFailureCause.SocketStateObservationTimeout] starts a REJOIN
+ *   because no reconnect loop was started by stateJob.
+ * - [SfuConnectFailureCause.RecoverableSocketFailure] waits for the reconnect
+ *   loop already started by stateJob.
+ * - [SfuConnectFailureCause.TerminalSocketFailure] fails immediately.
  */
 class JoinRecoverableFailureTest {
 
@@ -131,13 +127,13 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `recoverable socket disconnect awaits the existing reconnect loop`() = runTest(
+    fun `recoverable socket failure awaits the existing reconnect loop`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
             SfuConnectionResult.Failure(
-                SfuConnectException.Disconnected("SFU socket disconnected"),
-                recoverable = true,
+                Exception("SFU socket disconnected"),
+                cause = SfuConnectFailureCause.RecoverableSocketFailure,
             )
 
         val deferred = async {
@@ -157,13 +153,13 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `recoverable connect timeout starts a REJOIN itself`() = runTest(
+    fun `socket state observation timeout starts a REJOIN itself`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
             SfuConnectionResult.Failure(
-                SfuConnectException.Timeout("SFU connection timed out"),
-                recoverable = true,
+                Exception("SFU connection timed out"),
+                cause = SfuConnectFailureCause.SocketStateObservationTimeout,
             )
         // Stub the loop so we only assert it is invoked, not run it for real.
         coEvery { call.reconnect(any(), any()) } returns Unit
@@ -189,11 +185,14 @@ class JoinRecoverableFailureTest {
     }
 
     @Test
-    fun `non-recoverable failure fails immediately without awaiting reconnect`() = runTest(
+    fun `terminal socket failure fails immediately without awaiting reconnect`() = runTest(
         testDispatcher,
     ) {
         coEvery { mockSession.connectInternal(any(), any()) } returns
-            SfuConnectionResult.Failure(Exception("permanent auth error"), recoverable = false)
+            SfuConnectionResult.Failure(
+                Exception("permanent auth error"),
+                cause = SfuConnectFailureCause.TerminalSocketFailure,
+            )
 
         val result = call._join(joinAnalyticsModel = JoinAnalyticsModel(0, JoinReason.FirstAttempt))
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/JoinRecoverableFailureTest.kt
@@ -115,13 +115,12 @@ class JoinRecoverableFailureTest {
             call.joinRequest(any(), any(), any(), any(), any(), any(), any(), any())
         } returns Success(mockJoinResponse)
 
-        // Inject our mocked RtcSession instead of constructing a real one.
-        Call.testInstanceProvider.rtcSessionCreator = { mockSession }
+        // Inject our mocked RtcSession into this Call instead of constructing a real one.
+        call.unitTestRtcSessionFactory = { mockSession }
     }
 
     @After
     fun tearDown() {
-        Call.testInstanceProvider.rtcSessionCreator = null
         StreamVideo.removeClient()
         unmockkAll()
     }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -29,7 +29,7 @@ import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
 import io.getstream.video.android.core.analytics.reporting.model.AnalyticsCallAbortReason
 import io.getstream.video.android.core.call.RtcSession
-import io.getstream.video.android.core.call.SfuConnectException
+import io.getstream.video.android.core.call.SfuConnectFailureCause
 import io.getstream.video.android.core.call.SfuConnectionResult
 import io.getstream.video.android.core.call.connection.Publisher
 import io.getstream.video.android.core.errors.VideoErrorCode
@@ -53,7 +53,6 @@ import io.mockk.spyk
 import io.mockk.unmockkAll
 import io.mockk.verify
 import junit.framework.TestCase.assertEquals
-import junit.framework.TestCase.assertFalse
 import junit.framework.TestCase.assertNotNull
 import junit.framework.TestCase.assertNull
 import junit.framework.TestCase.assertTrue
@@ -297,18 +296,19 @@ class RtcSessionTest2 {
                 "Expected timeout message",
                 (result as SfuConnectionResult.Failure).error.message!!.contains("timed out"),
             )
-            // A timeout is recoverable — the stateJob triggers a reconnect, so the
-            // join flow should await it rather than failing permanently.
-            assertTrue("Expected recoverable=true for a timeout", result.recoverable)
+            assertEquals(
+                SfuConnectFailureCause.RecoverableSocketFailure,
+                result.cause,
+            )
             assertEquals(
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
-                (result as SfuConnectionResult.Failure).abortReason,
+                result.abortReason,
             )
         }
 
     @Suppress("DEPRECATION")
     @Test
-    fun `connectInternal safety timeout fires when socket stays non-terminal`() =
+    fun `connectInternal socket state observation timeout fires when socket stays non-terminal`() =
         runTest(testDispatcher) {
             val sfuSocketStateFlow = MutableStateFlow<SfuSocketState>(
                 SfuSocketState.Disconnected.Stopped,
@@ -346,7 +346,7 @@ class RtcSessionTest2 {
             coJustRun { rtcSession.sendCallStats(any(), any(), any()) }
 
             val resultDeferred = async { rtcSession.connectInternal() }
-            // Safety timeout = 2 * 50ms + 1000ms grace
+            // Socket state observation timeout = 2 * 50ms + 1000ms grace
             advanceTimeBy(1_101L)
             val result = resultDeferred.await()
 
@@ -355,15 +355,12 @@ class RtcSessionTest2 {
                 result is SfuConnectionResult.Failure,
             )
             assertTrue(
-                "Expected safety-timeout message",
+                "Expected socket state observation timeout message",
                 (result as SfuConnectionResult.Failure).error.message!!.contains("timed out"),
             )
-            assertTrue("Expected recoverable=true for a safety timeout", result.recoverable)
-            // A Timeout-typed error is what makes _join self-trigger a REJOIN for this path,
-            // since stateJob ignores the state the stuck socket was torn down into.
-            assertTrue(
-                "Expected a SfuConnectException.Timeout error for a safety timeout",
-                result.error is SfuConnectException.Timeout,
+            assertEquals(
+                SfuConnectFailureCause.SocketStateObservationTimeout,
+                result.cause,
             )
             assertEquals(
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
@@ -429,7 +426,10 @@ class RtcSessionTest2 {
                 AnalyticsCallAbortReason.REQUEST_TIMEOUT,
                 (result as SfuConnectionResult.Failure).abortReason,
             )
-            assertTrue("Expected recoverable=true for a transport timeout", result.recoverable)
+            assertEquals(
+                SfuConnectFailureCause.RecoverableSocketFailure,
+                result.cause,
+            )
         }
 
     @Suppress("DEPRECATION")
@@ -480,9 +480,9 @@ class RtcSessionTest2 {
                 "Expected SfuConnectionResult.Failure but got $result",
                 result is SfuConnectionResult.Failure,
             )
-            assertFalse(
-                "Expected recoverable=false for a permanent disconnect",
-                (result as SfuConnectionResult.Failure).recoverable,
+            assertEquals(
+                SfuConnectFailureCause.TerminalSocketFailure,
+                (result as SfuConnectionResult.Failure).cause,
             )
         }
 


### PR DESCRIPTION
### Goal

Refactor SFU connect failure classification to use domain-level failure causes instead of exception subclasses.
[AN-1294](https://linear.app/stream/issue/AND-1294/fix-the-timeout-based-logic-of-sfu-ws-connection)
The implementation on [PR: Recover initial join when connect safety-timeout leaves no reconnect
](https://github.com/GetStream/stream-video-android/pull/1741) uses `SfuConnectException.Timeout` and `SfuConnectException.Disconnected` to tell `_join()` how to handle a failed SFU connect attempt. That works mechanically, but the model is misleading:

- `Timeout` is not a network-layer exception here; it means `connectInternal()` gave up waiting for the socket to reach a terminal state.
- `Disconnected` is an SFU socket state, not an exception.
- `_join()` is really branching on domain failure causes, not exception types.

> This PR is primarily a naming/modeling refactor over the existing recovery behavior, intended to make the SFU connection lifecycle easier to reason about and avoid treating socket states as exceptions.


### Implementation

**Replace `SfuConnectException` with:**

```kotlin
internal sealed interface SfuConnectFailureCause {

     // RtcSession.connectInternal stopped waiting for the socket to reach a terminal state
    data object SocketStateObservationTimeout : SfuConnectFailureCause

     //The socket failure is already being recovered by RtcSession.stateJob.
    data object RecoverableSocketFailure : SfuConnectFailureCause

     // The socket failure should fail immediately without recovery.
    data object TerminalSocketFailure : SfuConnectFailureCause
}

```

**Refactor SfuConnectionResult.Failure**

**Before**

```kotlin
internal sealed class SfuConnectionResult {
    data class Failure(
        val recoverable: boolean = false,
         ....
    ) : SfuConnectionResult()
}
```
**After**

```kotlin
internal sealed class SfuConnectionResult {
    data class Failure(
        val cause: SfuConnectFailureCause,
         ....
    ) : SfuConnectionResult()
}
```

### 🎨 UI Changes

None

### Testing

Not required, this is a code refactor on WIP PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SFU connection recovery during call joining.
  * Recoverable connection failures now wait for ongoing recovery, while timeouts trigger a rejoin attempt.
  * Terminal connection failures now fail immediately with appropriate analytics reporting.
  * Improved handling and classification of connection timeouts and socket disconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->