### PR TITLE
test(e2e): harden recording and outgoing-call waits against backend latency

### DIFF
--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
@@ -351,12 +351,16 @@ class UserRobot {
     }
 
     fun acceptCallRecording(): UserRobot {
-        CallPage.RecordingButtons.accept.waitToAppear(timeOutMillis = 10.seconds).click()
+        // The recording-consent dialog only appears once the backend composite recorder
+        // emits call.recording_started, which can take 20-30s, so 10s is too short.
+        CallPage.RecordingButtons.accept.waitToAppear(timeOutMillis = 30.seconds).click()
         return this
     }
 
     fun declineCallRecording(): UserRobot {
-        CallPage.RecordingButtons.leave.waitToAppear(timeOutMillis = 10.seconds).click()
+        // See acceptCallRecording: the consent dialog is gated on the backend recorder
+        // starting (call.recording_started), which can take 20-30s.
+        CallPage.RecordingButtons.leave.waitToAppear(timeOutMillis = 30.seconds).click()
         return this
     }
 

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -202,11 +202,11 @@ fun UserRobot.assertRecordingView(isDisplayed: Boolean): UserRobot {
         assertTrue(CallPage.recordingIcon.waitToAppear(timeOutMillis = 30.seconds).isDisplayed())
         assertEquals(label, CallPage.callInfoView.findObject().text)
     } else {
-        // Recording stop is also backend-driven (call.recording_stopped); give it room.
-        // waitToDisappear returns as soon as the icon is gone, so the longer timeout is
-        // only spent when the backend is slow.
+        // The buddy records for ~60s, so the icon stays visible until the backend emits
+        // call.recording_stopped. waitToDisappear returns as soon as the icon is gone, so
+        // this longer timeout is only fully spent if the recording is still running.
         assertFalse(
-            CallPage.recordingIcon.waitToDisappear(timeOutMillis = 30.seconds).isDisplayed(),
+            CallPage.recordingIcon.waitToDisappear(timeOutMillis = 70.seconds).isDisplayed(),
         )
         assertNotEquals(label, CallPage.callInfoView.findObject().text)
     }

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -197,7 +197,9 @@ fun UserRobot.assertConnectionQualityIndicator(): UserRobot {
 fun UserRobot.assertRecordingView(isDisplayed: Boolean): UserRobot {
     val label = "Recording"
     if (isDisplayed) {
-        assertTrue(CallPage.recordingIcon.waitToAppear().isDisplayed())
+        // The backend composite recorder can take 20-30s to actually start and emit
+        // call.recording_started, so the icon needs a longer window than the 5s default.
+        assertTrue(CallPage.recordingIcon.waitToAppear(timeOutMillis = 30.seconds).isDisplayed())
         assertEquals(label, CallPage.callInfoView.findObject().text)
     } else {
         assertFalse(CallPage.recordingIcon.waitToDisappear().isDisplayed())
@@ -254,9 +256,11 @@ fun UserRobot.assertIncomingCall(isDisplayed: Boolean): UserRobot {
 
 fun UserRobot.assertOutgoingCall(audioOnly: Boolean = true, isDisplayed: Boolean): UserRobot {
     if (isDisplayed) {
+        // The outgoing ringing screen only renders after the call create/ring network
+        // round-trip completes, which can exceed 10s under CI load.
         assertTrue(
             "Decline call button",
-            RingPage.declineCallButton.waitToAppear(timeOutMillis = 10.seconds).isDisplayed(),
+            RingPage.declineCallButton.waitToAppear(timeOutMillis = 20.seconds).isDisplayed(),
         )
         assertTrue("Call label", RingPage.outgoingCallLabel.isDisplayed())
         assertTrue("Avatar", RingPage.callParticipantAvatar.isDisplayed())

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -202,7 +202,12 @@ fun UserRobot.assertRecordingView(isDisplayed: Boolean): UserRobot {
         assertTrue(CallPage.recordingIcon.waitToAppear(timeOutMillis = 30.seconds).isDisplayed())
         assertEquals(label, CallPage.callInfoView.findObject().text)
     } else {
-        assertFalse(CallPage.recordingIcon.waitToDisappear().isDisplayed())
+        // Recording stop is also backend-driven (call.recording_stopped); give it room.
+        // waitToDisappear returns as soon as the icon is gone, so the longer timeout is
+        // only spent when the backend is slow.
+        assertFalse(
+            CallPage.recordingIcon.waitToDisappear(timeOutMillis = 30.seconds).isDisplayed(),
+        )
         assertNotEquals(label, CallPage.callInfoView.findObject().text)
     }
     return this

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/ParticipantActionsTests.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/ParticipantActionsTests.kt
@@ -140,9 +140,14 @@ class ParticipantActionsTests : StreamTestCase() {
         step("GIVEN user starts a call") {
             userRobot.joinCall()
         }
-        step("AND participant joins the call and starts recording the call for 10 seconds") {
+        step("AND participant joins the call and starts recording the call") {
+            // Composite recording spins up ~10-15s after the request, so a short duration
+            // leaves almost no client-visible window. Record for 60s (and keep the buddy
+            // in the call for 120s) so the icon is reliably observable across all views,
+            // then still stops in time for the "recording disappeared" assertions.
             participantRobot
-                .setCallRecordingDuration(15)
+                .setCallDuration(120)
+                .setCallRecordingDuration(60)
                 .joinCall(callId, actions = arrayOf(RECORD_CALL))
         }
         step("WHEN participants join the call and one of them starts recording") {


### PR DESCRIPTION
### Goal

Closes [AND-1323](https://linear.app/stream/issue/AND-1323/fix-e2e-flaky-tests)

Two demo-app E2E tests fail deterministically on `develop` (and on any PR that runs the `Test compose` shard) because the tests assume the backend produces UI state faster than it actually does:

- `ParticipantActionsTests.testParticipantRecordsCall`
- `RingingTests.testUserRejectsTheOutgoingAudioCall`

Both surfaced as `java.lang.NullPointerException: findObject(...) must not be null` when a `waitToAppear` timed out before the expected element rendered. Captured logcats confirmed the SDK receives and handles the relevant events correctly (`CallRecordingStartedEvent` / `CallRecordingStoppedEvent`) — the failures are purely test-timing assumptions vs. backend latency.

**Root cause of the recording test:** the composite recorder takes ~10-15s to spin up before it emits `call.recording_started`. The buddy was told to record for only 15s, so ~10s of spin-up left just a **~5s client-visible window** — which closed before the 3-view assertion loop (`GRID`, `DYNAMIC`, `SPOTLIGHT`) could observe the recording icon. No timeout increase can fix a window that has already closed, so the real fix is to record long enough that the icon is reliably observable.

### Implementation

All changes are confined to `demo-app/src/androidTestE2etestingDebug` — no production/SDK code is touched.

**Recording test (`testParticipantRecordsCall`) — the core fix:**
- Record for `60s` (was `15s`) so the icon is reliably visible across all three views after the ~10-15s spin-up.
- Keep the buddy in the call for `120s` via `setCallDuration(120)` (buddy default is 30s) so the 60s recording runs to completion instead of being cut off when the buddy leaves — mirrors the existing `ReconnectionTests` pattern.
- `assertRecordingView(isDisplayed = false)` icon-disappear wait `5s → 70s`, since the recording now runs ~60s before `call.recording_stopped`. `waitToDisappear` returns as soon as the icon is gone, so the longer timeout is only fully spent while recording is still running.
- `acceptCallRecording()` / `declineCallRecording()` consent-dialog wait `10s → 30s` — the dialog only appears on `call.recording_started` (~10-15s in).
- `assertRecordingView(isDisplayed = true)` icon-appear wait `5s → 30s`.

**Ringing test (`testUserRejectsTheOutgoingAudioCall`):**
- `assertOutgoingCall(isDisplayed = true)` decline-button wait `10s → 20s` — the outgoing ringing screen only renders after the call create/ring network round-trip, which can exceed 10s under CI load.

### Testing

- [x] `Test compose` shard on CI — `testParticipantRecordsCall` and `testUserRejectsTheOutgoingAudioCall` now pass
- [x] `./gradlew :demo-app:spotlessApply` — formatting clean
- Change is test-only (UI-automation waits + buddy recording duration); no unit-test or SDK behavior affected.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes (N/A — test-only change)
- [x] New code is covered by unit tests (N/A — E2E test hardening)
- [x] Comparison screenshots added for visual changes (N/A — no UI change)
- [x] Affected documentation updated (KDocs, docusaurus, tutorial) (N/A)
- [x] Tutorial starter kit updated (N/A)
- [x] Examples/guides starter kits updated (`stream-video-examples`) (N/A)

### ☑️Reviewer Checklist
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Check the SDK Size Comparison table in the CI logs