### PR TITLE
Run e2e cron on android 16

### DIFF
--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -35,6 +35,7 @@ jobs:
     strategy:
       matrix:
         include:
+          - android_api_level: 36
           - android_api_level: 35
           - android_api_level: 34
           - android_api_level: 33


### PR DESCRIPTION
### Goal
Closes #AND-1316
Run e2e cron on android 16

### Implementation

Run e2e cron on android 16

### 🎨 UI Changes

None

### Testing

None