### PR TITLE
Fix peer connection previous-connect analytics scope

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalytics.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalytics.kt
@@ -162,16 +162,7 @@ internal class PeerConnectionAnalytics(
         iceState: VideoAnalyticsIceState,
         peerConnectionState: PeerConnection.PeerConnectionState?,
     ) {
-        when (peerConnectionState) {
-            PeerConnection.PeerConnectionState.CONNECTED -> {
-                if (role == PeerConnectionRole.PUBLISH) {
-                    stateHolder.updatePublisherEverConnected(true)
-                } else {
-                    stateHolder.updateSubscriberEverConnected(true)
-                }
-            }
-            else -> {}
-        }
+        val wasPrevConnected = stateHolder.isPcEverConnected(role)
 
         reporter.onPeerConnectionStateChanged(
             peerConnectionHashCode = peerConnectionHashCode,
@@ -183,9 +174,16 @@ internal class PeerConnectionAnalytics(
             joinStageAttemptId = joinAnalyticsStateHolder.state.value.joinStageAttemptId ?: "unknown",
             joinReason = joinAnalyticsStateHolder.state.value.joinReason ?: JoinReason.Unknown,
             sfuId = sfuAnalyticsStateHolder.sfuId.value,
-            wasPrevConnected = stateHolder.isPcEverConnected(role),
+            wasPrevConnected = wasPrevConnected,
             callSessionId = joinAnalyticsStateHolder.state.value.callSessionId,
         )
+
+        when (peerConnectionState) {
+            PeerConnection.PeerConnectionState.CONNECTED -> {
+                stateHolder.setPcEverConnected(role, true)
+            }
+            else -> {}
+        }
     }
 
     fun stop() {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalytics.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalytics.kt
@@ -162,6 +162,17 @@ internal class PeerConnectionAnalytics(
         iceState: VideoAnalyticsIceState,
         peerConnectionState: PeerConnection.PeerConnectionState?,
     ) {
+        when (peerConnectionState) {
+            PeerConnection.PeerConnectionState.CONNECTED -> {
+                if (role == PeerConnectionRole.PUBLISH) {
+                    stateHolder.updatePublisherEverConnected(true)
+                } else {
+                    stateHolder.updateSubscriberEverConnected(true)
+                }
+            }
+            else -> {}
+        }
+
         reporter.onPeerConnectionStateChanged(
             peerConnectionHashCode = peerConnectionHashCode,
             callId = callId,
@@ -172,6 +183,7 @@ internal class PeerConnectionAnalytics(
             joinStageAttemptId = joinAnalyticsStateHolder.state.value.joinStageAttemptId ?: "unknown",
             joinReason = joinAnalyticsStateHolder.state.value.joinReason ?: JoinReason.Unknown,
             sfuId = sfuAnalyticsStateHolder.sfuId.value,
+            wasPrevConnected = stateHolder.isPcEverConnected(role),
             callSessionId = joinAnalyticsStateHolder.state.value.callSessionId,
         )
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsStateHolder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsStateHolder.kt
@@ -17,6 +17,7 @@
 package io.getstream.video.android.core.analytics.call.observer
 
 import io.getstream.video.android.core.analytics.call.observer.model.Stage
+import io.getstream.video.android.core.analytics.reporting.model.PeerConnectionRole
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -45,6 +46,22 @@ internal class PeerConnectionAnalyticsStateHolder {
 
     fun updateSubscriberStage(stage: Stage) {
         _state.update { it.copy(subscriberStage = stage) }
+    }
+
+    fun updatePublisherEverConnected(wasPublisherEverConnected: Boolean) {
+        _state.update { it.copy(wasPublisherEverConnected = wasPublisherEverConnected) }
+    }
+
+    fun updateSubscriberEverConnected(wasSubscriberEverConnected: Boolean) {
+        _state.update { it.copy(wasSubscriberEverConnected = wasSubscriberEverConnected) }
+    }
+
+    fun isPcEverConnected(role: PeerConnectionRole): Boolean {
+        return if (role == PeerConnectionRole.PUBLISH) {
+            _state.value.wasPublisherEverConnected
+        } else {
+            _state.value.wasSubscriberEverConnected
+        }
     }
 
     fun update(
@@ -76,4 +93,6 @@ internal data class PeerConnectionAnalyticsState(
     val subscriberJob: Job? = null,
     val publisherStage: Stage = Stage.NOT_STARTED,
     val subscriberStage: Stage = Stage.NOT_STARTED,
+    val wasPublisherEverConnected: Boolean = false,
+    val wasSubscriberEverConnected: Boolean = false,
 )

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsStateHolder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsStateHolder.kt
@@ -64,6 +64,14 @@ internal class PeerConnectionAnalyticsStateHolder {
         }
     }
 
+    fun setPcEverConnected(role: PeerConnectionRole, connected: Boolean) {
+        if (role == PeerConnectionRole.PUBLISH) {
+            updatePublisherEverConnected(connected)
+        } else {
+            updateSubscriberEverConnected(connected)
+        }
+    }
+
     fun update(
         peerConnectionObserverJob: Job? = state.value.peerConnectionObserverJob,
         publisherJob: Job? = state.value.publisherJob,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/reporting/ClientEventReporter.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/analytics/reporting/ClientEventReporter.kt
@@ -82,7 +82,6 @@ internal class ClientEventReporter(
         ClientEventFactory(sdkVersion, userAgent, coordinatorAnalyticsStateHolder)
 
     private val postCallFlightSessions = ConcurrentHashMap<StageId, InFlightSession>()
-    private val pcEverConnected = ConcurrentHashMap<PeerConnectionRole, PcConnected>()
     private val pcEventReporterStateHolder = PeerConnectionEventReporterStateHolder()
 
     // --- Coordinator WS ---
@@ -285,6 +284,7 @@ internal class ClientEventReporter(
         joinReason: JoinReason,
         role: PeerConnectionRole,
         iceState: VideoAnalyticsIceState,
+        wasPrevConnected: Boolean,
         peerConnectionState: PeerConnection.PeerConnectionState?,
     ) {
         when (peerConnectionState) {
@@ -299,6 +299,7 @@ internal class ClientEventReporter(
                     joinReason,
                     role,
                     iceState,
+                    wasPrevConnected,
                     peerConnectionState,
                 )
             }
@@ -347,9 +348,9 @@ internal class ClientEventReporter(
         joinReason: JoinReason,
         role: PeerConnectionRole,
         iceState: VideoAnalyticsIceState,
+        wasPrevConnected: Boolean,
         peerConnectionState: PeerConnection.PeerConnectionState,
     ) {
-        val wasPrevConnected = pcEverConnected[role] != null
         val stageId = UUID.randomUUID().toString()
         val now = System.currentTimeMillis()
         postCallFlightSessions[stageId] = PostCallFlightSession(
@@ -400,7 +401,6 @@ internal class ClientEventReporter(
         peerConnectionState:
         PeerConnection.PeerConnectionState,
     ) {
-        pcEverConnected[role] = PcConnected(System.currentTimeMillis())
         val pcState = pcEventReporterStateHolder.map.remove(peerConnectionHashCode) ?: return
         val stageId = pcState.stageId
 
@@ -630,4 +630,3 @@ internal class PeerConnectionEventReporterState(
     var stageId: String,
     val peerConnectionRole: PeerConnectionRole,
 )
-internal class PcConnected(val lastConnectedTime: Long)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsTest.kt
@@ -103,6 +103,7 @@ class PeerConnectionAnalyticsTest {
                 joinReason = JoinReason.ReJoin,
                 role = PeerConnectionRole.SUBSCRIBE,
                 iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+                wasPrevConnected = false,
                 peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
             )
         }
@@ -131,6 +132,7 @@ class PeerConnectionAnalyticsTest {
                 joinReason = any(),
                 role = PeerConnectionRole.PUBLISH,
                 iceState = VideoAnalyticsIceState.CONNECTED,
+                wasPrevConnected = false,
                 peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
             )
         }
@@ -161,6 +163,7 @@ class PeerConnectionAnalyticsTest {
                 joinReason = any(),
                 role = PeerConnectionRole.PUBLISH,
                 iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+                wasPrevConnected = true,
                 peerConnectionState = PeerConnection.PeerConnectionState.CONNECTED,
             )
         }
@@ -191,6 +194,7 @@ class PeerConnectionAnalyticsTest {
                 joinReason = any(),
                 role = PeerConnectionRole.PUBLISH,
                 iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+                wasPrevConnected = false,
                 peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
             )
         }
@@ -220,6 +224,7 @@ class PeerConnectionAnalyticsTest {
                 joinReason = any(),
                 role = PeerConnectionRole.PUBLISH,
                 iceState = VideoAnalyticsIceState.FAILED,
+                wasPrevConnected = false,
                 peerConnectionState = PeerConnection.PeerConnectionState.FAILED,
             )
         }
@@ -285,7 +290,67 @@ class PeerConnectionAnalyticsTest {
                 joinReason = any(),
                 role = PeerConnectionRole.PUBLISH,
                 iceState = VideoAnalyticsIceState.CONNECTED,
+                wasPrevConnected = true,
                 peerConnectionState = PeerConnection.PeerConnectionState.CONNECTED,
+            )
+        }
+        scope.cancel()
+    }
+
+    @Test
+    fun `a publisher reconnect is flagged as previously connected without affecting subscriber`() {
+        val scope = CoroutineScope(Dispatchers.Unconfined)
+        val peerConnectionAnalytics = analytics(scope)
+
+        peerConnectionAnalytics.onPeerConnectionStateChanged(
+            peerConnectionHashCode = 42,
+            role = PeerConnectionRole.PUBLISH,
+            iceState = VideoAnalyticsIceState.CONNECTED,
+            peerConnectionState = PeerConnection.PeerConnectionState.CONNECTED,
+        )
+
+        peerConnectionAnalytics.onPeerConnectionStateChanged(
+            peerConnectionHashCode = 43,
+            role = PeerConnectionRole.SUBSCRIBE,
+            iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+            peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
+        )
+
+        peerConnectionAnalytics.onPeerConnectionStateChanged(
+            peerConnectionHashCode = 44,
+            role = PeerConnectionRole.PUBLISH,
+            iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+            peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
+        )
+
+        verify {
+            reporter.onPeerConnectionStateChanged(
+                peerConnectionHashCode = 43,
+                callId = "call-1",
+                callType = "default",
+                joinStageAttemptId = any(),
+                callSessionId = any(),
+                sfuId = any(),
+                joinReason = any(),
+                role = PeerConnectionRole.SUBSCRIBE,
+                iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+                wasPrevConnected = false,
+                peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
+            )
+        }
+        verify {
+            reporter.onPeerConnectionStateChanged(
+                peerConnectionHashCode = 44,
+                callId = "call-1",
+                callType = "default",
+                joinStageAttemptId = any(),
+                callSessionId = any(),
+                sfuId = any(),
+                joinReason = any(),
+                role = PeerConnectionRole.PUBLISH,
+                iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+                wasPrevConnected = true,
+                peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
             )
         }
         scope.cancel()

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/analytics/call/observer/PeerConnectionAnalyticsTest.kt
@@ -110,6 +110,32 @@ class PeerConnectionAnalyticsTest {
     }
 
     @Test
+    fun `a new call starts with wasPrevConnected set to false`() {
+        analytics(CoroutineScope(Dispatchers.Unconfined)).onPeerConnectionStateChanged(
+            peerConnectionHashCode = 42,
+            role = PeerConnectionRole.PUBLISH,
+            iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+            peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
+        )
+
+        verify(exactly = 1) {
+            reporter.onPeerConnectionStateChanged(
+                peerConnectionHashCode = 42,
+                callId = "call-1",
+                callType = "default",
+                joinStageAttemptId = any(),
+                callSessionId = any(),
+                sfuId = any(),
+                joinReason = any(),
+                role = PeerConnectionRole.PUBLISH,
+                iceState = VideoAnalyticsIceState.NOT_CONNECTED,
+                wasPrevConnected = false,
+                peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
+            )
+        }
+    }
+
+    @Test
     fun `a connecting publisher reports its current ice state immediately and marks the stage in progress`() = runTest {
         val session = mockSession(
             publisherState = PeerConnection.PeerConnectionState.CONNECTING,
@@ -163,7 +189,7 @@ class PeerConnectionAnalyticsTest {
                 joinReason = any(),
                 role = PeerConnectionRole.PUBLISH,
                 iceState = VideoAnalyticsIceState.NOT_CONNECTED,
-                wasPrevConnected = true,
+                wasPrevConnected = false,
                 peerConnectionState = PeerConnection.PeerConnectionState.CONNECTED,
             )
         }
@@ -290,15 +316,16 @@ class PeerConnectionAnalyticsTest {
                 joinReason = any(),
                 role = PeerConnectionRole.PUBLISH,
                 iceState = VideoAnalyticsIceState.CONNECTED,
-                wasPrevConnected = true,
+                wasPrevConnected = false,
                 peerConnectionState = PeerConnection.PeerConnectionState.CONNECTED,
             )
         }
+        assertTrue(stateHolder.isPcEverConnected(PeerConnectionRole.PUBLISH))
         scope.cancel()
     }
 
     @Test
-    fun `a publisher reconnect is flagged as previously connected without affecting subscriber`() {
+    fun `an existing call whose Publisher was previously connected sends wasPrevConnected as true`() {
         val scope = CoroutineScope(Dispatchers.Unconfined)
         val peerConnectionAnalytics = analytics(scope)
 
@@ -311,36 +338,14 @@ class PeerConnectionAnalyticsTest {
 
         peerConnectionAnalytics.onPeerConnectionStateChanged(
             peerConnectionHashCode = 43,
-            role = PeerConnectionRole.SUBSCRIBE,
-            iceState = VideoAnalyticsIceState.NOT_CONNECTED,
-            peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
-        )
-
-        peerConnectionAnalytics.onPeerConnectionStateChanged(
-            peerConnectionHashCode = 44,
             role = PeerConnectionRole.PUBLISH,
             iceState = VideoAnalyticsIceState.NOT_CONNECTED,
             peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
         )
 
-        verify {
+        verify(exactly = 1) {
             reporter.onPeerConnectionStateChanged(
                 peerConnectionHashCode = 43,
-                callId = "call-1",
-                callType = "default",
-                joinStageAttemptId = any(),
-                callSessionId = any(),
-                sfuId = any(),
-                joinReason = any(),
-                role = PeerConnectionRole.SUBSCRIBE,
-                iceState = VideoAnalyticsIceState.NOT_CONNECTED,
-                wasPrevConnected = false,
-                peerConnectionState = PeerConnection.PeerConnectionState.CONNECTING,
-            )
-        }
-        verify {
-            reporter.onPeerConnectionStateChanged(
-                peerConnectionHashCode = 44,
                 callId = "call-1",
                 callType = "default",
                 joinStageAttemptId = any(),

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/analytics/reporting/ClientEventReporterTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/analytics/reporting/ClientEventReporterTest.kt
@@ -87,6 +87,7 @@ class ClientEventReporterTest {
         iceState: VideoAnalyticsIceState,
         role: PeerConnectionRole = PeerConnectionRole.PUBLISH,
         pcHashCode: Int = 100,
+        wasPrevConnected: Boolean = false,
     ) = reporter.onPeerConnectionStateChanged(
         peerConnectionHashCode = pcHashCode,
         callId = "call-1",
@@ -97,6 +98,7 @@ class ClientEventReporterTest {
         joinReason = JoinReason.FirstAttempt,
         role = role,
         iceState = iceState,
+        wasPrevConnected = wasPrevConnected,
         peerConnectionState = pcState,
     )
 
@@ -329,6 +331,7 @@ class ClientEventReporterTest {
             pcState = PeerConnection.PeerConnectionState.CONNECTING,
             iceState = VideoAnalyticsIceState.NOT_CONNECTED,
             pcHashCode = 2,
+            wasPrevConnected = true,
         )
 
         val reconnectInitiated = dispatcher.sent.last()


### PR DESCRIPTION
### Goal

Closes #AND-1368

Ensure `wasPreviouslyConnected` is reported only for the relevant peer connection role within the current call analytics lifecycle, instead of leaking cached state from previous calls.

### Implementation
Moved peer connection “ever connected” tracking out of the client-level reporter state and into `PeerConnectionAnalyticsStateHolder`, so the value is scoped to peer connection analytics for the current call. `PeerConnectionAnalytics` now updates publisher/subscriber connected state when a `CONNECTED` event is observed and passes the role-specific `wasPrevConnected` value into `ClientEventReporter`.

### 🎨 UI Changes

None

### Testing

- first connection attempts report `wasPrevConnected = false`
- reconnects after a successful connection report `wasPrevConnected = true`
- publisher and subscriber previous-connect state are tracked independently
- reporter tests use the explicit `wasPrevConnected` input instead of relying on cached client-level state
- Verify manually in backend logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Analytics**
  * Improved peer-connection analytics to accurately identify whether publisher and subscriber connections have previously connected.
  * Reconnection events now report the correct prior-connection status for clearer connection lifecycle insights.

* **Tests**
  * Added coverage for initial connections, failures, reconnects, and publisher/subscriber-specific connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->