### PR TITLE
Run e2e on android 16

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -61,7 +61,7 @@ jobs:
           - batch: 2
       fail-fast: false
     env:
-      ANDROID_API_LEVEL: 34
+      ANDROID_API_LEVEL: 36
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0


### PR DESCRIPTION
### Goal
Closes #AND-1317
Run e2e on android 16
### Implementation

Run e2e on android 16
### 🎨 UI Changes

None

### Testing

None



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end testing to run against Android API level 36 for improved platform coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->