### PR TITLE
Stop orphaned publisher transceivers that trigger SFU force-rejoin

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
@@ -292,8 +292,13 @@ internal class Publisher(
                         return newTrack
                     }
                 } catch (e: Exception) {
-                    // Fallback if anything happens with the sender
-                    logger.w { "Failed to set track for ${publishOption.track_type}, creating new transceiver" }
+                    // Fallback if anything happens with the sender. Stop the old transceiver before
+                    // replacing it; otherwise it lingers on the PeerConnection as a live sendonly m-line
+                    // that SetPublisher.tracks never announces, and the SFU force-rejoins with
+                    // "track ... not announced by user". Only stop() (not dispose()): the PC is live and
+                    // owns the native sender; disposing here is a use-after-free on network_thread.
+                    logger.w { "Failed to set track for ${publishOption.track_type}, replacing transceiver" }
+                    safeCall { transceiver.stop() }
                     transceiverCache.remove(publishOption)
                     val fallbackTrack = newTrackFromSource(publishOption.track_type)
                     traceTrack(trackType, fallbackTrack.id())
@@ -353,6 +358,20 @@ internal class Publisher(
         track: MediaStreamTrack,
         publishOption: PublishOption,
     ) {
+        // Guard against orphans: never leave two live transceivers for the same
+        // [track_type, publish_option_id]. transceiverCache is keyed by that tuple, so add() would
+        // silently overwrite the entry and strand the old transceiver on the PeerConnection, where it
+        // keeps emitting a sendonly m-line that SetPublisher.tracks doesn't announce -> SFU rejoin loop.
+        // Only stop() (not dispose()): the PC is live and owns the native transceiver; disposing here
+        // is a use-after-free on network_thread. It is freed safely when the PC is torn down.
+        transceiverCache.get(publishOption)?.let { existing ->
+            logger.w {
+                "Existing ${publishOption.track_type} transceiver found (publishOptionId=${publishOption.id}); " +
+                    "stopping it before adding a new one to avoid an orphaned m-line."
+            }
+            safeCall { existing.stop() }
+            transceiverCache.remove(publishOption)
+        }
         val rtpParametersEncodings = computeTransceiverEncodings(
             captureFormat,
             publishOption,
@@ -406,12 +425,18 @@ internal class Publisher(
         // stop publishing with options not required anymore
         for (item in transceiverCache.items()) {
             val (option, transceiver) = item
-            val hasPublishOption = transceiverCache.has(option)
-            if (!hasPublishOption) continue
-            safeCall {
-                transceiver.stop()
-                transceiver.dispose()
+            // Keep transceivers whose option is still requested by the SFU. Comparing against the
+            // cache itself (the previous behaviour) was always true, so every transceiver was torn
+            // down on each ChangePublishOptions event — dropping tracks and, because dispose() frees
+            // senders the still-live PeerConnection keeps using, hard-crashing native WebRTC.
+            val stillRequested = publishOptions.any {
+                it.id == option.id && it.track_type == option.track_type
             }
+            if (stillRequested) continue
+            // Only stop() on a live PeerConnection: the m-line goes inactive/recycled in the next
+            // offer. Never dispose() here — the PC still owns the native transceiver/sender and frees
+            // it safely at teardown. Disposing mid-session is a use-after-free on network_thread.
+            safeCall { transceiver.stop() }
             transceiverCache.remove(option)
         }
     }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/PublisherTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/PublisherTest.kt
@@ -427,6 +427,152 @@ class PublisherTest {
         }
     }
 
+    /**
+     * Bug #1: the cleanup loop in [Publisher.syncPublishOptions] used to compare the cache against
+     * itself, so every transceiver was stopped/disposed on each ChangePublishOptions event. This
+     * asserts that transceivers whose options are still requested are left untouched.
+     */
+    @Test
+    fun `syncPublishOptions keeps transceivers whose options are still requested`() =
+        runTest(coroutineContext) {
+            val liveVideoTrack = mockk<VideoTrack>(relaxed = true) {
+                every { kind() } returns "video"
+                every { state() } returns MediaStreamTrack.State.LIVE
+                every { enabled() } returns true
+                every { isDisposed } returns false
+            }
+            val liveAudioTrack = mockk<AudioTrack>(relaxed = true) {
+                every { kind() } returns "audio"
+                every { state() } returns MediaStreamTrack.State.LIVE
+                every { enabled() } returns true
+                every { isDisposed } returns false
+            }
+            val videoTransceiver = mockk<RtpTransceiver>(relaxed = true) {
+                every { sender.track() } returns liveVideoTrack
+            }
+            val audioTransceiver = mockk<RtpTransceiver>(relaxed = true) {
+                every { sender.track() } returns liveAudioTrack
+            }
+            every {
+                mockPeerConnection.addTransceiver(any<MediaStreamTrack>(), any())
+            } returns videoTransceiver andThen audioTransceiver
+
+            publisher.publishStreamInternal("stream-1", TrackType.TRACK_TYPE_VIDEO)
+            publisher.publishStreamInternal("stream-1", TrackType.TRACK_TYPE_AUDIO)
+            assertEquals(2, mockTransceiverCache.items().size)
+
+            // Re-send the SAME options that are already active (both still requested).
+            publisher.syncPublishOptions(
+                captureFormat = CameraEnumerationAndroid.CaptureFormat(1280, 720, 24, 30),
+                publishOptions = listOf(videoPublishOption, audioPublishOption),
+            )
+
+            // Nothing should have been torn down or removed.
+            verify(exactly = 0) { videoTransceiver.stop() }
+            verify(exactly = 0) { videoTransceiver.dispose() }
+            verify(exactly = 0) { audioTransceiver.stop() }
+            verify(exactly = 0) { audioTransceiver.dispose() }
+            verify(exactly = 0) { mockTransceiverCache.remove(videoPublishOption) }
+            verify(exactly = 0) { mockTransceiverCache.remove(audioPublishOption) }
+            assertEquals(2, mockTransceiverCache.items().size)
+        }
+
+    /**
+     * Bug #2: when the sender can't be reused, [Publisher.publishStreamInternal] falls back to a new
+     * transceiver. It used to drop the old one from the cache without stopping it, leaving a live
+     * sendonly m-line that SetPublisher.tracks never announces -> SFU force-rejoins. This asserts the
+     * old transceiver is now stopped (but not disposed on the live PC), and exactly one transceiver
+     * remains announced.
+     */
+    @Test
+    fun `publishStreamInternal fallback stops the orphaned transceiver`() =
+        runTest(coroutineContext) {
+            val senderA = mockk<RtpSender>(relaxed = true)
+            val senderB = mockk<RtpSender>(relaxed = true)
+            val transceiverA = mockk<RtpTransceiver>(relaxed = true) {
+                every { sender } returns senderA
+            }
+            val transceiverB = mockk<RtpTransceiver>(relaxed = true) {
+                every { sender } returns senderB
+            }
+            every {
+                mockPeerConnection.addTransceiver(any<MediaStreamTrack>(), any())
+            } returns transceiverA andThen transceiverB
+
+            // First publish creates & caches transceiver A.
+            publisher.publishStreamInternal("stream-1", TrackType.TRACK_TYPE_VIDEO)
+            assertEquals(1, mockTransceiverCache.items().size)
+
+            // Arrange the failure that drops us into the fallback: A's track is disposed and setTrack throws.
+            val disposedTrack = mockk<VideoTrack>(relaxed = true) {
+                every { isDisposed } returns true
+                every { kind() } returns "video"
+            }
+            every { senderA.track() } returns disposedTrack
+            every { senderA.setTrack(any(), any()) } throws RuntimeException("sender failure")
+
+            // B is healthy so it stays announced.
+            every { senderB.track() } returns mockk<VideoTrack>(relaxed = true) {
+                every { isDisposed } returns false
+                every { kind() } returns "video"
+                every { state() } returns MediaStreamTrack.State.LIVE
+                every { id() } returns "track-B"
+            }
+
+            publisher.publishStreamInternal("stream-1", TrackType.TRACK_TYPE_VIDEO)
+
+            // Old transceiver A is stopped (the fix) so its m-line goes inactive; it is NOT disposed
+            // because the PeerConnection is live and owns it (disposing mid-session crashes native WebRTC).
+            verify(exactly = 1) { transceiverA.stop() }
+            verify(exactly = 0) { transceiverA.dispose() }
+            // Exactly one live transceiver remains, and it's B.
+            assertEquals(1, mockTransceiverCache.items().size)
+            assertEquals(transceiverB, mockTransceiverCache.get(videoPublishOption))
+        }
+
+    /**
+     * Bug #3: [Publisher.addTransceiver] caches by [track_type, publish_option_id], so adding a second
+     * transceiver for the same tuple used to silently overwrite the cache entry and strand the old
+     * transceiver on the PeerConnection (an orphaned m-line). This asserts the guard stops any
+     * pre-existing transceiver before adding the new one (without disposing it on the live PC).
+     */
+    @Test
+    fun `addTransceiver stops existing transceiver for the same publish option before adding`() =
+        runTest(coroutineContext) {
+            val liveTrack = mockk<VideoTrack>(relaxed = true) {
+                every { kind() } returns "video"
+                every { state() } returns MediaStreamTrack.State.LIVE
+                every { enabled() } returns true
+                every { isDisposed } returns false
+            }
+            val existingTransceiver = mockk<RtpTransceiver>(relaxed = true) {
+                every { sender.track() } returns liveTrack
+            }
+            mockTransceiverCache.add(videoPublishOption, existingTransceiver)
+
+            val newTransceiver = mockk<RtpTransceiver>(relaxed = true)
+            every {
+                mockPeerConnection.addTransceiver(any<MediaStreamTrack>(), any())
+            } returns newTransceiver
+
+            val newTrack = mockk<VideoTrack>(relaxed = true) {
+                every { kind() } returns "video"
+                every { id() } returns "new-track"
+            }
+            publisher.addTransceiver(
+                streamIdList = listOf("stream-1"),
+                captureFormat = CameraEnumerationAndroid.CaptureFormat(1280, 720, 24, 30),
+                track = newTrack,
+                publishOption = videoPublishOption,
+            )
+
+            // The stale transceiver is stopped (m-line goes inactive) and replaced by the new one.
+            // It is NOT disposed on the live PeerConnection — that would be a native use-after-free.
+            verify(exactly = 1) { existingTransceiver.stop() }
+            verify(exactly = 0) { existingTransceiver.dispose() }
+            assertEquals(newTransceiver, mockTransceiverCache.get(videoPublishOption))
+        }
+
     @Test
     fun `getTrackType returns the correct track type if found`() = runTest {
         // 1) Mock a video track with a specific ID


### PR DESCRIPTION
### Goal

Fixes [AND-1351](https://linear.app/stream/issue/AND-1351/fix-changepublishoption-bug-where-sdk-was-not-able-to-change-codec-mid) linked to VID-1367
Fixes three publisher transceiver-lifecycle bugs that can leave a live `sendonly` m-line on the publisher `PeerConnection` which `SetPublisher.tracks` never announces. The SFU then rejects the offer with `track ... not announced by user` and force-rejoins the publisher — a disruptive reconnect for the user.

The three bugs this PR solves:

1. **`syncPublishOptions` tears down every transceiver** — the cleanup loop compared the transceiver cache against itself, so it always matched and stopped/disposed *all* transceivers (audio + video) on each SFU `ChangePublishOptions` event, dropping tracks (and crashing native WebRTC via `dispose()` on a live PC).
2. **`publishStreamInternal` fallback orphans the old transceiver** — the sender-reuse fallback created a replacement transceiver but dropped the old one from the cache without stopping it, leaving an orphaned live m-line that is never announced.
3. **`addTransceiver` strands the previous transceiver** — for the same `[track_type, publish_option_id]` the cache entry was silently overwritten, orphaning the earlier transceiver on the `PeerConnection`.


### Implementation

- **`syncPublishOptions` cleanup predicate** — the cleanup loop compared the transceiver cache against itself (`transceiverCache.has(option)`), which was always `true`, so *every* transceiver was torn down on each `ChangePublishOptions` event (dropping audio + video). It now keeps transceivers whose `[id, track_type]` option is still requested by the SFU and only removes the ones that are actually gone.
- **`publishStreamInternal` fallback** — when the sender can't be reused, the fallback created a replacement transceiver but dropped the old one from the cache *without stopping it*, leaving an orphaned live m-line. It now `stop()`s the old transceiver before replacing it.
- **`addTransceiver` guard** — the cache is keyed by `[track_type, publish_option_id]`, so adding a second transceiver for the same tuple silently overwrote the entry and stranded the previous transceiver. A guard now `stop()`s any pre-existing transceiver for the same option before adding the new one.

In all three paths we call `stop()` **only**, never `dispose()`, on a live `PeerConnection`: `stop()` marks the m-line inactive so it is recycled in the next offer, while the PC retains ownership of the native transceiver/sender and frees it safely at teardown. Disposing mid-session is a use-after-free on `network_thread` and hard-crashes native WebRTC (`SIGSEGV`), which we observed and fixed during on-device reproduction.

### Testing

- [x] `./gradlew :stream-video-android-core:testDebugUnitTest --tests "io.getstream.video.android.core.call.connection.PublisherTest"` — BUILD SUCCESSFUL
- [x] `./gradlew :stream-video-android-core:spotlessApply` — BUILD SUCCESSFUL
- [x] Pre-push quality gate (spotlessCheck) — BUILD SUCCESSFUL
- Manual (on device): reproduced each bug via temporary debug hooks (SFU `ChangePublishOptions` codec swap VP9→H264, sender fallback, duplicate transceiver). With the fix: old video transceiver is `stop()`ed, audio is untouched, no orphaned m-line, no `not announced by user` force-rejoin, and no native `SIGSEGV`. Debug hooks removed before this PR.

New unit tests added to `PublisherTest`:
- `syncPublishOptions keeps transceivers whose options are still requested`
- `publishStreamInternal fallback stops the orphaned transceiver`
- `addTransceiver stops existing transceiver for the same publish option before adding`

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

Skipped — pure RTC logic fix, no UI change.