### PR TITLE
Enforce the noise-cancellation capability and call settings in core

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/CallScreen.kt
@@ -699,9 +699,10 @@ fun CallScreen(
         }
 
         if (isShowingSettingMenu) {
-            var isNoiseCancellationEnabled by remember {
-                mutableStateOf(call.isAudioProcessingEnabled())
-            }
+            // Collected, not snapshotted: the SDK withdraws noise cancellation on its own when
+            // the capability or the call type's mode changes mid-call.
+            val isNoiseCancellationEnabled by call.state.audioProcessingEnabled
+                .collectAsStateWithLifecycle()
             val settings by call.state.settings.collectAsStateWithLifecycle()
             val noiseCancellationFeatureEnabled =
                 settings?.audio?.noiseCancellation?.isEnabled == true
@@ -735,7 +736,7 @@ fun CallScreen(
                     isShowingFeedbackDialog = true
                 },
                 onNoiseCancellation = {
-                    isNoiseCancellationEnabled = call.toggleAudioProcessing()
+                    call.toggleAudioProcessing()
                 },
                 selectedIncomingVideoResolution = selectedIncomingVideoResolution,
                 onSelectIncomingVideoResolution = {

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyViewModel.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyViewModel.kt
@@ -26,7 +26,6 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.DeviceStatus
 import io.getstream.video.android.core.StreamVideo
-import io.getstream.video.android.core.utils.isAutoOn
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.User
@@ -142,9 +141,6 @@ class CallLobbyViewModel @Inject constructor(
 
             // enable/disable camera capture (no preview would be visible otherwise)
             call.camera.setEnabled(isCameraEnabled)
-
-            val isNoiseCancellationEnabled = settings?.audio?.noiseCancellation?.isAutoOn ?: false
-            call.setAudioProcessingEnabled(isNoiseCancellationEnabled)
         }
     }
 

--- a/stream-video-android-core/api/stream-video-android-core.api
+++ b/stream-video-android-core/api/stream-video-android-core.api
@@ -9001,6 +9001,7 @@ public final class io/getstream/video/android/core/CallState {
 	public final fun clearParticipants ()V
 	public final fun getAcceptedBy ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getActiveSpeakers ()Lkotlinx/coroutines/flow/StateFlow;
+	public final fun getAudioProcessingEnabled ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getBackstage ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getBlockedUserIds ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getBlockedUsers ()Lkotlinx/coroutines/flow/StateFlow;

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -68,6 +68,7 @@ import io.getstream.video.android.core.call.components.CallSessionManager
 import io.getstream.video.android.core.call.components.CallStatsReporter
 import io.getstream.video.android.core.call.components.ClientCallRegistry
 import io.getstream.video.android.core.call.components.MediaManagerFactory
+import io.getstream.video.android.core.call.components.NoiseCancellationPolicy
 import io.getstream.video.android.core.call.components.RtcSessionFactory
 import io.getstream.video.android.core.call.components.SessionMonitor
 import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
@@ -97,6 +98,8 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.threeten.bp.OffsetDateTime
@@ -499,12 +502,18 @@ public class Call(
     @Volatile
     private var noiseCancellationSignalPending: Boolean = false
 
+    private val noiseCancellationPolicy = NoiseCancellationPolicy()
+
+    /** Guards the call type's auto-on default so it is applied at most once per call. */
+    private var autoOnApplied: Boolean = false
+
     init {
         media.startAudioLevelMonitoring()
         powerManager = safeCallWithDefault(null) {
             clientImpl.context.getSystemService(POWER_SERVICE) as? PowerManager
         }
         observeNoiseCancellationSignalTarget()
+        observeNoiseCancellationPolicy()
     }
 
     /** Basic crud operations */
@@ -907,16 +916,38 @@ public class Call(
      * cannot differ between two calls running at the same time.
      */
     fun setAudioProcessingEnabled(enabled: Boolean) {
+        if (enabled && !isNoiseCancellationAllowed()) {
+            logger.w {
+                "[setAudioProcessingEnabled] #sfu; rejected, noise cancellation is not " +
+                    "available for this call"
+            }
+            return
+        }
         media.setAudioProcessingEnabled(enabled)
-        // Signals what was actually applied, not what was asked for: with no audio processor
-        // configured the request is a no-op locally, and the SFU must not be told otherwise.
+        // Publishes and signals what was actually applied, not what was asked for: with no audio
+        // processor configured the request is a no-op locally, and neither the state flow nor the
+        // SFU must be told otherwise.
+        publishAudioProcessingState()
         notifyNoiseCancellationState(media.isAudioProcessingEnabledIfCreated())
     }
 
-    fun toggleAudioProcessing(): Boolean = media.toggleAudioProcessing().also {
-        // Signals what is running, not what the toggle now reports: before a factory exists the
-        // toggle reflects the wanted state, and the SFU must only hear about real processing.
-        notifyNoiseCancellationState(media.isAudioProcessingEnabledIfCreated())
+    fun toggleAudioProcessing(): Boolean {
+        // Reads without building a factory: the gate runs before join, and a factory created
+        // there would capture the pre-join audio bitrate profile.
+        if (!media.isAudioProcessingEnabled() && !isNoiseCancellationAllowed()) {
+            logger.w {
+                "[toggleAudioProcessing] #sfu; rejected, noise cancellation is not " +
+                    "available for this call"
+            }
+            return false
+        }
+        return media.toggleAudioProcessing().also {
+            publishAudioProcessingState()
+            // Signals what is running, not what the toggle now reports: before a factory exists
+            // the toggle reflects the wanted state, and the SFU must only hear real processing.
+            notifyNoiseCancellationState(media.isAudioProcessingEnabledIfCreated())
+        }
+    }
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -948,6 +948,64 @@ public class Call(
             notifyNoiseCancellationState(media.isAudioProcessingEnabledIfCreated())
         }
     }
+
+    /**
+     * Whether the server permits noise cancellation for this call, per the capability granted to
+     * the user and the call type's noise-cancellation mode.
+     */
+    private fun isNoiseCancellationAllowed(): Boolean = noiseCancellationPolicy.isAllowed(
+        capabilities = state.ownCapabilities.value,
+        settings = state.settings.value,
+    )
+
+    /**
+     * Publishes the state observers should see: what the call asked for while no factory exists,
+     * and what is actually processing once one does. Never builds a factory.
+     */
+    private fun publishAudioProcessingState() {
+        state.setAudioProcessingEnabled(media.isAudioProcessingEnabled())
+    }
+
+    /**
+     * Keeps noise cancellation inside what the server allows.
+     *
+     * Deliberately waits for settings to resolve before deciding anything: treating "not told
+     * yet" as "not allowed" would switch noise cancellation off and back on during join. Once
+     * resolved this applies the call type's auto-on default, and withdraws noise cancellation if
+     * the capability or the mode is taken away mid-call.
+     */
+    private fun observeNoiseCancellationPolicy() {
+        scope.launch {
+            state.settings
+                .filterNotNull()
+                .combine(
+                    state.ownCapabilities,
+                ) { settings, capabilities -> settings to capabilities }
+                .collect { (settings, capabilities) ->
+                    if (!noiseCancellationPolicy.isAllowed(capabilities, settings)) {
+                        // Withdraws unconditionally rather than only when something is already
+                        // processing: a state wanted before the factory existed is remembered and
+                        // would otherwise be applied the moment one is built, after the server
+                        // had withheld it.
+                        val wasProcessing = media.isAudioProcessingEnabledIfCreated()
+                        if (wasProcessing || media.isAudioProcessingWanted()) {
+                            logger.i {
+                                "[noiseCancellation] withdrawing, no longer allowed for this call"
+                            }
+                            media.setAudioProcessingEnabled(false)
+                            publishAudioProcessingState()
+                            notifyNoiseCancellationState(false)
+                        }
+                        return@collect
+                    }
+                    if (!autoOnApplied) {
+                        autoOnApplied = true
+                        if (noiseCancellationPolicy.isAutoOn(capabilities, settings)) {
+                            setAudioProcessingEnabled(true)
+                        }
+                    }
+                }
+        }
     }
 
     /**
@@ -1009,6 +1067,7 @@ public class Call(
                 // while joining and after the signal that found no session.
                 val applied = media.isAudioProcessingEnabledIfCreated()
                 if (noiseCancellationSignalPending || desiredNoiseCancellationEnabled || applied) {
+                    publishAudioProcessingState()
                     notifyNoiseCancellationState(applied)
                 }
             }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -534,6 +534,22 @@ public class CallState(
     private val _settings: MutableStateFlow<CallSettingsResponse?> = MutableStateFlow(null)
     public val settings: StateFlow<CallSettingsResponse?> = _settings
 
+    private val _audioProcessingEnabled: MutableStateFlow<Boolean> = MutableStateFlow(false)
+
+    /**
+     * Whether local audio processing (noise cancellation) is currently running for this call.
+     *
+     * The SDK changes this on its own, not only in response to the app: the call type's
+     * noise-cancellation mode and the user's `enable-noise-cancellation` capability can both
+     * withdraw it mid-call. Observe this instead of snapshotting
+     * [Call.isAudioProcessingEnabled], or UI bound to it will go stale.
+     */
+    public val audioProcessingEnabled: StateFlow<Boolean> = _audioProcessingEnabled
+
+    internal fun setAudioProcessingEnabled(enabled: Boolean) {
+        _audioProcessingEnabled.value = enabled
+    }
+
     private val _durationInMs = flow {
         while (currentCoroutineContext().isActive) {
             delay(1000)

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
@@ -314,6 +314,19 @@ internal class CallMediaManager(
         _peerConnectionFactory?.isAudioProcessingEnabled() ?: false
 
     /**
+     * Whether this call wants audio processing, whether or not a factory exists to run it yet.
+     *
+     * The wanted state outlives the factory, so a policy that withholds noise cancellation has to
+     * clear it — otherwise the next factory applies it after the server said no.
+     */
+    fun isAudioProcessingWanted(): Boolean = desiredAudioProcessingEnabled
+
+    /** Forgets the wanted audio-processing state, so nothing is re-applied after the call ends. */
+    fun resetDesiredAudioProcessing() {
+        desiredAudioProcessingEnabled = false
+    }
+
+    /**
      * Records the wanted audio-processing state and applies it to the factory if one exists.
      * A factory built later picks the value up on creation, so this never has to build one.
      */
@@ -343,6 +356,9 @@ internal class CallMediaManager(
     }
 
     fun cleanup() {
+        // The wanted state must not outlive the call: a reused Call would otherwise re-apply it
+        // to the factory built for the next session.
+        resetDesiredAudioProcessing()
         mediaManager.cleanup()
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
@@ -76,7 +76,9 @@ internal class CallMediaManager(
 
     /**
      * Audio-processing state this call wants, remembered separately from the factory so it
-     * survives one not existing yet or being recreated.
+     * survives one not existing yet or being recreated. Applying it must never itself build a
+     * factory: one created before join captures the pre-join audio bitrate profile and defeats
+     * [ensureFactoryMatchesAudioProfile].
      *
      * The processor itself is owned by the client and shared by every call, and its enabled flag
      * lives on that one instance. Rather than clearing the flag when a call ends — which reaches
@@ -303,18 +305,17 @@ internal class CallMediaManager(
      * Audio-processing state as far as it is known, without forcing the peer-connection factory
      * to be built. False before the factory exists — nothing can be processing yet.
      *
-     * Used where the state is reported rather than changed, which must never bring a factory into
-     * existence: one created before join would be built with the pre-join audio bitrate profile
-     * and defeat [ensureFactoryMatchesAudioProfile].
+     * Used where the state is reported rather than changed — state publishing, the policy gate
+     * and signalling — which must never bring a factory into existence: one created before join
+     * would be built with the pre-join audio bitrate profile and defeat
+     * [ensureFactoryMatchesAudioProfile].
      */
     fun isAudioProcessingEnabledIfCreated(): Boolean =
         _peerConnectionFactory?.isAudioProcessingEnabled() ?: false
 
     /**
      * Records the wanted audio-processing state and applies it to the factory if one exists.
-     * A factory built later picks the value up on creation, so this never has to build one:
-     * a factory created before join captures the pre-join audio bitrate profile and defeats
-     * [ensureFactoryMatchesAudioProfile].
+     * A factory built later picks the value up on creation, so this never has to build one.
      */
     fun setAudioProcessingEnabled(enabled: Boolean) {
         desiredAudioProcessingEnabled = enabled

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/NoiseCancellationPolicy.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/NoiseCancellationPolicy.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.components
+
+import io.getstream.android.video.generated.models.CallSettingsResponse
+import io.getstream.android.video.generated.models.OwnCapability
+import io.getstream.video.android.core.utils.isAutoOn
+import io.getstream.video.android.core.utils.isEnabled
+
+/**
+ * Decides whether local noise cancellation may run for a call.
+ *
+ * Two server-driven things gate it: the `enable-noise-cancellation` capability granted to the
+ * user, and the noise-cancellation mode configured on the call type.
+ *
+ * Decision only — applying it belongs to [io.getstream.video.android.core.Call].
+ */
+internal class NoiseCancellationPolicy {
+
+    /**
+     * True when noise cancellation may be enabled for this call.
+     *
+     * A null [settings] means the server has not told us yet. Callers must treat that as "not
+     * decided" and wait, rather than as a refusal — deciding before settings resolve would switch
+     * noise cancellation off and straight back on during join.
+     */
+    fun isAllowed(
+        capabilities: List<OwnCapability>,
+        settings: CallSettingsResponse?,
+    ): Boolean {
+        val noiseCancellation = settings?.audio?.noiseCancellation ?: return false
+        if (!noiseCancellation.isEnabled) return false
+        return capabilities.contains(OwnCapability.EnableNoiseCancellation)
+    }
+
+    /**
+     * True when the call type asks for noise cancellation to start on, and it is allowed to.
+     */
+    fun isAutoOn(
+        capabilities: List<OwnCapability>,
+        settings: CallSettingsResponse?,
+    ): Boolean {
+        val noiseCancellation = settings?.audio?.noiseCancellation ?: return false
+        return noiseCancellation.isAutoOn && isAllowed(capabilities, settings)
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallTestSeams.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallTestSeams.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.video.android.core
 
+import io.getstream.android.video.generated.models.CallSettingsResponse
+import io.getstream.android.video.generated.models.NoiseCancellationSettings
+import io.getstream.android.video.generated.models.OwnCapability
 import io.getstream.video.android.core.call.RtcSession
 import io.getstream.video.android.core.call.components.CallMediaManager
 import io.getstream.video.android.core.call.components.CallSessionManager
@@ -24,6 +27,7 @@ import io.getstream.video.android.core.internal.module.CoordinatorConnectionModu
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
  * Seeds an active [RtcSession] on a real [Call], for tests that start from an already-joined
@@ -125,3 +129,31 @@ internal fun Call.mediaAppliesWantedState() {
     field.isAccessible = true
     media.peerConnectionFactory.setAudioProcessingEnabled(field.get(media) as Boolean)
 }
+
+/**
+ * Seeds the server-driven capability list and call settings a real [CallState] would receive from
+ * the coordinator, for tests that exercise policy gates (noise cancellation, permissions).
+ *
+ * Reflective on purpose: in production both are written only by coordinator responses and events,
+ * and that write path should not grow setters that exist solely for tests.
+ */
+internal fun CallState.injectServerState(
+    capabilities: List<OwnCapability>? = null,
+    settings: CallSettingsResponse? = null,
+) {
+    capabilities?.let { mutableStateField<List<OwnCapability>>("_ownCapabilities").value = it }
+    settings?.let { mutableStateField<CallSettingsResponse?>("_settings").value = it }
+}
+
+/** Builds the minimum settings object the noise-cancellation policy reads. */
+internal fun noiseCancellationSettings(
+    mode: NoiseCancellationSettings.Mode,
+): CallSettingsResponse = mockk(relaxed = true) {
+    every { audio.noiseCancellation } returns NoiseCancellationSettings(mode)
+}
+
+@Suppress("UNCHECKED_CAST")
+private fun <T> CallState.mutableStateField(name: String): MutableStateFlow<T> =
+    CallState::class.java.getDeclaredField(name).apply {
+        isAccessible = true
+    }.get(this) as MutableStateFlow<T>

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallTestSeams.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallTestSeams.kt
@@ -157,3 +157,13 @@ private fun <T> CallState.mutableStateField(name: String): MutableStateFlow<T> =
     CallState::class.java.getDeclaredField(name).apply {
         isAccessible = true
     }.get(this) as MutableStateFlow<T>
+
+/** Whether a peer-connection factory has been built for this call yet. */
+internal fun Call.hasPeerConnectionFactory(): Boolean {
+    val field = CallMediaManager::class.java.getDeclaredField("_peerConnectionFactory")
+    field.isAccessible = true
+    return field.get(mediaComponent()) != null
+}
+
+/** Whether this call still wants audio processing, independently of any factory existing. */
+internal fun Call.isAudioProcessingWanted(): Boolean = mediaComponent().isAudioProcessingWanted()

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationPolicyGateTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationPolicyGateTest.kt
@@ -22,11 +22,14 @@ import io.getstream.video.android.core.base.IntegrationTestBase
 import io.getstream.video.android.core.call.RtcSession
 import io.mockk.coVerify
 import io.mockk.mockk
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 /**
  * Covers the core-level gate: noise cancellation may only be turned on when the server both
@@ -100,5 +103,39 @@ class NoiseCancellationPolicyGateTest : IntegrationTestBase(connectCoordinatorWS
         call.setAudioProcessingEnabled(false)
 
         coVerify(timeout = TIMEOUT_MS) { session.stopNoiseCancellation() }
+    }
+
+    @Test
+    fun `withdrawal clears a state wanted before any factory existed`() = runTest {
+        val (call, _) = call(
+            listOf(OwnCapability.EnableNoiseCancellation),
+            NoiseCancellationSettings.Mode.Available,
+        )
+
+        // Wanted while no factory exists, so nothing is processing yet and a withdrawal that only
+        // looks at what is running would find nothing to do.
+        call.setAudioProcessingEnabled(true)
+        assertTrue(call.isAudioProcessingWanted())
+
+        // The server then withholds it. The wanted state has to go, or the next factory applies
+        // it after the server said no.
+        call.state.injectServerState(capabilities = emptyList())
+
+        withTimeout(TIMEOUT_MS) {
+            while (call.isAudioProcessingWanted()) {
+                delay(10)
+            }
+        }
+        assertFalse(call.isAudioProcessingWanted())
+    }
+
+    @Test
+    fun `the toggle gate does not build a peer-connection factory`() = runTest {
+        val (call, _) = call(emptyList(), NoiseCancellationSettings.Mode.Available)
+
+        // Refused by the gate, and must not have created a factory on the way: one built before
+        // join captures the pre-join audio bitrate profile.
+        assertFalse(call.toggleAudioProcessing())
+        assertFalse(call.hasPeerConnectionFactory())
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationPolicyGateTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationPolicyGateTest.kt
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core
+
+import io.getstream.android.video.generated.models.NoiseCancellationSettings
+import io.getstream.android.video.generated.models.OwnCapability
+import io.getstream.video.android.core.base.IntegrationTestBase
+import io.getstream.video.android.core.call.RtcSession
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertFalse
+
+/**
+ * Covers the core-level gate: noise cancellation may only be turned on when the server both
+ * grants the capability and leaves it enabled on the call type.
+ */
+@RunWith(RobolectricTestRunner::class)
+class NoiseCancellationPolicyGateTest : IntegrationTestBase(connectCoordinatorWS = false) {
+
+    private companion object {
+        const val TIMEOUT_MS = 2_000L
+    }
+
+    private fun call(
+        capabilities: List<OwnCapability>,
+        mode: NoiseCancellationSettings.Mode?,
+    ): Pair<Call, RtcSession> {
+        val call = client.call("default", randomUUID())
+        call.state.injectServerState(
+            capabilities = capabilities,
+            settings = mode?.let { noiseCancellationSettings(it) },
+        )
+        val session = mockk<RtcSession>(relaxed = true)
+        call.injectSession(session)
+        return call to session
+    }
+
+    @Test
+    fun `enabling is refused without the capability`() = runTest {
+        val (call, session) = call(emptyList(), NoiseCancellationSettings.Mode.Available)
+
+        call.setAudioProcessingEnabled(true)
+
+        assertFalse(call.isAudioProcessingEnabled())
+        coVerify(exactly = 0) { session.startNoiseCancellation() }
+    }
+
+    @Test
+    fun `enabling is refused when the call type disables noise cancellation`() = runTest {
+        val (call, session) = call(
+            listOf(OwnCapability.EnableNoiseCancellation),
+            NoiseCancellationSettings.Mode.Disabled,
+        )
+
+        call.setAudioProcessingEnabled(true)
+
+        assertFalse(call.isAudioProcessingEnabled())
+        coVerify(exactly = 0) { session.startNoiseCancellation() }
+    }
+
+    @Test
+    fun `enabling is refused before settings resolve`() = runTest {
+        val (call, session) = call(listOf(OwnCapability.EnableNoiseCancellation), mode = null)
+
+        call.setAudioProcessingEnabled(true)
+
+        coVerify(exactly = 0) { session.startNoiseCancellation() }
+    }
+
+    @Test
+    fun `toggling on is refused when not allowed`() = runTest {
+        val (call, session) = call(emptyList(), NoiseCancellationSettings.Mode.Available)
+
+        assertFalse(call.toggleAudioProcessing())
+        coVerify(exactly = 0) { session.startNoiseCancellation() }
+    }
+
+    @Test
+    fun `disabling is always permitted so a withdrawal can never be blocked`() = runTest {
+        val (call, session) = call(emptyList(), NoiseCancellationSettings.Mode.Disabled)
+
+        call.setAudioProcessingEnabled(false)
+
+        coVerify(timeout = TIMEOUT_MS) { session.stopNoiseCancellation() }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
@@ -16,6 +16,8 @@
 
 package io.getstream.video.android.core
 
+import io.getstream.android.video.generated.models.NoiseCancellationSettings
+import io.getstream.android.video.generated.models.OwnCapability
 import io.getstream.result.Result
 import io.getstream.video.android.core.base.IntegrationTestBase
 import io.getstream.video.android.core.call.RtcSession
@@ -55,9 +57,22 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
         injectPeerConnectionFactory(factory)
     }
 
-    /** A joined call whose audio processing can genuinely be turned on. */
+    /**
+     * Seeds the server state noise cancellation needs: capability granted and the call type's mode
+     * set to available. Without both the policy gate refuses and nothing is signalled — see
+     * [NoiseCancellationPolicyGateTest].
+     */
+    private fun Call.allowNoiseCancellation() {
+        state.injectServerState(
+            capabilities = listOf(OwnCapability.EnableNoiseCancellation),
+            settings = noiseCancellationSettings(NoiseCancellationSettings.Mode.Available),
+        )
+    }
+
+    /** A joined, allowed call whose audio processing can genuinely be turned on. */
     private fun callWithProcessor(): Pair<Call, RtcSession> {
         val call = client.call("default", randomUUID())
+        call.allowNoiseCancellation()
         call.injectWorkingProcessor()
         val session = mockk<RtcSession>(relaxed = true)
         call.injectSession(session)
@@ -99,6 +114,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
     @Test
     fun `nothing is signalled as started when no processor is running`() = runTest {
         val call = client.call("default", randomUUID())
+        call.allowNoiseCancellation()
         val session = mockk<RtcSession>(relaxed = true)
         call.injectSession(session)
 
@@ -113,6 +129,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
     @Test
     fun `toggle reports the wanted state but signals what is running`() = runTest {
         val call = client.call("default", randomUUID())
+        call.allowNoiseCancellation()
         val session = mockk<RtcSession>(relaxed = true)
         call.injectSession(session)
 
@@ -129,6 +146,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
     @Test
     fun `state changed before a session exists is signalled once one is installed`() = runTest {
         val call = client.call("default", randomUUID())
+        call.allowNoiseCancellation()
         call.injectWorkingProcessor()
 
         // The call type's auto-on default and any pre-join change land while joining is still in

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
@@ -196,6 +196,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
     @Test
     fun `a state applied only once the factory exists is signalled on join`() = runTest {
         val call = client.call("default", randomUUID())
+        call.allowNoiseCancellation()
 
         // Wanted before any factory exists, so nothing is applied yet and the signal finds no
         // session to send at.

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/NoiseCancellationPolicyTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/NoiseCancellationPolicyTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.components
+
+import io.getstream.android.video.generated.models.CallSettingsResponse
+import io.getstream.android.video.generated.models.NoiseCancellationSettings
+import io.getstream.android.video.generated.models.OwnCapability
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NoiseCancellationPolicyTest {
+
+    private val policy = NoiseCancellationPolicy()
+    private val granted = listOf(OwnCapability.EnableNoiseCancellation)
+
+    private fun settings(mode: NoiseCancellationSettings.Mode): CallSettingsResponse =
+        mockk(relaxed = true) {
+            every { audio.noiseCancellation } returns NoiseCancellationSettings(mode)
+        }
+
+    private fun settingsWithoutNoiseCancellation(): CallSettingsResponse = mockk(relaxed = true) {
+        every { audio.noiseCancellation } returns null
+    }
+
+    @Test
+    fun `allowed when the capability is granted and the mode is available`() {
+        assertTrue(
+            policy.isAllowed(granted, settings(NoiseCancellationSettings.Mode.Available)),
+        )
+    }
+
+    @Test
+    fun `allowed when the capability is granted and the mode is auto-on`() {
+        assertTrue(policy.isAllowed(granted, settings(NoiseCancellationSettings.Mode.AutoOn)))
+    }
+
+    @Test
+    fun `not allowed without the capability, whatever the mode says`() {
+        assertFalse(
+            policy.isAllowed(emptyList(), settings(NoiseCancellationSettings.Mode.AutoOn)),
+        )
+    }
+
+    @Test
+    fun `not allowed when the call type disables it, even with the capability`() {
+        assertFalse(
+            policy.isAllowed(granted, settings(NoiseCancellationSettings.Mode.Disabled)),
+        )
+    }
+
+    @Test
+    fun `not allowed for an unrecognised mode`() {
+        assertFalse(
+            policy.isAllowed(granted, settings(NoiseCancellationSettings.Mode.Unknown("future"))),
+        )
+    }
+
+    @Test
+    fun `not allowed when the call type carries no noise-cancellation settings`() {
+        assertFalse(policy.isAllowed(granted, settingsWithoutNoiseCancellation()))
+    }
+
+    @Test
+    fun `not decided before settings resolve`() {
+        // Null settings mean the server has not told us yet. Callers must wait rather than treat
+        // this as a refusal, or noise cancellation flaps off and back on during join.
+        assertFalse(policy.isAllowed(granted, null))
+        assertFalse(policy.isAutoOn(granted, null))
+    }
+
+    @Test
+    fun `auto-on only for the auto-on mode`() {
+        assertTrue(policy.isAutoOn(granted, settings(NoiseCancellationSettings.Mode.AutoOn)))
+        assertFalse(policy.isAutoOn(granted, settings(NoiseCancellationSettings.Mode.Available)))
+    }
+
+    @Test
+    fun `auto-on requires the capability too`() {
+        assertFalse(
+            policy.isAutoOn(emptyList(), settings(NoiseCancellationSettings.Mode.AutoOn)),
+        )
+    }
+}


### PR DESCRIPTION
Stacked on #1771. Merge after parent.

### Goal

Fixes [AND-1401](https://linear.app/stream/issue/AND-1401/noise-cancellation-capability-and-call-settings-are-not-enforced-in)

Core checked neither `OwnCapability.EnableNoiseCancellation` nor the call type's `noise_cancellation` mode, so noise cancellation ran regardless of what the server granted. Android enforced neither check — and shipped the mode helpers (`NoiseCancellationUtils`) in core while only the demo app consumed them.

Last of a three-part stack (#1770, #1771).

### Implementation

- `NoiseCancellationPolicy` owns both checks. `Call` reconciles against it: enabling is refused when either is withheld, and withdrawn if either is taken away mid-call. Disabling is always permitted so a withdrawal can never be blocked.
- The reconciler waits for settings to **resolve** rather than reading "not told yet" as a refusal — the latter switches noise cancellation off and back on during join.
- The call type's `auto-on` default moves out of the demo app's lobby view model into core, so every app gets it instead of whoever remembered to wire it.
- Applying a wanted state no longer forces the peer-connection factory into existence — `CallMediaManager` remembers it and a factory created later picks it up on construction. This matters beyond tidiness: a factory built before join captures the pre-join audio bitrate profile and defeats `ensureFactoryMatchesAudioProfile`.
- **New public API:** `CallState.audioProcessingEnabled: StateFlow<Boolean>`, so consumers can observe SDK-driven changes. Additive only — the API dump gains exactly one getter, nothing removed or altered. Version constant untouched.
- demo-app collects that flow instead of snapshotting `isAudioProcessingEnabled()`, and now reads settings only to decide whether to show the menu item.

Behaviour note for review: an app running on a call type where the capability is not granted loses noise cancellation, silently. That is the intended fix, and it is the line worth reading closely. The check is also a soft one — the noise-cancellation artifact is publicly resolvable and `ManagedAudioProcessingFactory` is public, so this closes the default path rather than making it airtight; definitive enforcement is server-side.

### 🎨 UI Changes

None in the SDK. In the demo app the noise-cancellation menu item now reflects SDK-driven changes rather than only local taps.

### Testing

```
./gradlew :stream-video-android-core:testDebugUnitTest   # 1014 tests, 0 failures, 50 pre-existing skips
./gradlew :stream-video-android-core:apiCheck            # passes against the regenerated dump
./gradlew :demo-app:compileDevelopmentDebugKotlin
```

New coverage, 18 cases:

- `NoiseCancellationPolicyTest` (9) — capability x mode matrix, including an unrecognised mode and the settings-not-yet-resolved case.
- `NoiseCancellationPolicyGateTest` (5) — enabling refused without the capability, with the mode disabled, and before settings resolve; toggling-on refused; disabling always allowed.
- `NoiseCancellationSignalTest` (4) — updated to seed the server state the gate now requires.

Three gate tests were verified red with the gate removed. Server state is seeded reflectively in `CallTestSeams` rather than by adding setters to `CallState` that would exist only for tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added noise cancellation controls with call-level state visibility.
  * Noise cancellation now respects call settings and permissions, including automatic activation where configured.
  * Added customizable participant labels and video preview styling for the call lobby.
  * Improved audio-processing status reporting and per-call state handling.

* **Bug Fixes**
  * Fixed race conditions affecting participant state initialization.
  * Ensured noise cancellation is disabled when no longer permitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->