### PR TITLE
e2e: Port the chat test harness improvements: retry visibility, video on retries only

### DIFF
--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/rules/RetryRule.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/rules/RetryRule.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.e2e.test.rules
+package io.getstream.video.android.rules
 
 import android.database.sqlite.SQLiteDatabase
 import android.os.Environment
@@ -24,65 +24,147 @@ import io.getstream.video.android.uiautomator.allureScreenrecord
 import io.getstream.video.android.uiautomator.allureScreenshot
 import io.getstream.video.android.uiautomator.allureWindowHierarchy
 import io.getstream.video.android.uiautomator.device
+import io.qameta.allure.kotlin.Allure
+import io.qameta.allure.kotlin.model.Stage
+import io.qameta.allure.kotlin.model.TestResult
+import io.qameta.allure.kotlin.util.ResultsUtils
 import org.junit.rules.TestRule
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import java.io.File
+import java.util.UUID
 
-/** Annotation to retry a specific failed test. **/
-@Retention(AnnotationRetention.RUNTIME)
-@Target(AnnotationTarget.FUNCTION)
-public annotation class Retry(val count: Int)
-
-/** Rule to retry all failed tests. **/
+/**
+ * Rule to retry failed tests up to [count] attempts.
+ *
+ * Each failed attempt that is retried is written as its own Allure result sharing the real
+ * test's historyId, so Allure TestOps groups the attempts as retries and can flag the test
+ * as flaky. Screen recording only runs on retry attempts: the first attempt of a healthy
+ * test passes, and recording it would be paid for and discarded on every test.
+ */
 public class RetryRule(private val count: Int) : TestRule {
 
-    override fun apply(base: Statement, description: Description): Statement = statement(
-        base,
-        description,
-    )
+    override fun apply(base: Statement, description: Description): Statement = object : Statement() {
+        @Throws(Throwable::class)
+        override fun evaluate() {
+            val testName = description.displayName
+            val databaseOperations = DatabaseOperations()
+            var caughtThrowable: Throwable? = null
 
-    private fun statement(base: Statement, description: Description): Statement {
-        return object : Statement() {
-            @Throws(Throwable::class)
-            override fun evaluate() {
-                val retryAnnotation: Retry? = description.getAnnotation(Retry::class.java)
-                val retryCount = retryAnnotation?.count ?: count
-                val databaseOperations = DatabaseOperations()
-                var caughtThrowable: Throwable? = null
-                lateinit var videoFilePath: String
-                lateinit var recordingThread: Thread
-
-                for (i in 0 until retryCount) {
-                    try {
-                        System.err.println("${description.displayName}: run #${i + 1} started.")
-                        device.executeShellCommand("logcat -c")
-                        videoFilePath = "${Environment.getExternalStorageDirectory().absolutePath}/${description.methodName}.mp4"
+            for (attempt in 1..count) {
+                val recordVideo = attempt > 1
+                // methodName, not displayName: the display name contains parentheses, which
+                // break when the recording commands go through the device shell.
+                val videoFilePath =
+                    "${Environment.getExternalStorageDirectory().absolutePath}/${description.methodName}.mp4"
+                var recordingThread: Thread? = null
+                val startMillis = System.currentTimeMillis()
+                try {
+                    System.err.println("$testName: run #$attempt started.")
+                    device.executeShellCommand("logcat -c")
+                    if (recordVideo) {
                         recordingThread = startVideoRecording(videoFilePath)
-                        base.evaluate()
-                        stopVideoRecording(videoFilePath, recordingThread)
-                        return
-                    } catch (t: Throwable) {
-                        System.err.println("${description.displayName}: run #${i + 1} failed.")
-                        caughtThrowable = t
-                        databaseOperations.clearDatabases()
-                        stopVideoRecording(videoFilePath, recordingThread)
-                        device.allureLogcat(name = "logcat_${i + 1}")
-                        device.allureScreenshot(name = "screenshot_${i + 1}")
-                        device.allureWindowHierarchy(name = "hierarchy_${i + 1}")
+                    }
+                    base.evaluate()
+                    recordingThread?.let { stopRecordingSafely(testName, videoFilePath, it) }
+                    return
+                } catch (t: Throwable) {
+                    System.err.println("$testName: run #$attempt failed.")
+                    caughtThrowable = t
+                    databaseOperations.clearDatabases()
+                    val recordingStopped = recordingThread?.let {
+                        stopRecordingSafely(
+                            testName,
+                            videoFilePath,
+                            it,
+                        )
+                    }
+                    device.allureLogcat(name = "logcat_$attempt")
+                    device.allureScreenshot(name = "screenshot_$attempt")
+                    device.allureWindowHierarchy(name = "hierarchy_$attempt")
+                    if (recordingStopped == true) {
                         device.allureScreenrecord(
-                            name = "record_${i + 1}",
+                            name = "record_$attempt",
                             file = File(videoFilePath),
                         )
-                    } finally {
+                    }
+                    if (attempt < count) {
+                        writeFailedAttemptResult(attempt, t, startMillis)
+                    }
+                } finally {
+                    if (recordingThread != null) {
                         device.executeShellCommand("rm $videoFilePath")
                     }
                 }
-
-                throw caughtThrowable ?: IllegalStateException()
             }
+
+            throw caughtThrowable ?: IllegalStateException("$testName failed without a captured error")
         }
     }
+
+    /**
+     * Writes the failed attempt as a separate, already-finished Allure result. The current
+     * (real) result keeps running; its accumulated steps and attachments are moved to the
+     * attempt result so each result describes exactly one attempt.
+     */
+    private fun writeFailedAttemptResult(attempt: Int, error: Throwable, startMillis: Long) {
+        val lifecycle = Allure.lifecycle
+        val attemptResult = TestResult(uuid = UUID.randomUUID().toString())
+        var populated = false
+        var realStart: Long? = null
+        lifecycle.updateTestCase { current ->
+            attemptResult.historyId = current.historyId
+            attemptResult.testCaseId = current.testCaseId
+            attemptResult.fullName = current.fullName
+            attemptResult.name = current.name
+            attemptResult.description = current.description
+            attemptResult.labels.addAll(current.labels)
+            attemptResult.links.addAll(current.links)
+            attemptResult.parameters.addAll(current.parameters)
+            attemptResult.steps.addAll(current.steps)
+            attemptResult.attachments.addAll(current.attachments)
+            current.steps.clear()
+            current.attachments.clear()
+            realStart = current.start
+            populated = true
+        }
+        if (!populated) {
+            return
+        }
+        with(attemptResult) {
+            status = ResultsUtils.getStatus(error)
+            statusDetails = ResultsUtils.getStatusDetails(error)
+            // TestOps shows the same-historyId result with the latest start as the launch's
+            // current one and lists the rest as retries. The real result starts a few ms before
+            // any attempt, so each attempt's start is shifted just below it, keeping attempt
+            // order and leaving the real (final) result current.
+            start = realStart?.let { it - (count - attempt) } ?: startMillis
+            stop = System.currentTimeMillis()
+        }
+        // scheduleTestCase stores the result by reference and does not touch the thread context,
+        // so the running test stays current. It resets the stage, hence FINISHED is set after.
+        lifecycle.scheduleTestCase(attemptResult)
+        attemptResult.stage = Stage.FINISHED
+        lifecycle.writeTestCase(attemptResult.uuid)
+    }
+
+    /**
+     * Stops the recording without failing the test: a recording infrastructure problem must
+     * not change the test result or skip the failure reporting. Returns whether the recording
+     * was stopped and its file is usable.
+     */
+    private fun stopRecordingSafely(
+        testName: String,
+        videoFilePath: String,
+        thread: Thread,
+    ): Boolean =
+        runCatching { stopVideoRecording(videoFilePath, thread) }
+            .onFailure {
+                System.err.println(
+                    "$testName: stopping the screen recording failed: $it",
+                )
+            }
+            .isSuccess
 
     private fun startVideoRecording(remoteVideoPath: String): Thread {
         return Thread {
@@ -124,29 +206,24 @@ public class RetryRule(private val count: Int) : TestRule {
     }
 }
 
-public open class DatabaseOperations {
+private class DatabaseOperations {
 
-    public open fun clearDatabases() {
-        val databaseOperations = DatabaseOperations()
-        val dbFiles = databaseOperations.getAllDatabaseFiles().filterNot {
-            shouldIgnoreFile(
-                it.path,
-            )
-        }
-        dbFiles.forEach { clearDatabase(it, databaseOperations) }
+    fun clearDatabases() {
+        getAllDatabaseFiles()
+            .filterNot(::shouldIgnoreFile)
+            .forEach(::clearDatabase)
     }
 
-    private fun shouldIgnoreFile(path: String): Boolean {
+    private fun shouldIgnoreFile(file: File): Boolean {
         val ignoredSuffixes = arrayOf("-journal", "-shm", "-uid", "-wal")
-        return ignoredSuffixes.any { path.endsWith(it) }
+        return ignoredSuffixes.any { file.path.endsWith(it) }
     }
 
-    private fun clearDatabase(dbFile: File, dbOperations: DatabaseOperations) {
-        dbOperations.openDatabase(dbFile).use { database ->
-            val tablesToClear = dbOperations.getTableNames(
-                database,
-            ).filterNot { it == "room_master_table" }
-            tablesToClear.forEach { dbOperations.deleteTableContent(database, it) }
+    private fun clearDatabase(dbFile: File) {
+        openDatabase(dbFile).use { database ->
+            getTableNames(database)
+                .filterNot { it == "room_master_table" }
+                .forEach { deleteTableContent(database, it) }
         }
     }
 

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/StreamTestCase.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/StreamTestCase.kt
@@ -28,10 +28,10 @@ import android.Manifest.permission.READ_MEDIA_VIDEO
 import android.Manifest.permission.RECORD_AUDIO
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.annotation.SuppressLint
-import io.getstream.chat.android.e2e.test.rules.RetryRule
 import io.getstream.video.android.robots.ParticipantRobot
 import io.getstream.video.android.robots.UserRobot
 import io.getstream.video.android.robots.VideoView
+import io.getstream.video.android.rules.RetryRule
 import io.getstream.video.android.uiautomator.device
 import io.getstream.video.android.uiautomator.grantPermission
 import io.getstream.video.android.uiautomator.startApp

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/uiautomator/Wait.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/uiautomator/Wait.kt
@@ -53,26 +53,21 @@ public fun UiObject2.waitForText(
     var textPresent = false
     while (!textPresent && System.currentTimeMillis() < endTime) {
         textPresent = if (mustBeEqual) text == expectedText else text.contains(expectedText)
+        if (!textPresent) {
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
     }
     return this
 }
 
 public fun BySelector.waitForCount(count: Int, timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout): List<UiObject2> {
     val endTime = System.currentTimeMillis() + timeOutMillis
-    var elements: List<UiObject2> = emptyList()
-    var success = false
-    while (!success && System.currentTimeMillis() < endTime) {
+    var elements: List<UiObject2> = findObjects()
+    while (elements.size != count && System.currentTimeMillis() < endTime) {
+        Thread.sleep(POLL_INTERVAL_MILLIS)
         elements = findObjects()
-        success = elements.size == count
     }
     return elements
 }
 
-public fun UiObject2.waitForTextToChange(text: String, timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout): UiObject2 {
-    val endTime = System.currentTimeMillis() + timeOutMillis
-    var textChanged = false
-    while (!textChanged && System.currentTimeMillis() < endTime) {
-        textChanged = this.text != text
-    }
-    return this
-}
+private const val POLL_INTERVAL_MILLIS = 50L

--- a/fastlane/Allurefile
+++ b/fastlane/Allurefile
@@ -20,11 +20,13 @@ desc 'Create launch on Allure TestOps'
 lane :allure_launch do |options|
   next unless is_check_required(sources: sources_matrix[:e2e], force_check: @force_check)
 
+  # Only real scheduled runs are named 'Cron checks'. A manual dispatch of the nightly
+  # workflow falls back to the head commit message, so it stays distinguishable in TestOps.
   launch_id = allure_create_launch(
     url: allure_api_url,
     project_id: allure_project_id,
     github_run_details: github_run_details,
-    cron: options[:cron]
+    cron: options[:cron] && ENV['GITHUB_EVENT_NAME'] == 'schedule'
   )
   sh("echo 'LAUNCH_ID=#{launch_id}' >> $GITHUB_ENV") if is_ci
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -98,7 +98,12 @@ private_lane :batch_tests do |options|
     install(tool: :test_parser)
     sh("java -jar test-parser.jar #{options[:test_apk_path]} ./")
     test_names = File.read('AllTests.txt').split
-    current_batch = test_names.each_slice((test_names.size.to_f / options[:batch_count].to_i).ceil).to_a[options[:batch].to_i]
+    batch = options[:batch].to_i
+    batch_count = options[:batch_count].to_i
+    # Round-robin split always yields exactly batch_count groups. Slicing by a rounded-up
+    # size can yield fewer groups than batch_count, making the last batch nil and crashing.
+    current_batch = test_names.select.with_index { |_, i| i % batch_count == batch }
+    UI.user_error!("Batch #{batch} is empty: #{test_names.size} tests cannot fill #{batch_count} batches") if current_batch.empty?
     "-e class #{current_batch.join(',')}"
   else
     ''


### PR DESCRIPTION
### Goal

Port the E2E harness improvements from the chat repo (GetStream/stream-chat-android#6568): make retry attempts visible in Allure TestOps, record video only on retries, and fix the CI batch split.

Resolves AND-1308

### Implementation

- `RetryRule`: each failed attempt that is retried becomes its own Allure result (same historyId), so TestOps shows retries and can flag flaky tests. Before, a pass-on-retry looked identical to a stable pass.
- `RetryRule`: screen recording runs only on retry attempts. Before, every test recorded an 8 Mbit/s video and discarded it on pass.
- `RetryRule`: the recording file uses `methodName` instead of `displayName` (the display name's parentheses break when the recording commands go through the device shell on this uiautomator version), and a recording stop failure logs instead of replacing the test result. Both were caught by a live probe run during the port.
- `RetryRule` moved to `io.getstream.video.android.rules`: the file declared a chat package inside this repo.
- `Wait.kt`: `waitForText` and `waitForCount` poll at 50ms instead of spinning a CPU core until timeout; unused `waitForTextToChange` removed.
- `Allurefile`: launches are named "Cron checks" only for real scheduled runs, so manual dispatches of the nightly stay out of the flakiness analytics (TestOps project 69).
- `Fastfile`: `batch_tests` splits round-robin (the old rounded-up slicing could produce fewer groups than batches and crash on `nil` for the last shard).

### Metrics

**E2E CI duration (this repo)**, sum of the 3 test batch jobs:

| Run | Total across batches |
|---|---:|
| recent full runs, other branches | 38.1 to 45.6 min |
| **this PR (first run)** | **37.8 min** |

That overlaps with the best baseline, so on duration this is within single-run variance. This suite is smaller and more network-bound than chat's, so the recording overhead it removes was a smaller share of its runtime. The nightly trend will tell whether a duration gain shows on top.

**Retry visibility and recordings** (the substance of this PR):

| | Before | After |
|---|---|---|
| Test passes on retry | looks identical to a stable pass | failed attempt visible in TestOps with its own error, steps and artifacts |
| First-attempt pass rate | unmeasurable | measurable |
| Recording on a passing attempt | always, then discarded | never |

For reference, chat measured a large duration gain from the same change (PR gate from about 40 to about 25 minutes wall clock; see GetStream/stream-chat-android#6568), but its suite is bigger and CPU-bound, so those numbers do not transfer here.

### Testing

Verified live on an emulator with a temporary probe test (fails attempt 1, passes attempt 2), pulling `/sdcard/googletest/test_outputfiles/allure-results` afterwards:

1. One result JSON per attempt, all sharing the same `historyId`; the failed attempt carries its own steps, error, `logcat_1`/`screenshot_1`/`hierarchy_1`, and no video; the passed result has the latest `start`, so TestOps keeps it as the current one.
2. A normally passing test writes exactly one result and records no video.
3. To reproduce: temporarily flip an assertion in any test and run it via `connectedE2etestingDebugAndroidTest`.

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI test waiting by adding reliable polling for text and object counts.
  * Enhanced retry handling so failed attempts are recorded separately without causing additional failures when video cleanup encounters issues.
  * Fixed test batching to detect and report empty batches clearly.
  * Corrected scheduled test run labeling for automated versus manually triggered runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

