### PR TITLE
Always announce video layers on SetPublisher

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
@@ -206,25 +206,36 @@ internal class Publisher(
                 session_id = sessionId,
             )
             val response = sfuClient.setPublisher(request)
-            logger.i { "Received answer: ${response.sdp}" }
             if (response.error != null) {
                 logger.e {
                     "SetPublisherRequest Received error: ${response.error}, SetPublisherRequest: $request"
                 }
                 tracer.trace("negotiate-error-setpublisher", response.error.message ?: "unknown")
-                logger.e { "rejoin cause error in sfuClient.setPublisher, message:${response.error.message}" }
-
                 when (response.error.code) {
                     /**
-                     *  We are getting this error right away after joining the call first time
-                     *  Full error: 16:04:05.032 Call:PeerC...:publisher  E  (DefaultDispatcher-worker-17:526) SetPublisherRequest Received error: Error{code=ERROR_CODE_REQUEST_VALIDATION_FAILED, message=Invalid SetPublisher request, should_retry=false}
-                     * This will cause emission of ParticipantLeftEvent to other person
+                     * Historically common right after first join when video layers were omitted
+                     * for non-LIVE tracks. Layers are now always computed from publish options, so
+                     * remaining validation failures are treated as a real publisher/SFU mismatch.
                      */
-                    ErrorCode.ERROR_CODE_REQUEST_VALIDATION_FAILED -> rejoin()
+                    ErrorCode.ERROR_CODE_REQUEST_VALIDATION_FAILED -> {
+                        logger.e {
+                            "rejoin cause error in sfuClient.setPublisher, " +
+                                "message:${response.error.message}"
+                        }
+                        rejoin()
+                    }
 
-                    else -> {}
+                    else -> {
+                        logger.e {
+                            "Unhandled SetPublisher error code=${response.error.code}, " +
+                                "message=${response.error.message}"
+                        }
+                    }
                 }
+                return@submit
             }
+
+            logger.i { "Received answer: ${response.sdp}" }
             setRemoteDescription(SessionDescription(SessionDescription.Type.ANSWER, response.sdp))
                 .onErrorSuspend {
                     tracer.trace(
@@ -234,7 +245,6 @@ internal class Publisher(
                 }.onSuccess {
                     logger.d { "Publisher negotiation successfully done ✅" }
                 }
-            // Set ice trickle
         }
         isIceRestarting = false
     }
@@ -649,16 +659,15 @@ internal class Publisher(
         }
         val isTrackLive = track.state() == MediaStreamTrack.State.LIVE
         val isAudio = isAudioTrackType(publishOption.track_type)
