### PR TITLE
Noise cancellation state no longer leaks between calls or misreports

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -913,8 +913,10 @@ public class Call(
         notifyNoiseCancellationState(media.isAudioProcessingEnabledIfCreated())
     }
 
-    fun toggleAudioProcessing(): Boolean = media.toggleAudioProcessing().also { enabled ->
-        notifyNoiseCancellationState(enabled)
+    fun toggleAudioProcessing(): Boolean = media.toggleAudioProcessing().also {
+        // Signals what is running, not what the toggle now reports: before a factory exists the
+        // toggle reflects the wanted state, and the SFU must only hear about real processing.
+        notifyNoiseCancellationState(media.isAudioProcessingEnabledIfCreated())
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -891,8 +891,21 @@ public class Call(
         return state.settings.value?.video?.enabled ?: false
     }
 
+    /**
+     * Whether noise cancellation is running for this call.
+     *
+     * The audio processor supplied to [StreamVideoBuilder] is a single instance shared by every
+     * call, so this state is only meaningful for the call currently in progress. Two calls in
+     * progress at once cannot have different noise-cancellation states.
+     */
     fun isAudioProcessingEnabled(): Boolean = media.isAudioProcessingEnabled()
 
+    /**
+     * Turns noise cancellation on or off for this call, and tells the SFU about it.
+     *
+     * Takes effect for the call in progress; see [isAudioProcessingEnabled] for why the state
+     * cannot differ between two calls running at the same time.
+     */
     fun setAudioProcessingEnabled(enabled: Boolean) {
         media.setAudioProcessingEnabled(enabled)
         // Signals what was actually applied, not what was asked for: with no audio processor

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
@@ -286,8 +286,17 @@ internal class CallMediaManager(
         mediaManager.screenShare.disable(fromUser = true)
     }
 
-    fun isAudioProcessingEnabled(): Boolean {
-        return peerConnectionFactory.isAudioProcessingEnabled()
+    /**
+     * Whether noise cancellation is on for this call: what is actually processing once a factory
+     * exists, and what the call asked for before then.
+     *
+     * Never builds a factory. Once one exists its answer wins, so a call under MUSIC_HIGH_QUALITY
+     * reports off even though it asked for on — nothing is attached to process its audio.
+     */
+    fun isAudioProcessingEnabled(): Boolean = if (_peerConnectionFactory != null) {
+        isAudioProcessingEnabledIfCreated()
+    } else {
+        desiredAudioProcessingEnabled
     }
 
     /**
@@ -312,10 +321,17 @@ internal class CallMediaManager(
         _peerConnectionFactory?.setAudioProcessingEnabled(enabled)
     }
 
+    /**
+     * Flips the wanted audio-processing state, applying it if a factory exists.
+     *
+     * Goes through [setAudioProcessingEnabled] rather than the factory so a toggle before joining
+     * cannot build one: a factory created there captures the pre-join audio bitrate profile, and
+     * one holding the shared processor is kept rather than released, so the profile would be
+     * pinned for the rest of the call.
+     */
     fun toggleAudioProcessing(): Boolean {
-        return peerConnectionFactory.toggleAudioProcessing().also { enabled ->
-            desiredAudioProcessingEnabled = enabled
-        }
+        setAudioProcessingEnabled(!desiredAudioProcessingEnabled)
+        return isAudioProcessingEnabled()
     }
 
     /** Disables all local capture devices. Used when leaving the call. */

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
@@ -296,6 +296,10 @@ internal class CallMediaManager(
     }
 
     fun cleanup() {
+        // The audio processor is owned by the client and shared by every call, so this call's
+        // choice has to be cleared here or it carries into the next one. Reads the backing
+        // field directly: cleanup must never lazily build a factory just to reset it.
+        _peerConnectionFactory?.resetAudioProcessing()
         mediaManager.cleanup()
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
@@ -74,6 +74,17 @@ internal class CallMediaManager(
     // peerConnectionFactory is nullable and recreated when audioBitrateProfile changes (before joining)
     private var _peerConnectionFactory: StreamPeerConnectionFactory? = null
 
+    /**
+     * Audio-processing state this call wants, remembered separately from the factory so it
+     * survives one not existing yet or being recreated.
+     *
+     * The processor itself is owned by the client and shared by every call, and its enabled flag
+     * lives on that one instance. Rather than clearing the flag when a call ends — which reaches
+     * across into whatever call runs next — every factory applies the state its own call asked
+     * for as it is built. Defaults to off so a call that never asks does not inherit.
+     */
+    private var desiredAudioProcessingEnabled: Boolean = false
+
     var peerConnectionFactory: StreamPeerConnectionFactory
         get() {
             if (_peerConnectionFactory == null) {
@@ -85,7 +96,9 @@ internal class CallMediaManager(
                     audioBitrateProfileProvider = { mediaManager.microphone.audioBitrateProfile.value },
                     sharedEglBaseProvider = { eglBase() },
                     webRtcLoggingLevel = clientImpl.loggingLevel.webRtcLoggingLevel,
-                )
+                ).also { factory ->
+                    factory.setAudioProcessingEnabled(desiredAudioProcessingEnabled)
+                }
             }
             return _peerConnectionFactory!!
         }
@@ -171,9 +184,17 @@ internal class CallMediaManager(
      * This should only be called before the call is joined.
      */
     fun recreatePeerConnectionFactory() {
-        _peerConnectionFactory?.dispose()
-        _peerConnectionFactory = null
+        val previous = _peerConnectionFactory
         // Next access to peerConnectionFactory will recreate it with current profile
+        _peerConnectionFactory = null
+        if (previous?.hasAudioProcessingAttached() == true) {
+            // The shared audio processor is torn down when the native factory holding it is
+            // released, which would leave the client without one for every later call. Dropping
+            // the factory instead leaks it, the same way a factory is dropped on call cleanup.
+            logger.i { "Keeping the previous factory alive: it holds the shared audio processor" }
+            return
+        }
+        previous?.dispose()
     }
 
     /** Applies server-provided call settings to the local media manager. */
@@ -280,12 +301,21 @@ internal class CallMediaManager(
     fun isAudioProcessingEnabledIfCreated(): Boolean =
         _peerConnectionFactory?.isAudioProcessingEnabled() ?: false
 
+    /**
+     * Records the wanted audio-processing state and applies it to the factory if one exists.
+     * A factory built later picks the value up on creation, so this never has to build one:
+     * a factory created before join captures the pre-join audio bitrate profile and defeats
+     * [ensureFactoryMatchesAudioProfile].
+     */
     fun setAudioProcessingEnabled(enabled: Boolean) {
-        return peerConnectionFactory.setAudioProcessingEnabled(enabled)
+        desiredAudioProcessingEnabled = enabled
+        _peerConnectionFactory?.setAudioProcessingEnabled(enabled)
     }
 
     fun toggleAudioProcessing(): Boolean {
-        return peerConnectionFactory.toggleAudioProcessing()
+        return peerConnectionFactory.toggleAudioProcessing().also { enabled ->
+            desiredAudioProcessingEnabled = enabled
+        }
     }
 
     /** Disables all local capture devices. Used when leaving the call. */
@@ -296,10 +326,6 @@ internal class CallMediaManager(
     }
 
     fun cleanup() {
-        // The audio processor is owned by the client and shared by every call, so this call's
-        // choice has to be cleared here or it carries into the next one. Reads the backing
-        // field directly: cleanup must never lazily build a factory just to reset it.
-        _peerConnectionFactory?.resetAudioProcessing()
         mediaManager.cleanup()
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
@@ -104,6 +104,15 @@ public class StreamPeerConnectionFactory(
             stream.video.sfu.models.AudioBitrateProfile.AUDIO_BITRATE_PROFILE_MUSIC_HIGH_QUALITY
     }
 
+    /**
+     * Whether the shared audio processor was handed to a native factory that is still alive.
+     *
+     * Unlike [isAudioProcessingAttached] this never speculates: it is only true once the native
+     * factory exists and was built with the processor. [dispose] uses it to decide whether
+     * tearing this factory down would take the shared processor with it.
+     */
+    internal fun hasAudioProcessingAttached(): Boolean = factoryCreated && audioProcessingAttached
+
     private val webRtcLogger by taggedLogger("Call:WebRTC")
     private val audioLogger by taggedLogger("Call:AudioTrackCallback")
 
@@ -192,7 +201,14 @@ public class StreamPeerConnectionFactory(
      * Factory that builds all the connections based on the extensive configuration provided under
      * the hood.
      */
-    private val factory: PeerConnectionFactory by lazy { createFactory() }
+    /**
+     * Held as an explicit [Lazy] so [dispose] can tell whether a native factory was ever built.
+     * Reading [factory] builds one, which would attach the shared audio processor purely so it
+     * could be torn down again.
+     */
+    private val factoryLazy = lazy { createFactory() }
+
+    private val factory: PeerConnectionFactory get() = factoryLazy.value
 
     private var adm: JavaAudioDeviceModule? = null
 
@@ -737,16 +753,6 @@ public class StreamPeerConnectionFactory(
     }
 
     /**
-     * Clears the shared audio processor's enabled state.
-     *
-     * The [ManagedAudioProcessingFactory] is owned by the client and reused by every call, so a
-     * call must not leave its choice behind for whichever call comes next.
-     */
-    internal fun resetAudioProcessing() {
-        audioProcessing?.isEnabled = false
-    }
-
-    /**
      * Updates the audio track usage for the audio device module.
      * This allows toggling between different audio usage types (e.g., USAGE_MEDIA vs USAGE_VOICE_COMMUNICATION).
      *
@@ -760,8 +766,16 @@ public class StreamPeerConnectionFactory(
     /**
      * Disposes the factory and releases resources.
      * This should only be called when no active peer connections are using it.
+     *
+     * Does nothing when no native factory was ever built — building one here would attach the
+     * shared audio processor only to release it again. Callers must also check
+     * [hasAudioProcessingAttached] first: releasing a factory built with the shared processor
+     * takes that processor down with it.
      */
     internal fun dispose() {
+        if (!factoryLazy.isInitialized()) {
+            return
+        }
         try {
             factory.dispose()
         } catch (e: Exception) {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactory.kt
@@ -84,6 +84,26 @@ public class StreamPeerConnectionFactory(
      */
     internal var audioBitrateProfile: stream.video.sfu.models.AudioBitrateProfile? = null
 
+    /**
+     * Whether [audioProcessing] was wired into the native factory when it was built. Under
+     * MUSIC_HIGH_QUALITY the processor is deliberately left off, so the shared module's own
+     * `isEnabled` flag says nothing about whether processing actually runs for this call.
+     */
+    private var audioProcessingAttached: Boolean = false
+
+    private var factoryCreated: Boolean = false
+
+    /**
+     * True when audio processing is — or will be — wired into the native factory for this call.
+     * Before the factory is built the only honest answer is what it will be built with.
+     */
+    private fun isAudioProcessingAttached(): Boolean = if (factoryCreated) {
+        audioProcessingAttached
+    } else {
+        audioProcessing != null && audioBitrateProfileProvider?.invoke() !=
+            stream.video.sfu.models.AudioBitrateProfile.AUDIO_BITRATE_PROFILE_MUSIC_HIGH_QUALITY
+    }
+
     private val webRtcLogger by taggedLogger("Call:WebRTC")
     private val audioLogger by taggedLogger("Call:AudioTrackCallback")
 
@@ -232,7 +252,10 @@ public class StreamPeerConnectionFactory(
             .apply {
                 // Disable audio processing (noise cancellation) when MUSIC_HIGH_QUALITY is enabled
                 if (!isMusicHighQuality) {
-                    audioProcessing?.also { setAudioProcessingFactory(it) }
+                    audioProcessing?.also {
+                        setAudioProcessingFactory(it)
+                        this@StreamPeerConnectionFactory.audioProcessingAttached = true
+                    }
                 } else {
                     setAudioProcessingEnabled(false)
                 }
@@ -243,6 +266,7 @@ public class StreamPeerConnectionFactory(
                 adm,
             )
             .createPeerConnectionFactory()
+            .also { factoryCreated = true }
     }
 
     private fun initAudioDeviceModule(): JavaAudioDeviceModule? {
@@ -680,26 +704,46 @@ public class StreamPeerConnectionFactory(
 
     /**
      * True if the audio processing is enabled, false otherwise.
+     *
+     * Returns false when the processor is not wired into the native factory — under
+     * MUSIC_HIGH_QUALITY nothing is processing this call's audio, whatever the shared
+     * module's own flag happens to say.
      */
     public fun isAudioProcessingEnabled(): Boolean {
+        if (!isAudioProcessingAttached()) return false
         return audioProcessing?.isEnabled ?: false
     }
 
     /**
      * Sets the audio processing on or off.
+     *
+     * No-op when the processor is not wired into the native factory: the module is shared
+     * across calls, and a call that cannot use it must not change what other calls observe.
      */
     public fun setAudioProcessingEnabled(enabled: Boolean) {
+        if (!isAudioProcessingAttached()) return
         audioProcessing?.isEnabled = enabled
     }
 
     /**
-     * Toggles the audio processing on and off.
+     * Toggles the audio processing on and off, returning the resulting state.
      */
     public fun toggleAudioProcessing(): Boolean {
+        if (!isAudioProcessingAttached()) return false
         return audioProcessing?.let {
             it.isEnabled = !it.isEnabled
             it.isEnabled
         } ?: false
+    }
+
+    /**
+     * Clears the shared audio processor's enabled state.
+     *
+     * The [ManagedAudioProcessingFactory] is owned by the client and reused by every call, so a
+     * call must not leave its choice behind for whichever call comes next.
+     */
+    internal fun resetAudioProcessing() {
+        audioProcessing?.isEnabled = false
     }
 
     /**

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallTestSeams.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallTestSeams.kt
@@ -114,3 +114,14 @@ private fun Call.mediaComponent(): CallMediaManager {
     field.isAccessible = true
     return field.get(this) as CallMediaManager
 }
+
+/**
+ * Applies the wanted audio-processing state to the installed factory, the way building one does in
+ * production. Tests install a factory directly, which bypasses that step.
+ */
+internal fun Call.mediaAppliesWantedState() {
+    val media = mediaComponent()
+    val field = CallMediaManager::class.java.getDeclaredField("desiredAudioProcessingEnabled")
+    field.isAccessible = true
+    media.peerConnectionFactory.setAudioProcessingEnabled(field.get(media) as Boolean)
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
@@ -172,4 +172,25 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
         coVerify(timeout = SIGNAL_TIMEOUT_MS) { session.stopNoiseCancellation() }
         assertEquals(false, signalled.last())
     }
+
+    @Test
+    fun `a state applied only once the factory exists is signalled on join`() = runTest {
+        val call = client.call("default", randomUUID())
+
+        // Wanted before any factory exists, so nothing is applied yet and the signal finds no
+        // session to send at.
+        call.setAudioProcessingEnabled(true)
+
+        // The factory is built while joining and applies the wanted state, so by the time a
+        // session appears noise cancellation really is running.
+        call.injectWorkingProcessor()
+        call.mediaAppliesWantedState()
+
+        val session = mockk<RtcSession>(relaxed = true)
+        val signalled = record(session)
+        call.injectSession(session)
+
+        coVerify(timeout = SIGNAL_TIMEOUT_MS) { session.startNoiseCancellation() }
+        assertEquals(listOf(true), signalled)
+    }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
@@ -111,17 +111,19 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
     }
 
     @Test
-    fun `toggle signals the resolved state, not the requested one`() = runTest {
+    fun `toggle reports the wanted state but signals what is running`() = runTest {
         val call = client.call("default", randomUUID())
         val session = mockk<RtcSession>(relaxed = true)
         call.injectSession(session)
 
-        // No processor is configured, so the toggle cannot turn anything on — and the signal must
-        // follow what actually happened locally.
-        val enabled = call.toggleAudioProcessing()
+        // No factory exists yet, so the toggle records what the call wants and reports that —
+        // building one here would capture the pre-join audio bitrate profile. Nothing is
+        // processing, so the SFU is told noise cancellation is off.
+        val wanted = call.toggleAudioProcessing()
 
-        assertEquals(false, enabled)
+        assertEquals(true, wanted)
         coVerify(timeout = SIGNAL_TIMEOUT_MS) { session.stopNoiseCancellation() }
+        coVerify(exactly = 0) { session.startNoiseCancellation() }
     }
 
     @Test

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
@@ -138,10 +138,9 @@ class CallMediaManagerTest {
     }
 
     @Test
-    fun `audio-processing toggles delegate to the injected factory`() {
+    fun `audio-processing state and changes go through the injected factory`() {
         val factory = mockk<StreamPeerConnectionFactory>(relaxed = true)
         every { factory.isAudioProcessingEnabled() } returns true
-        every { factory.toggleAudioProcessing() } returns false
 
         val manager = manager()
         manager.peerConnectionFactory = factory
@@ -149,11 +148,9 @@ class CallMediaManagerTest {
         assertThat(manager.peerConnectionFactory).isSameInstanceAs(factory)
         assertThat(manager.isAudioProcessingEnabled()).isTrue()
         manager.setAudioProcessingEnabled(true)
-        assertThat(manager.toggleAudioProcessing()).isFalse()
 
         verify { factory.isAudioProcessingEnabled() }
         verify { factory.setAudioProcessingEnabled(true) }
-        verify { factory.toggleAudioProcessing() }
     }
 
     @Test
@@ -194,17 +191,17 @@ class CallMediaManagerTest {
     }
 
     @Test
-    fun `toggling audio processing records the resulting state`() {
+    fun `toggling flips the wanted state without asking the factory to toggle`() {
         val factory = mockk<StreamPeerConnectionFactory>(relaxed = true)
-        every { factory.toggleAudioProcessing() } returns true
+        every { factory.isAudioProcessingEnabled() } returns true
         val manager = manager()
         manager.peerConnectionFactory = factory
 
         assertThat(manager.toggleAudioProcessing()).isTrue()
 
-        // The recorded state follows what actually happened, not what was requested.
-        manager.setAudioProcessingEnabled(false)
-        verify { factory.setAudioProcessingEnabled(false) }
+        // Expressed as a set, so a toggle before joining can never build a factory.
+        verify { factory.setAudioProcessingEnabled(true) }
+        verify(exactly = 0) { factory.toggleAudioProcessing() }
     }
 
     @Test

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
@@ -36,7 +36,9 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
 import org.junit.Test
+import org.webrtc.ManagedAudioProcessingFactory
 import org.webrtc.audio.JavaAudioDeviceModule.AudioSamples
+import stream.video.sfu.models.AudioBitrateProfile
 
 /**
  * Unit tests for [CallMediaManager], which owns the media pipeline: the peer-connection
@@ -248,5 +250,25 @@ class CallMediaManagerTest {
         advanceUntilIdle()
 
         verify { mediaManager.microphone.select(wired) }
+    }
+
+    @Test
+    fun `a factory built later applies the state the call already asked for`() {
+        val processor = mockk<ManagedAudioProcessingFactory>(relaxed = true)
+        every { clientImpl.audioProcessing } returns processor
+        every { mediaManager.microphone.audioBitrateProfile } returns MutableStateFlow(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_STANDARD_UNSPECIFIED,
+        )
+        val manager = manager()
+
+        // Recorded while no factory exists, so nothing is applied yet.
+        manager.setAudioProcessingEnabled(true)
+        verify(exactly = 0) { processor.isEnabled = any() }
+
+        // Building the factory is what applies it — that is how a call keeps its own state
+        // without the setter having to create one.
+        manager.peerConnectionFactory
+
+        verify { processor.isEnabled = true }
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
@@ -157,6 +157,28 @@ class CallMediaManagerTest {
     }
 
     @Test
+    fun `cleanup clears the shared audio processor so it cannot leak into the next call`() {
+        val factory = mockk<StreamPeerConnectionFactory>(relaxed = true)
+        val manager = manager()
+        manager.peerConnectionFactory = factory
+
+        manager.cleanup()
+
+        verify { factory.resetAudioProcessing() }
+        verify { mediaManager.cleanup() }
+    }
+
+    @Test
+    fun `cleanup does not build a factory when the call never used one`() {
+        val manager = manager()
+
+        // Reads the backing field, so no lazy factory is created just to be reset.
+        manager.cleanup()
+
+        verify { mediaManager.cleanup() }
+    }
+
+    @Test
     fun `localMicrophoneAudioLevel is exposed`() {
         assertThat(manager().localMicrophoneAudioLevel.value).isEqualTo(0f)
     }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
@@ -157,25 +157,54 @@ class CallMediaManagerTest {
     }
 
     @Test
-    fun `cleanup clears the shared audio processor so it cannot leak into the next call`() {
+    fun `recreating the factory releases one that does not hold the shared audio processor`() {
         val factory = mockk<StreamPeerConnectionFactory>(relaxed = true)
+        every { factory.hasAudioProcessingAttached() } returns false
         val manager = manager()
         manager.peerConnectionFactory = factory
 
-        manager.cleanup()
+        manager.recreatePeerConnectionFactory()
 
-        verify { factory.resetAudioProcessing() }
-        verify { mediaManager.cleanup() }
+        verify { factory.dispose() }
     }
 
     @Test
-    fun `cleanup does not build a factory when the call never used one`() {
+    fun `recreating the factory keeps one that holds the shared audio processor`() {
+        val factory = mockk<StreamPeerConnectionFactory>(relaxed = true)
+        every { factory.hasAudioProcessingAttached() } returns true
+        val manager = manager()
+        manager.peerConnectionFactory = factory
+
+        manager.recreatePeerConnectionFactory()
+
+        // Releasing it would tear the processor down for every later call, so it is dropped
+        // rather than disposed — the same way a factory is dropped when a call ends.
+        verify(exactly = 0) { factory.dispose() }
+    }
+
+    @Test
+    fun `setting audio processing does not build a factory for a call that has none`() {
         val manager = manager()
 
-        // Reads the backing field, so no lazy factory is created just to be reset.
-        manager.cleanup()
+        // Recorded for whichever factory is built later; building one here would capture the
+        // pre-join audio bitrate profile. Nothing to verify beyond it not creating or throwing.
+        manager.setAudioProcessingEnabled(true)
 
-        verify { mediaManager.cleanup() }
+        manager.recreatePeerConnectionFactory()
+    }
+
+    @Test
+    fun `toggling audio processing records the resulting state`() {
+        val factory = mockk<StreamPeerConnectionFactory>(relaxed = true)
+        every { factory.toggleAudioProcessing() } returns true
+        val manager = manager()
+        manager.peerConnectionFactory = factory
+
+        assertThat(manager.toggleAudioProcessing()).isTrue()
+
+        // The recorded state follows what actually happened, not what was requested.
+        manager.setAudioProcessingEnabled(false)
+        verify { factory.setAudioProcessingEnabled(false) }
     }
 
     @Test

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactoryTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactoryTest.kt
@@ -41,6 +41,7 @@ import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnection
 import org.webrtc.PeerConnection.Observer
 import org.webrtc.PeerConnectionFactory
+import stream.video.sfu.models.AudioBitrateProfile
 import stream.video.sfu.models.PublishOption
 
 class StreamPeerConnectionFactoryTest {
@@ -242,5 +243,72 @@ class StreamPeerConnectionFactoryTest {
         val first = factory.toggleAudioProcessing()
         assertTrue("Should now be enabled", first)
         verify { mockAudioProc.isEnabled = true }
+    }
+
+    // 10) Audio processing is only reported / mutated when the processor is actually attached
+
+    private fun factoryWithProfile(
+        profile: AudioBitrateProfile,
+        audioProcessing: ManagedAudioProcessingFactory?,
+    ): StreamPeerConnectionFactory = StreamPeerConnectionFactory(
+        context = mockContext,
+        audioProcessing = audioProcessing,
+        audioBitrateProfileProvider = { profile },
+        sharedEglBaseProvider = { mockk(relaxed = true) },
+    )
+
+    @Test
+    fun `isAudioProcessingEnabled is false under MUSIC_HIGH_QUALITY even when the module is on`() {
+        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
+        every { mockAudioProc.isEnabled } returns true
+
+        val musicFactory = factoryWithProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_MUSIC_HIGH_QUALITY,
+            mockAudioProc,
+        )
+
+        assertFalse(
+            "Processor is never attached under MUSIC_HIGH_QUALITY, so nothing is processing",
+            musicFactory.isAudioProcessingEnabled(),
+        )
+    }
+
+    @Test
+    fun `setAudioProcessingEnabled leaves the shared module alone under MUSIC_HIGH_QUALITY`() {
+        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
+        val musicFactory = factoryWithProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_MUSIC_HIGH_QUALITY,
+            mockAudioProc,
+        )
+
+        musicFactory.setAudioProcessingEnabled(true)
+
+        verify(exactly = 0) { mockAudioProc.isEnabled = any() }
+    }
+
+    @Test
+    fun `toggleAudioProcessing is a no-op under MUSIC_HIGH_QUALITY`() {
+        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
+        val musicFactory = factoryWithProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_MUSIC_HIGH_QUALITY,
+            mockAudioProc,
+        )
+
+        assertFalse("Nothing to toggle when unattached", musicFactory.toggleAudioProcessing())
+        verify(exactly = 0) { mockAudioProc.isEnabled = any() }
+    }
+
+    @Test
+    fun `resetAudioProcessing clears the shared module so it cannot leak into the next call`() {
+        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
+        every { mockAudioProc.isEnabled } returns true
+
+        val callFactory = factoryWithProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_STANDARD_UNSPECIFIED,
+            mockAudioProc,
+        )
+        callFactory.resetAudioProcessing()
+
+        verify { mockAudioProc.isEnabled = false }
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactoryTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactoryTest.kt
@@ -298,17 +298,37 @@ class StreamPeerConnectionFactoryTest {
         verify(exactly = 0) { mockAudioProc.isEnabled = any() }
     }
 
-    @Test
-    fun `resetAudioProcessing clears the shared module so it cannot leak into the next call`() {
-        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
-        every { mockAudioProc.isEnabled } returns true
+    // 11) The shared processor is only considered held once a native factory really owns it
 
+    @Test
+    fun `hasAudioProcessingAttached is false until a native factory has been built`() {
+        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
         val callFactory = factoryWithProfile(
             AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_STANDARD_UNSPECIFIED,
             mockAudioProc,
         )
-        callFactory.resetAudioProcessing()
 
-        verify { mockAudioProc.isEnabled = false }
+        // The profile says the processor *would* be attached, but nothing has been built yet, so
+        // releasing this factory could not take the shared processor down with it.
+        assertFalse(
+            "Nothing owns the processor before the native factory exists",
+            callFactory.hasAudioProcessingAttached(),
+        )
+    }
+
+    @Test
+    fun `dispose leaves the shared module alone when no native factory was built`() {
+        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
+        val callFactory = factoryWithProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_STANDARD_UNSPECIFIED,
+            mockAudioProc,
+        )
+
+        // Must not build a factory just to release it: doing so would attach the shared
+        // processor and then tear it down for every later call.
+        callFactory.dispose()
+
+        verify(exactly = 0) { mockAudioProc.createNative(any()) }
+        verify(exactly = 0) { mockAudioProc.isEnabled = any() }
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactoryTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/connection/StreamPeerConnectionFactoryTest.kt
@@ -331,4 +331,39 @@ class StreamPeerConnectionFactoryTest {
         verify(exactly = 0) { mockAudioProc.createNative(any()) }
         verify(exactly = 0) { mockAudioProc.isEnabled = any() }
     }
+
+    @Test
+    fun `once the factory is built the attached flag decides what is reported`() {
+        val mockAudioProc = mockk<ManagedAudioProcessingFactory>(relaxed = true)
+        every { mockAudioProc.isEnabled } returns true
+        val callFactory = factoryWithProfile(
+            AudioBitrateProfile.AUDIO_BITRATE_PROFILE_VOICE_STANDARD_UNSPECIFIED,
+            mockAudioProc,
+        )
+
+        // Before the factory is built the profile is the only evidence available. Once it is
+        // built, what it was actually wired with is what counts — the profile can have changed
+        // since, and a rebuilt factory may have left the processor off.
+        setPrivate(callFactory, "factoryCreated", true)
+        setPrivate(callFactory, "audioProcessingAttached", false)
+        assertFalse(
+            "Nothing attached, so nothing is processing",
+            callFactory.isAudioProcessingEnabled(),
+        )
+        assertFalse("Nothing to lose by releasing it", callFactory.hasAudioProcessingAttached())
+
+        setPrivate(callFactory, "audioProcessingAttached", true)
+        assertTrue("Attached and enabled", callFactory.isAudioProcessingEnabled())
+        assertTrue(
+            "Releasing it would take the shared processor down",
+            callFactory.hasAudioProcessingAttached(),
+        )
+    }
+
+    private fun setPrivate(target: StreamPeerConnectionFactory, name: String, value: Any) {
+        StreamPeerConnectionFactory::class.java.getDeclaredField(name).apply {
+            isAccessible = true
+            set(target, value)
+        }
+    }
 }


### PR DESCRIPTION
Stacked on #1770. Merge after parent.

### Goal

Fixes [AND-1400](https://linear.app/stream/issue/AND-1400/noise-cancellation-state-leaks-across-calls-and)

The audio processor is owned by the client and shared by every call. Two defects followed from that:

- **Misreport.** Under the `MUSIC_HIGH_QUALITY` audio bitrate profile the processor is deliberately never attached to the native factory, but `isAudioProcessingEnabled()` still read the shared module's own `isEnabled` flag — so it returned `true` while nothing was processing, and UI bound to it highlighted an inactive feature.
- **Cross-call leak.** The flag was never cleared on leave, so enabling noise cancellation in one call silently enabled it in the next, regardless of that call's type or settings.

JS scopes this per-call in `MicrophoneManager`; Swift per-call via `setAudioFilter`.

Second of a three-part stack. AND-1401 follows.

### Implementation

- `StreamPeerConnectionFactory` tracks whether `audioProcessing` was actually wired into the native factory. `isAudioProcessingEnabled()` reports that; `setAudioProcessingEnabled` / `toggleAudioProcessing` no-op rather than mutating a module this call cannot use.
- Before the factory is built the attachment check falls back to what it *will* be built with, so the pre-join lobby path (`setAudioProcessingEnabled(isAutoOn)`) keeps working.
- `resetAudioProcessing()` clears the shared flag; `CallMediaManager.cleanup()` calls it on leave, reading the backing field so cleanup never lazily builds a factory just to reset one.
- No public API change — `apiCheck` passes with the API dump unchanged.

### 🎨 UI Changes

None in the SDK. Fixes stale highlighting in UI that binds to `isAudioProcessingEnabled()` — the demo app's settings-menu item is one such consumer.

### Testing

```
./gradlew :stream-video-android-core:testDebugUnitTest   # 1000 tests, 0 failures, 50 pre-existing skips
./gradlew :stream-video-android-core:apiCheck            # passes, api dump unchanged
./gradlew :stream-video-android-core:spotlessApply
```

New coverage — `StreamPeerConnectionFactoryTest` +4, `CallMediaManagerTest` +2:

- Getter returns false under `MUSIC_HIGH_QUALITY` even with the module flagged on; setter and toggle leave the shared module untouched there.
- `resetAudioProcessing` clears the shared module.
- `cleanup()` resets it, and does not build a factory when the call never used one.

The three guard tests were verified red with the fix reverted, so they aren't vacuous.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-processing state reporting for calls where processing is unavailable.
  * Prevented noise-cancellation settings from leaking between calls.
  * Ensured call cleanup resets audio processing without creating unnecessary call resources.
  * Disabled audio processing for high-quality music calls, preventing unsupported state changes or reporting.

* **Documentation**
  * Updated the Android SDK changelog with the latest audio-processing and call behavior fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->