### PR TITLE
Fix the flaky MockK Context setup in PictureInPictureTest

### DIFF
--- a/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/pip/PictureInPictureTest.kt
+++ b/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/pip/PictureInPictureTest.kt
@@ -137,6 +137,8 @@ public class PictureInPictureTest {
         val builder = getPictureInPictureParams(Rational(16, 9), pipConfig)
         val params = builder.build()
 
+        // The PictureInPictureParams getters are only public from API 33,
+        // so the params values can only be asserted in the TIRAMISU tests.
         assertNotNull(params)
     }
 
@@ -145,7 +147,21 @@ public class PictureInPictureTest {
     public fun `should set title and seamless resize for TIRAMISU`() {
         val builder = getPictureInPictureParams(Rational(9, 16), pipConfig)
         val params = builder.build()
-        assertNotNull(params)
+
+        assertEquals(Rational(9, 16), params.aspectRatio)
+        assertEquals("Video Player", params.title.toString())
+        assertTrue(params.isSeamlessResizeEnabled)
+        assertTrue(params.isAutoEnterEnabled)
+    }
+
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    public fun `should disable auto-enter when configuration disables it for TIRAMISU`() {
+        val config = PictureInPictureConfiguration(enable = true, autoEnterEnabled = false)
+
+        val params = getPictureInPictureParams(Rational(9, 16), config).build()
+
+        assertFalse(params.isAutoEnterEnabled)
     }
 
     @Test

--- a/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/pip/PictureInPictureTest.kt
+++ b/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/pip/PictureInPictureTest.kt
@@ -17,8 +17,8 @@
 package io.getstream.video.android.compose.pip
 
 import android.app.Activity
-import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.os.Build
 import android.util.Rational
 import io.getstream.video.android.core.Call
@@ -66,7 +66,7 @@ public class PictureInPictureTest {
     // enterPictureInPicture Test
     @Test
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
-    public fun `should enter pip mode with correct params`() {
+    public fun `should enter pip mode when O and above`() {
         val screenSharing = mockk<ScreenSharingSession>(relaxed = true)
         every { call.state.screenSharingSession.value } returns screenSharing
 
@@ -104,8 +104,8 @@ public class PictureInPictureTest {
         val screenSharing = mockk<ScreenSharingSession>()
         every { screenSharing.participant } returns localParticipant
 
-        val aspect1 = getAspect(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, null)
-        val aspect2 = getAspect(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, screenSharing)
+        val aspect1 = getAspect(Configuration.ORIENTATION_PORTRAIT, null)
+        val aspect2 = getAspect(Configuration.ORIENTATION_PORTRAIT, screenSharing)
 
         assertEquals(Rational(9, 16), aspect1)
         assertEquals(Rational(9, 16), aspect2)
@@ -113,7 +113,7 @@ public class PictureInPictureTest {
 
     @Test
     public fun `should return 16x9 when landscape`() {
-        val aspect = getAspect(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE, null)
+        val aspect = getAspect(Configuration.ORIENTATION_LANDSCAPE, null)
         assertEquals(Rational(16, 9), aspect)
     }
 
@@ -125,7 +125,7 @@ public class PictureInPictureTest {
         val screenSharing = mockk<ScreenSharingSession>()
         every { screenSharing.participant } returns remoteParticipant
 
-        val aspect = getAspect(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, screenSharing)
+        val aspect = getAspect(Configuration.ORIENTATION_PORTRAIT, screenSharing)
         assertEquals(Rational(16, 9), aspect)
     }
 
@@ -133,35 +133,43 @@ public class PictureInPictureTest {
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.S]) // Android 12
-    public fun `should set aspect ratio and auto-enter when SDK S`() {
+    public fun `should enable auto-enter by default when SDK S`() {
         val builder = getPictureInPictureParams(Rational(16, 9), pipConfig)
         val params = builder.build()
 
-        // The PictureInPictureParams getters are only public from API 33,
-        // so the params values can only be asserted in the TIRAMISU tests.
-        assertNotNull(params)
-    }
-
-    @Test
-    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
-    public fun `should set title and seamless resize for TIRAMISU`() {
-        val builder = getPictureInPictureParams(Rational(9, 16), pipConfig)
-        val params = builder.build()
-
-        assertEquals(Rational(9, 16), params.aspectRatio)
-        assertEquals("Video Player", params.title.toString())
-        assertTrue(params.isSeamlessResizeEnabled)
+        // getAspectRatio() returns float until API 32 and Rational from 33, so calling it
+        // against the current SDK stubs throws NoSuchMethodError on the S runtime.
+        // Only the boolean getters can be asserted here.
         assertTrue(params.isAutoEnterEnabled)
     }
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
-    public fun `should disable auto-enter when configuration disables it for TIRAMISU`() {
-        val config = PictureInPictureConfiguration(enable = true, autoEnterEnabled = false)
+    public fun `should set aspect ratio and title for TIRAMISU`() {
+        val builder = getPictureInPictureParams(Rational(9, 16), pipConfig)
+        val params = builder.build()
 
-        val params = getPictureInPictureParams(Rational(9, 16), config).build()
+        assertEquals(Rational(9, 16), params.aspectRatio)
+        assertEquals("Video Player", params.title.toString())
+        // isSeamlessResizeEnabled() defaults to true when never set, so this only guards
+        // a regression to setSeamlessResizeEnabled(false); set-true is not observable.
+        assertTrue(params.isSeamlessResizeEnabled)
+    }
 
-        assertFalse(params.isAutoEnterEnabled)
+    @Test
+    @Config(sdk = [Build.VERSION_CODES.TIRAMISU])
+    public fun `should follow the configured auto-enter for TIRAMISU`() {
+        val enabled = getPictureInPictureParams(
+            Rational(9, 16),
+            PictureInPictureConfiguration(enable = true, autoEnterEnabled = true),
+        ).build()
+        val disabled = getPictureInPictureParams(
+            Rational(9, 16),
+            PictureInPictureConfiguration(enable = true, autoEnterEnabled = false),
+        ).build()
+
+        assertTrue(enabled.isAutoEnterEnabled)
+        assertFalse(disabled.isAutoEnterEnabled)
     }
 
     @Test

--- a/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/pip/PictureInPictureTest.kt
+++ b/stream-video-android-ui-compose/src/test/kotlin/io/getstream/video/android/compose/pip/PictureInPictureTest.kt
@@ -17,13 +17,10 @@
 package io.getstream.video.android.compose.pip
 
 import android.app.Activity
-import android.content.Context
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
-import android.content.res.Configuration
 import android.os.Build
 import android.util.Rational
-import androidx.core.content.ContextCompat
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.ParticipantState
 import io.getstream.video.android.core.model.ScreenSharingSession
@@ -31,50 +28,38 @@ import io.getstream.video.android.core.pip.PictureInPictureConfiguration
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
-import io.mockk.verify
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
 public class PictureInPictureTest {
 
-    private lateinit var context: Context
+    private lateinit var activity: Activity
     private lateinit var call: Call
     private lateinit var pipConfig: PictureInPictureConfiguration
 
     @Before
     public fun setup() {
-        context = mockk(relaxed = true)
+        activity = Robolectric.buildActivity(Activity::class.java).create().get()
         call = mockk(relaxed = true)
         pipConfig = PictureInPictureConfiguration(true)
 
-        val packageManager = mockk<PackageManager>()
-        every { context.packageManager } returns packageManager
-        every { packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE) } returns true
-
-        val resources = mockk<android.content.res.Resources>()
-        val configuration = Configuration()
-        configuration.orientation = ActivityInfo.SCREEN_ORIENTATION_PORTRAIT
-        every { resources.configuration } returns configuration
-        every { context.resources } returns resources
-
-        // Mock findActivity()
-        val activity = mockk<Activity>(relaxed = true)
-        mockkStatic("io.getstream.video.android.compose.pip.PictureInPictureKt")
-        every { context.findActivity() } returns activity
+        shadowOf(activity.packageManager)
+            .setSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE, true)
     }
 
     @After
     public fun tearDown() {
-        unmockkStatic(ContextCompat::class)
         clearAllMocks()
     }
 
@@ -84,35 +69,29 @@ public class PictureInPictureTest {
     public fun `should enter pip mode with correct params`() {
         val screenSharing = mockk<ScreenSharingSession>(relaxed = true)
         every { call.state.screenSharingSession.value } returns screenSharing
-        val activity = context.findActivity()!!
 
-        enterPictureInPicture(context, call, pipConfig)
+        enterPictureInPicture(activity, call, pipConfig)
 
-        verify(exactly = 1) { activity.enterPictureInPictureMode(any()) }
+        assertTrue(activity.isInPictureInPictureMode)
     }
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.N]) // below O
     public fun `should enter pip mode without params when below O`() {
-        every {
-            context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
-        } returns true
-        val activity = context.findActivity()!!
+        enterPictureInPicture(activity, call, pipConfig)
 
-        enterPictureInPicture(context, call, pipConfig)
-
-        verify(exactly = 1) { activity.enterPictureInPictureMode() }
+        assertTrue(activity.isInPictureInPictureMode)
     }
 
     @Test
     @Config(sdk = [Build.VERSION_CODES.O])
     public fun `should not enter pip when feature not supported`() {
-        every {
-            context.packageManager.hasSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE)
-        } returns false
-        enterPictureInPicture(context, call, pipConfig)
-        val activity = context.findActivity()!!
-        verify(exactly = 0) { activity.enterPictureInPictureMode(any()) }
+        shadowOf(activity.packageManager)
+            .setSystemFeature(PackageManager.FEATURE_PICTURE_IN_PICTURE, false)
+
+        enterPictureInPicture(activity, call, pipConfig)
+
+        assertFalse(activity.isInPictureInPictureMode)
     }
 
     // getAspect test


### PR DESCRIPTION
### Goal

Fix the flaky `PictureInPictureTest > should enter pip mode with correct params` test. It fails intermittently on CI during `setup` with:

```
io.mockk.MockKException: Can't instantiate proxy for class android.content.Context
Caused by: io.mockk.proxy.MockKAgentException: Value for this result is not assigned
```

The failure is a race in MockK's inline agent when it proxies platform classes. The test shares its JVM with the Paparazzi snapshot tests, which append to the bootstrap classpath, and that combination makes the agent attach unreliable on the Linux runners. Seen on PR #1776, where the diff was test-only.

Resolves [AND-1446](https://linear.app/stream/issue/AND-1446/fix-the-mockk-context-flake-in-pictureinpicturetest).

### Implementation

The test class already runs with Robolectric, so the platform classes do not need to be mocked at all:

- Replaced `mockk<Context>()` with a real Robolectric `Activity` (`Robolectric.buildActivity(Activity::class.java).create().get()`). Since the context is itself an `Activity`, `findActivity()` resolves it naturally, so the `mockkStatic("...PictureInPictureKt")` call is gone too.
- The PiP system feature is now controlled with `shadowOf(activity.packageManager).setSystemFeature(...)` instead of mocked `PackageManager` and `Resources`.
- The enter-PiP assertions now check `activity.isInPictureInPictureMode`. Robolectric's `ShadowActivity` sets that flag in both `enterPictureInPictureMode` overloads (verified in the Robolectric 4.11.1 shadow source).
- MockK is kept only for the domain classes (`Call`, `ScreenSharingSession`, `ParticipantState`). `tearDown` now only calls `clearAllMocks()`; the old `unmockkStatic(ContextCompat::class)` was unmocking something that was never mocked.

With no inline-agent proxying of `android.content.Context`, the race that caused the flake cannot happen anymore.

After review, the assertions were strengthened:

- The `getPictureInPictureParams` tests assert the built params values where the runtime allows it: `isAutoEnterEnabled` on S and above, plus aspect ratio and title on TIRAMISU (`getAspectRatio()` returned `float` until API 32, so it can only be asserted from 33).
- The configured auto-enter test covers both the enabled and the disabled case, so removing the `setAutoEnterEnabled` call in production fails the tests.
- The `getAspect` tests pass `Configuration.ORIENTATION_*`, the values production actually feeds, instead of `ActivityInfo.SCREEN_ORIENTATION_*`.

### 🎨 UI Changes

No UI changes, this is a test-only change.

### Testing

Run the test class locally:

```
./gradlew :stream-video-android-ui-compose:testDebugUnitTest --tests "io.getstream.video.android.compose.pip.PictureInPictureTest"
```

All 10 tests pass (0 failures, 0 skipped).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved Picture-in-Picture coverage using realistic device and activity behavior.
  * Added validation for supported, pre-Oreo, and unsupported-device scenarios.
  * Tests now verify the activity’s actual Picture-in-Picture state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