+        // Layer math only needs dimension + PublishOption — not LIVE/frames. Previously we skipped
+        // computeLayers when !LIVE, announced empty layers, and SFU rejected SetPublisher on first
+        // join (then we rejoined). Always compute so muted/non-LIVE video still has layers.
         val layers = if (!isAudio) {
-            if (isTrackLive) {
-                computeLayers(
-                    captureFormat,
-                    track,
-                    publishOption,
-                )
-            } else {
-                transceiverCache.getLayers(publishOption)
-            }
+            computeLayers(
+                captureFormat,
+                track,
+                publishOption,
+            ) ?: transceiverCache.getLayers(publishOption)
         } else {
             null
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/Publisher.kt
@@ -195,8 +195,8 @@ internal class Publisher(
         logger.i { "Negotiating with tracks: $trackInfos" }
         logger.i { "Offer: ${offer.description}" }
 
-        safeCall {
-            isIceRestarting = iceRestart
+        isIceRestarting = iceRestart
+        try {
             setLocalDescription(offer).onErrorSuspend {
                 tracer.trace("negotiate-error-setlocaldescription", it.message ?: "unknown")
             }
@@ -245,8 +245,12 @@ internal class Publisher(
                 }.onSuccess {
                     logger.d { "Publisher negotiation successfully done ✅" }
                 }
+        } catch (e: Exception) {
+            logger.e(e) { "[negotiate] Exception occurred: ${e.message}" }
+        } finally {
+            // Must clear even when returning early from @submit (inline safeCall used to skip this).
+            isIceRestarting = false
         }
-        isIceRestarting = false
     }
 
     override suspend fun stats(): ComputedStats? = safeCallWithDefault(null) {

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/PublisherTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/PublisherTest.kt
@@ -62,7 +62,10 @@ import stream.video.sfu.event.VideoSender
 import stream.video.sfu.models.AudioBitrateProfile
 import stream.video.sfu.models.Codec
 import stream.video.sfu.models.DegradationPreference
+import stream.video.sfu.models.Error
+import stream.video.sfu.models.ErrorCode
 import stream.video.sfu.models.PublishOption
+import stream.video.sfu.models.TrackInfo
 import stream.video.sfu.models.TrackType
 import stream.video.sfu.models.VideoDimension
 import stream.video.sfu.signal.SetPublisherResponse
@@ -92,6 +95,7 @@ class PublisherTest {
     private lateinit var publisher: Publisher
     private val coroutineContext = UnconfinedTestDispatcher()
     private val testScope = TestScope(coroutineContext)
+    private var rejoinInvocations = 0
 
     //region Example PublishOptions
     private val videoPublishOption = PublishOption(
@@ -129,6 +133,7 @@ class PublisherTest {
     @Before
     fun setUp() {
         MockKAnnotations.init(this, relaxUnitFun = true)
+        rejoinInvocations = 0
 
         // Mock the mediaManager and peerConnectionFactory so they return mock Audio/Video tracks.
         every { mockPeerConnectionFactory.makeAudioTrack(any(), any()) } answers {
@@ -171,7 +176,7 @@ class PublisherTest {
                 maxBitRate = 1_500_000,
                 sfuClient = mockSignalServerService,
                 sessionId = "session-id",
-                rejoin = { },
+                rejoin = { rejoinInvocations++ },
                 tracer = mockk(relaxed = true),
                 fastReconnect = {},
                 transceiverCache = mockTransceiverCache,
@@ -283,6 +288,70 @@ class PublisherTest {
         publisher.negotiate()
 
         coVerify(exactly = 0) { mockSignalServerService.setPublisher(any()) }
+    }
+
+    @Test
+    fun `getAnnouncedTracks includes video layers even when track is not LIVE`() {
+        val mockVideoTrack = mockk<VideoTrack>(relaxed = true) {
+            every { id() } returns "video-1"
+            every { kind() } returns "video"
+            every { isDisposed } returns false
+            every { state() } returns MediaStreamTrack.State.ENDED
+        }
+        val mockSender = mockk<RtpSender>(relaxed = true) {
+            every { track() } returns mockVideoTrack
+        }
+        val mockTransceiver = mockk<RtpTransceiver>(relaxed = true) {
+            every { sender } returns mockSender
+            every { mid } returns "0"
+        }
+        every { mockTransceiverCache.items() } returns listOf(
+            TransceiverId(videoPublishOption, mockTransceiver),
+        )
+        every { mockTransceiverCache.indexOf(videoPublishOption) } returns 0
+        every { mockTransceiverCache.getLayers(videoPublishOption) } returns null
+
+        val announced = publisher.getAnnouncedTracks(null, null)
+
+        assertEquals(1, announced.size)
+        assertTrue(announced[0].muted)
+        assertTrue(announced[0].layers.isNotEmpty())
+    }
+
+    @Test
+    fun `SetPublisher validation failure rejoins`() = runTest(coroutineContext) {
+        every { publisher.getAnnouncedTracks(any(), any()) } returns listOf(
+            TrackInfo(
+                track_id = "video-1",
+                track_type = TrackType.TRACK_TYPE_VIDEO,
+                mid = "0",
+                muted = false,
+                layers = listOf(
+                    stream.video.sfu.models.VideoLayer(
+                        rid = "f",
+                        video_dimension = VideoDimension(1280, 720),
+                        bitrate = 1_000_000,
+                        fps = 30,
+                    ),
+                ),
+                publish_option_id = videoPublishOption.id,
+            ),
+        )
+        coEvery { publisher.setLocalDescription(any()) } returns Result.Success(Unit)
+        coEvery { publisher.setRemoteDescription(any()) } returns Result.Success(Unit)
+        coEvery { mockSignalServerService.setPublisher(any()) } returns SetPublisherResponse(
+            sdp = "",
+            error = Error(
+                code = ErrorCode.ERROR_CODE_REQUEST_VALIDATION_FAILED,
+                message = "Invalid SetPublisher request",
+                should_retry = false,
+            ),
+        )
+
+        publisher.negotiate(source = "test")
+
+        coVerify(exactly = 1) { mockSignalServerService.setPublisher(any()) }
+        assertEquals(1, rejoinInvocations)
     }
 
     @Test

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/PublisherTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/PublisherTest.kt
@@ -351,7 +351,55 @@ class PublisherTest {
         publisher.negotiate(source = "test")
 
         coVerify(exactly = 1) { mockSignalServerService.setPublisher(any()) }
+        coVerify(exactly = 0) { publisher.setRemoteDescription(any()) }
         assertEquals(1, rejoinInvocations)
+    }
+
+    @Test
+    fun `iceRestart SetPublisher error clears isIceRestarting so later negotiate runs`() = runTest(
+        coroutineContext,
+    ) {
+        every { publisher.getAnnouncedTracks(any(), any()) } returns listOf(
+            TrackInfo(
+                track_id = "video-1",
+                track_type = TrackType.TRACK_TYPE_VIDEO,
+                mid = "0",
+                muted = false,
+                layers = listOf(
+                    stream.video.sfu.models.VideoLayer(
+                        rid = "f",
+                        video_dimension = VideoDimension(1280, 720),
+                        bitrate = 1_000_000,
+                        fps = 30,
+                    ),
+                ),
+                publish_option_id = videoPublishOption.id,
+            ),
+        )
+        coEvery { publisher.setLocalDescription(any()) } returns Result.Success(Unit)
+        coEvery { publisher.setRemoteDescription(any()) } returns Result.Success(Unit)
+        coEvery { mockSignalServerService.setPublisher(any()) } returnsMany listOf(
+            SetPublisherResponse(
+                sdp = "",
+                error = Error(
+                    code = ErrorCode.ERROR_CODE_PARTICIPANT_NOT_FOUND,
+                    message = "participant not found",
+                    should_retry = false,
+                ),
+            ),
+            SetPublisherResponse(
+                sdp = fakeSdpAnswer.description,
+                error = null,
+            ),
+        )
+
+        publisher.negotiate(source = "ice-restart", iceRestart = true)
+        assertEquals(0, rejoinInvocations)
+
+        // Without finally clearing isIceRestarting, this second call would no-op.
+        publisher.negotiate(source = "after-ice-restart-error")
+
+        coVerify(exactly = 2) { mockSignalServerService.setPublisher(any()) }
     }
 
     @Test


### PR DESCRIPTION
### Goal

Fixes [AND-1377](https://linear.app/stream/issue/AND-1377/avoid-full-rejoin-on-first-setpublisher-validation-failure)
Prevent unnecessary full rejoins when the first `SetPublisher` races ahead of the video track becoming `LIVE`.

On first join, Android often negotiated while `track.state() != LIVE`. Layer computation was gated on LIVE, so the announce went out with empty `layers`. The SFU rejected that with `ERROR_CODE_REQUEST_VALIDATION_FAILED` / `Invalid SetPublisher request`, and `Publisher` rejoined — flashing reconnect UI and emitting `ParticipantLeft` to peers. The second session usually succeeded.

Seen in dogfood and Blink (`default:019f45a0-1388-70ab-970d-ee1b4d195d3a`).

Dashboard: https://beta.dashboard.getstream.io/organization/1234199/1336271/video/call/viewer/default:019f45a0-1388-70ab-970d-ee1b4d195d3a/

### Implementation

- Always compute video/screenshare layers from capture dimension + `PublishOption` in `toTrackInfo`, even when the track is not LIVE (`TrackInfo.muted` can still reflect `!LIVE`).
- Layer math does not depend on frames/capturer readiness; empty layers were a self-imposed gate, not an async “layers ready” signal.
- Keep `ERROR_CODE_REQUEST_VALIDATION_FAILED` → `rejoin()` for remaining real mismatches (aligned with prior recovery that fixed persistent validation failures).
- On SetPublisher error, return early instead of applying a potentially empty remote SDP.
- Unit coverage for non-LIVE video still announcing layers, and validation failure still rejoining.

### Testing

- [x] `./gradlew :stream-video-android-core:testDebugUnitTest --tests "io.getstream.video.android.core.call.connection.PublisherTest"` — passed
- [x] Manual dogfood: join with camera racing mid-join; first announce can be `muted=true` with nonempty `q/h/f` layers; SetPublisher succeeds without validation rejoin
- React/iOS note: React keys RPC retry on `should_retry` (this validation case is `should_retry=false`). Android still rejoins on remaining validation failures after the layers fix; that recovery path is intentional.

<details>

<summary>Evidence from dogfood</summary>

```
Negotiating with tracks: ... muted=true, layers=[q/h/f...]
Publisher negotiation successfully done ✅
No Invalid SetPublisher / REQUEST_VALIDATION_FAILED
```

</details>

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

N/A — analytics/RTC publish path fix, no UI change.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of publisher validation errors during connection negotiation.
  * Automatically rejoins when publisher validation fails.
  * Ensured ended video tracks are announced correctly with their available layers.
  * Improved reporting of other publisher errors during negotiation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->