### PR TITLE
Stabilize the flaky E2E emulator tests

### DIFF
--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -85,8 +85,12 @@ jobs:
         if: failure()
         with:
           name: test_artifacts_${{ env.ANDROID_API_LEVEL }}
+          # The allure results carry the retry rule's failure artifacts (logcat,
+          # screenshot, hierarchy per failed attempt), which TestOps deduplicates
+          # away when the same test passes on another API level.
           path: |
             fastlane/recordings/*
+            fastlane/allure-results/*
             fastlane/video-buddy-server.log
             fastlane/video-buddy-console.log
   slack:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -85,13 +85,17 @@ jobs:
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d
         timeout-minutes: 45
+        env:
+          # Passed through the environment and expanded quoted, so the value cannot
+          # inject shell commands into the script line; the Fastfile validates it too.
+          TEST_CLASS: ${{ inputs.test_class }}
         with:
           api-level: ${{ env.ANDROID_API_LEVEL }}
           disable-animations: true
           profile: pixel
           arch : x86_64
           emulator-options: -no-snapshot-save -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -camera-back none -camera-front none
-          script: bundle exec fastlane run_e2e_test batch:${{ matrix.batch }} batch_count:${{ strategy.job-total }} ${{ inputs.test_class && format('test_class:{0}', inputs.test_class) || '' }}
+          script: bundle exec fastlane run_e2e_test batch:${{ matrix.batch }} batch_count:${{ strategy.job-total }} test_class:"$TEST_CLASS"
       - name: Allure TestOps Upload
         if: ${{ env.LAUNCH_ID != '' && (success() || failure()) }}
         run: bundle exec fastlane allure_upload

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -4,9 +4,19 @@ on:
   pull_request:
 
   workflow_dispatch:
+    inputs:
+      api_level:
+        description: 'Android API level to run on'
+        type: string
+        required: false
+        default: '34'
+      test_class:
+        description: 'Fully qualified test class to run on its own, optionally with #method. Every batch job then runs it, giving independent samples of a flaky test.'
+        type: string
+        required: false
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
@@ -61,7 +71,7 @@ jobs:
           - batch: 2
       fail-fast: false
     env:
-      ANDROID_API_LEVEL: 34
+      ANDROID_API_LEVEL: ${{ inputs.api_level || '34' }}
       LAUNCH_ID: ${{ needs.allure_testops_launch.outputs.launch_id }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -81,7 +91,7 @@ jobs:
           profile: pixel
           arch : x86_64
           emulator-options: -no-snapshot-save -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -camera-back none -camera-front none
-          script: bundle exec fastlane run_e2e_test batch:${{ matrix.batch }} batch_count:${{ strategy.job-total }}
+          script: bundle exec fastlane run_e2e_test batch:${{ matrix.batch }} batch_count:${{ strategy.job-total }} ${{ inputs.test_class && format('test_class:{0}', inputs.test_class) || '' }}
       - name: Allure TestOps Upload
         if: ${{ env.LAUNCH_ID != '' && (success() || failure()) }}
         run: bundle exec fastlane allure_upload
@@ -100,7 +110,11 @@ jobs:
         timeout-minutes: 10
         with:
           name: test_artifacts_${{ matrix.batch }}
+          # The allure results carry the retry rule's failure artifacts (logcat,
+          # screenshot, hierarchy per failed attempt), which TestOps deduplicates
+          # away when the same test passes in another batch.
           path: |
             fastlane/recordings/*
+            fastlane/allure-results/*
             fastlane/video-buddy-server.log
             fastlane/video-buddy-console.log

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
@@ -32,11 +32,11 @@ import io.getstream.video.android.uiautomator.device
 import io.getstream.video.android.uiautomator.findObject
 import io.getstream.video.android.uiautomator.findObjects
 import io.getstream.video.android.uiautomator.isDisplayed
-import io.getstream.video.android.uiautomator.retryOnStaleObjectException
 import io.getstream.video.android.uiautomator.seconds
 import io.getstream.video.android.uiautomator.typeText
 import io.getstream.video.android.uiautomator.waitForText
 import io.getstream.video.android.uiautomator.waitToAppear
+import io.getstream.video.android.uiautomator.waitToAppearAndClick
 
 class UserRobot {
 
@@ -55,31 +55,31 @@ class UserRobot {
     // LoginPage actions
 
     fun loginWithEmail(email: String): UserRobot {
-        LoginPage.emailSignIn.waitToAppear().click()
+        LoginPage.emailSignIn.waitToAppearAndClick()
         device.typeText(email) // using shell because UIAutomator does not see the input field
-        LoginPage.loginButton.findObject().click()
+        LoginPage.loginButton.waitToAppearAndClick()
         return this
     }
 
     fun loginAsRandomUser(): UserRobot {
-        LoginPage.randomUserSignInButton.waitToAppear().click()
+        LoginPage.randomUserSignInButton.waitToAppearAndClick()
         return this
     }
 
     // CallDetailsPage actions
 
     fun logout(): UserRobot {
-        CallDetailsPage.wheelIcon.waitToAppear(timeOutMillis = 20.seconds).click()
-        CallDetailsPage.signOutButton.waitToAppear().click()
+        CallDetailsPage.wheelIcon.waitToAppearAndClick(timeOutMillis = 20.seconds)
+        CallDetailsPage.signOutButton.waitToAppearAndClick()
         return this
     }
 
     fun directCall(audioOnly: Boolean): UserRobot {
-        CallDetailsPage.wheelIcon.waitToAppear().click()
-        CallDetailsPage.directCallButton.waitToAppear().click()
-        DirectCallPage.participantName.waitToAppear().click()
+        CallDetailsPage.wheelIcon.waitToAppearAndClick()
+        CallDetailsPage.directCallButton.waitToAppearAndClick()
+        DirectCallPage.participantName.waitToAppearAndClick()
         val callButton = if (audioOnly) audioCallButton else videoCallButton
-        callButton.findObject().click()
+        callButton.waitToAppearAndClick()
         return this
     }
 
@@ -96,7 +96,6 @@ class UserRobot {
             microphone(microphone, hard = true)
         }
         joinCallFromLobby()
-        waitForCallToStart()
         return this
     }
 
@@ -104,7 +103,7 @@ class UserRobot {
         if (callId != null) {
             CallDetailsPage.callIdInputField.waitToAppear().typeText(callId)
         }
-        CallDetailsPage.joinCallButton.waitToAppear().click()
+        CallDetailsPage.joinCallButton.waitToAppearAndClick()
         waitForLobbyToOpen()
         return this
     }
@@ -117,7 +116,7 @@ class UserRobot {
     // LobbyPage actions
 
     fun joinCallFromLobby(): UserRobot {
-        LobbyPage.joinCallButton.findObject().click()
+        LobbyPage.joinCallButton.waitToAppearAndClick()
         waitForCallToStart()
         return this
     }
@@ -130,18 +129,18 @@ class UserRobot {
     // RingPage actions
 
     fun acceptIncomingCall(): UserRobot {
-        RingPage.acceptCallButton.waitToAppear().click()
+        RingPage.acceptCallButton.waitToAppearAndClick()
         return this
     }
 
     fun declineIncomingCall(): UserRobot {
-        RingPage.declineCallButton.waitToAppear().click()
+        RingPage.declineCallButton.waitToAppearAndClick()
         return this
     }
 
     fun declineIncomingCallIfExists(): UserRobot {
         if (RingPage.declineCallButton.isDisplayed()) {
-            RingPage.declineCallButton.findObject().click()
+            RingPage.declineCallButton.waitToAppearAndClick()
         }
         return this
     }
@@ -162,9 +161,9 @@ class UserRobot {
         val isFrontCamera = CallPage.cameraPositionToggleFront.findObjects().isNotEmpty()
 
         if (position == CameraPosition.BACK && isFrontCamera) {
-            CallPage.cameraPositionToggleFront.findObject().click()
+            CallPage.cameraPositionToggleFront.waitToAppearAndClick()
         } else if (position == CameraPosition.FRONT && !isFrontCamera) {
-            CallPage.cameraPositionToggleBack.findObject().click()
+            CallPage.cameraPositionToggleBack.waitToAppearAndClick()
         }
 
         return this
@@ -180,26 +179,26 @@ class UserRobot {
             hard -> when (action) {
                 UserControls.ENABLE -> {
                     if (isEnabled) {
-                        CallPage.cameraEnabledToggle.findObject().click()
-                        CallPage.cameraDisabledToggle.waitToAppear().click()
+                        CallPage.cameraEnabledToggle.waitToAppearAndClick()
+                        CallPage.cameraDisabledToggle.waitToAppearAndClick()
                     } else {
-                        CallPage.cameraDisabledToggle.findObject().click()
+                        CallPage.cameraDisabledToggle.waitToAppearAndClick()
                     }
                 }
                 UserControls.DISABLE -> {
                     if (isEnabled) {
-                        CallPage.cameraEnabledToggle.findObject().click()
+                        CallPage.cameraEnabledToggle.waitToAppearAndClick()
                     } else {
-                        CallPage.cameraDisabledToggle.findObject().click()
-                        CallPage.cameraEnabledToggle.waitToAppear().click()
+                        CallPage.cameraDisabledToggle.waitToAppearAndClick()
+                        CallPage.cameraEnabledToggle.waitToAppearAndClick()
                     }
                 }
             }
             action == UserControls.ENABLE && !isEnabled -> {
-                CallPage.cameraDisabledToggle.findObject().click()
+                CallPage.cameraDisabledToggle.waitToAppearAndClick()
             }
             action == UserControls.DISABLE && isEnabled -> {
-                CallPage.cameraEnabledToggle.findObject().click()
+                CallPage.cameraEnabledToggle.waitToAppearAndClick()
             }
         }
 
@@ -216,26 +215,26 @@ class UserRobot {
             hard -> when (action) {
                 UserControls.ENABLE -> {
                     if (isEnabled) {
-                        CallPage.microphoneEnabledToggle.findObject().click()
-                        CallPage.microphoneDisabledToggle.waitToAppear().click()
+                        CallPage.microphoneEnabledToggle.waitToAppearAndClick()
+                        CallPage.microphoneDisabledToggle.waitToAppearAndClick()
                     } else {
-                        CallPage.microphoneDisabledToggle.findObject().click()
+                        CallPage.microphoneDisabledToggle.waitToAppearAndClick()
                     }
                 }
                 UserControls.DISABLE -> {
                     if (isEnabled) {
-                        CallPage.microphoneEnabledToggle.findObject().click()
+                        CallPage.microphoneEnabledToggle.waitToAppearAndClick()
                     } else {
-                        CallPage.microphoneDisabledToggle.findObject().click()
-                        CallPage.microphoneEnabledToggle.waitToAppear().click()
+                        CallPage.microphoneDisabledToggle.waitToAppearAndClick()
+                        CallPage.microphoneEnabledToggle.waitToAppearAndClick()
                     }
                 }
             }
             action == UserControls.ENABLE && !isEnabled -> {
-                CallPage.microphoneDisabledToggle.findObject().click()
+                CallPage.microphoneDisabledToggle.waitToAppearAndClick()
             }
             action == UserControls.DISABLE && isEnabled -> {
-                CallPage.microphoneEnabledToggle.findObject().click()
+                CallPage.microphoneEnabledToggle.waitToAppearAndClick()
             }
         }
 
@@ -246,10 +245,10 @@ class UserRobot {
         val isEnabled = CallPage.callSettingsOpenToggle.findObjects().isNotEmpty()
 
         if (action == UserControls.ENABLE && !isEnabled) {
-            CallPage.callSettingsClosedToggle.findObject().click()
+            CallPage.callSettingsClosedToggle.waitToAppearAndClick()
             CallPage.callSettingsOpenToggle.waitToAppear()
         } else if (action == UserControls.DISABLE && isEnabled) {
-            CallPage.callSettingsOpenToggle.findObject().click()
+            CallPage.callSettingsOpenToggle.waitToAppearAndClick()
         }
 
         return this
@@ -265,7 +264,7 @@ class UserRobot {
         }
 
         if (locator.isDisplayed()) {
-            locator.findObject().click()
+            locator.waitToAppearAndClick()
         }
 
         settings(UserControls.DISABLE)
@@ -281,7 +280,7 @@ class UserRobot {
         }
 
         if (locator.isDisplayed()) {
-            locator.findObject().click()
+            locator.waitToAppearAndClick()
         }
 
         settings(UserControls.DISABLE)
@@ -289,14 +288,14 @@ class UserRobot {
     }
 
     fun endCall(): UserRobot {
-        CallPage.hangUpButton.waitToAppear().click()
+        CallPage.hangUpButton.waitToAppearAndClick()
         return this
     }
 
     fun raiseHand(): UserRobot {
         settings(UserControls.ENABLE)
         if (SettingsMenu.raiseHandButton.isDisplayed()) {
-            SettingsMenu.raiseHandButton.findObject().click()
+            SettingsMenu.raiseHandButton.waitToAppearAndClick()
         } else {
             settings(UserControls.DISABLE)
         }
@@ -306,7 +305,7 @@ class UserRobot {
     fun lowerHand(): UserRobot {
         settings(UserControls.ENABLE)
         if (SettingsMenu.lowerHandButton.isDisplayed()) {
-            SettingsMenu.lowerHandButton.findObject().click()
+            SettingsMenu.lowerHandButton.waitToAppearAndClick()
         } else {
             settings(UserControls.DISABLE)
         }
@@ -315,7 +314,7 @@ class UserRobot {
 
     fun switchNoiseCancellationToggle(): UserRobot {
         settings(UserControls.ENABLE)
-        SettingsMenu.noiseCancellationButton.findObject().click()
+        SettingsMenu.noiseCancellationButton.waitToAppearAndClick()
         settings(UserControls.DISABLE)
         return this
     }
@@ -328,7 +327,7 @@ class UserRobot {
             Background.BLUR -> SettingsMenu.blurBackgroundDisabledToggle
         }
         if (locator.isDisplayed()) {
-            locator.findObject().click()
+            locator.waitToAppearAndClick()
         } else {
             settings(UserControls.DISABLE)
         }
@@ -336,11 +335,11 @@ class UserRobot {
     }
 
     fun setView(mode: VideoView): UserRobot {
-        CallPage.callViewButton.waitToAppear().click()
+        CallPage.callViewButton.waitToAppearAndClick()
         when (mode) {
-            VideoView.DYNAMIC -> CallPage.ViewMenu.dynamic.waitToAppear().click()
-            VideoView.SPOTLIGHT -> CallPage.ViewMenu.spotlight.waitToAppear().click()
-            VideoView.GRID -> CallPage.ViewMenu.grid.waitToAppear().click()
+            VideoView.DYNAMIC -> CallPage.ViewMenu.dynamic.waitToAppearAndClick()
+            VideoView.SPOTLIGHT -> CallPage.ViewMenu.spotlight.waitToAppearAndClick()
+            VideoView.GRID -> CallPage.ViewMenu.grid.waitToAppearAndClick()
         }
         return this
     }
@@ -353,30 +352,31 @@ class UserRobot {
     fun acceptCallRecording(): UserRobot {
         // The recording-consent dialog only appears once the backend composite recorder
         // emits call.recording_started, which can take 20-30s, so 10s is too short.
-        CallPage.RecordingButtons.accept.waitToAppear(timeOutMillis = 30.seconds).click()
+        CallPage.RecordingButtons.accept.waitToAppearAndClick(timeOutMillis = 30.seconds)
         return this
     }
 
     fun declineCallRecording(): UserRobot {
         // See acceptCallRecording: the consent dialog is gated on the backend recorder
         // starting (call.recording_started), which can take 20-30s.
-        CallPage.RecordingButtons.leave.waitToAppear(timeOutMillis = 30.seconds).click()
+        CallPage.RecordingButtons.leave.waitToAppearAndClick(timeOutMillis = 30.seconds)
         return this
     }
 
     fun waitForParticipantsOnCall(count: Int = 1, timeOutMillis: Long = 100.seconds): UserRobot {
         val user = 1
         val participants = user + count
-        device.retryOnStaleObjectException {
-            CallPage.participantsCountBadge
-                .waitToAppear()
-                .waitForText(expectedText = participants.toString(), timeOutMillis = timeOutMillis)
-        }
+        CallPage.participantsCountBadge.waitForText(
+            expectedText = participants.toString(),
+            timeOutMillis = timeOutMillis,
+        )
         return this
     }
 
     private fun waitForCallToStart(): UserRobot {
-        CallPage.callInfoView.waitToAppear(timeOutMillis = 15.seconds)
+        // Joining goes through the call create/join round-trip plus the SFU connection,
+        // which can exceed 15s on a loaded CI emulator, so the window is deliberately wide.
+        CallPage.callInfoView.waitToAppear(timeOutMillis = 30.seconds)
         return this
     }
 }

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
@@ -34,7 +34,7 @@ import io.getstream.video.android.uiautomator.findObjects
 import io.getstream.video.android.uiautomator.isDisplayed
 import io.getstream.video.android.uiautomator.seconds
 import io.getstream.video.android.uiautomator.typeText
-import io.getstream.video.android.uiautomator.waitForText
+import io.getstream.video.android.uiautomator.waitDisplayed
 import io.getstream.video.android.uiautomator.waitToAppear
 import io.getstream.video.android.uiautomator.waitToAppearAndClick
 
@@ -256,14 +256,13 @@ class UserRobot {
 
     fun closedCaption(action: UserControls): UserRobot {
         settings(UserControls.ENABLE)
-        sleep()
 
         val locator = when (action) {
             UserControls.ENABLE -> SettingsMenu.startClosedCaptionButton
             UserControls.DISABLE -> SettingsMenu.stopClosedCaptionButton
         }
 
-        if (locator.isDisplayed()) {
+        if (locator.waitDisplayed()) {
             locator.waitToAppearAndClick()
         }
 
@@ -279,7 +278,7 @@ class UserRobot {
             UserControls.DISABLE -> SettingsMenu.stopTranscriptionButton
         }
 
-        if (locator.isDisplayed()) {
+        if (locator.waitDisplayed()) {
             locator.waitToAppearAndClick()
         }
 
@@ -294,7 +293,7 @@ class UserRobot {
 
     fun raiseHand(): UserRobot {
         settings(UserControls.ENABLE)
-        if (SettingsMenu.raiseHandButton.isDisplayed()) {
+        if (SettingsMenu.raiseHandButton.waitDisplayed()) {
             SettingsMenu.raiseHandButton.waitToAppearAndClick()
         } else {
             settings(UserControls.DISABLE)
@@ -304,7 +303,7 @@ class UserRobot {
 
     fun lowerHand(): UserRobot {
         settings(UserControls.ENABLE)
-        if (SettingsMenu.lowerHandButton.isDisplayed()) {
+        if (SettingsMenu.lowerHandButton.waitDisplayed()) {
             SettingsMenu.lowerHandButton.waitToAppearAndClick()
         } else {
             settings(UserControls.DISABLE)
@@ -326,7 +325,7 @@ class UserRobot {
             Background.IMAGE -> SettingsMenu.imageBackgroundDisabledToggle
             Background.BLUR -> SettingsMenu.blurBackgroundDisabledToggle
         }
-        if (locator.isDisplayed()) {
+        if (locator.waitDisplayed()) {
             locator.waitToAppearAndClick()
         } else {
             settings(UserControls.DISABLE)
@@ -367,13 +366,9 @@ class UserRobot {
     }
 
     fun waitForParticipantsOnCall(count: Int = 1, timeOutMillis: Long = 100.seconds): UserRobot {
-        val user = 1
-        val participants = user + count
-        CallPage.participantsCountBadge.waitForText(
-            expectedText = participants.toString(),
-            timeOutMillis = timeOutMillis,
-        )
-        return this
+        // Same badge and expected value; the assert makes a timeout fail here with a clear
+        // message instead of letting a later assertion fail further from the cause.
+        return assertParticipantsCountOnCall(count, timeOutMillis)
     }
 
     private fun waitForCallToStart(): UserRobot {

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
@@ -336,10 +336,13 @@ class UserRobot {
 
     fun setView(mode: VideoView): UserRobot {
         CallPage.callViewButton.waitToAppearAndClick()
+        // With many live video tiles the emulator UI is busy, and the opened menu can take
+        // several seconds to land in the accessibility tree, so the items get a wide window.
+        val timeOutMillis = 15.seconds
         when (mode) {
-            VideoView.DYNAMIC -> CallPage.ViewMenu.dynamic.waitToAppearAndClick()
-            VideoView.SPOTLIGHT -> CallPage.ViewMenu.spotlight.waitToAppearAndClick()
-            VideoView.GRID -> CallPage.ViewMenu.grid.waitToAppearAndClick()
+            VideoView.DYNAMIC -> CallPage.ViewMenu.dynamic.waitToAppearAndClick(timeOutMillis)
+            VideoView.SPOTLIGHT -> CallPage.ViewMenu.spotlight.waitToAppearAndClick(timeOutMillis)
+            VideoView.GRID -> CallPage.ViewMenu.grid.waitToAppearAndClick(timeOutMillis)
         }
         return this
     }

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -145,12 +145,10 @@ fun UserRobot.assertParticipantsCountOnCall(
 ): UserRobot {
     val user = 1
     val participants = (user + count).toString()
-    val actualCount = device.retryOnStaleObjectException {
-        CallPage.participantsCountBadge
-            .waitToAppear()
-            .waitForText(expectedText = participants, timeOutMillis = timeOutMillis)
-            .text
-    }
+    val actualCount = CallPage.participantsCountBadge.waitForText(
+        expectedText = participants,
+        timeOutMillis = timeOutMillis,
+    )
     assertEquals(participants, actualCount)
     return this
 }
@@ -200,7 +198,13 @@ fun UserRobot.assertRecordingView(isDisplayed: Boolean): UserRobot {
         // The backend composite recorder can take 20-30s to actually start and emit
         // call.recording_started, so the icon needs a longer window than the 5s default.
         assertTrue(CallPage.recordingIcon.waitToAppear(timeOutMillis = 30.seconds).isDisplayed())
-        assertEquals(label, CallPage.callInfoView.findObject().text)
+        // After a network drop the label can briefly read "Reconnecting.." before it settles
+        // back to "Recording", so poll instead of asserting on the first read.
+        val callInfoText = CallPage.callInfoView.waitForText(
+            expectedText = label,
+            timeOutMillis = 15.seconds,
+        )
+        assertEquals(label, callInfoText)
     } else {
         // The buddy records for ~60s, so the icon stays visible until the backend emits
         // call.recording_stopped. waitToDisappear returns as soon as the icon is gone, so
@@ -262,10 +266,10 @@ fun UserRobot.assertIncomingCall(isDisplayed: Boolean): UserRobot {
 fun UserRobot.assertOutgoingCall(audioOnly: Boolean = true, isDisplayed: Boolean): UserRobot {
     if (isDisplayed) {
         // The outgoing ringing screen only renders after the call create/ring network
-        // round-trip completes, which can exceed 10s under CI load.
+        // round-trip completes, which can exceed 20s on the slower CI emulators (API 28).
         assertTrue(
             "Decline call button",
-            RingPage.declineCallButton.waitToAppear(timeOutMillis = 20.seconds).isDisplayed(),
+            RingPage.declineCallButton.waitToAppear(timeOutMillis = 30.seconds).isDisplayed(),
         )
         assertTrue("Call label", RingPage.outgoingCallLabel.isDisplayed())
         assertTrue("Avatar", RingPage.callParticipantAvatar.isDisplayed())

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -290,9 +290,11 @@ fun UserRobot.assertOutgoingCall(audioOnly: Boolean = true, isDisplayed: Boolean
 
 fun UserRobot.assertConnectingView(): UserRobot {
     assertEquals("Connecting...", RingPage.callProgressBar.waitToAppear().text)
+    // Connecting covers the same call join round-trip as waitForCallToStart, which can
+    // exceed 10s on a loaded CI emulator, so both use the same 30s window.
     assertFalse(
         "Connecting screen should disappear",
-        RingPage.callProgressBar.waitToDisappear(timeOutMillis = 10000).isDisplayed(),
+        RingPage.callProgressBar.waitToDisappear(timeOutMillis = 30.seconds).isDisplayed(),
     )
     return this
 }

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/rules/RetryRule.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/rules/RetryRule.kt
@@ -104,8 +104,13 @@ public class RetryRule(private val count: Int) : TestRule {
                             "$testName: capturing failure artifacts failed: $it",
                         )
                     }
+                    // The connection is device-global state that outlives the test process,
+                    // so it is restored even after the final attempt: otherwise one
+                    // reconnection test failing all attempts leaves the rest of the batch
+                    // without network.
+                    restoreInternetConnection(testName)
                     if (attempt < count) {
-                        recoverForNextAttempt(testName)
+                        leaveLeftoverCall(testName)
                         runCatching { writeFailedAttemptResult(attempt, t, startMillis) }
                             .onFailure {
                                 System.err.println(
@@ -125,16 +130,23 @@ public class RetryRule(private val count: Int) : TestRule {
     }
 
     /**
-     * Best-effort recovery before the next attempt. The instrumentation runs inside the app
-     * process, so the app cannot be force-stopped or its process killed without killing the
-     * test itself: leftover state has to be reset in place. A failed attempt can leave the
-     * internet connection disabled (reconnection tests) or a call still active or ringing;
-     * without this reset, every following attempt inherits that state and fails the same way,
-     * which defeats the retries.
+     * A reconnection test that fails between disabling and enabling the connection leaves
+     * wifi and data off. Best-effort: [io.getstream.video.android.uiautomator.waitForInternetConnection]
+     * throws when the connection does not come back within its window, and that must not
+     * replace the test failure.
      */
-    private fun recoverForNextAttempt(testName: String) {
+    private fun restoreInternetConnection(testName: String) {
         runCatching { device.enableInternetConnection() }
             .onFailure { System.err.println("$testName: restoring the connection failed: $it") }
+    }
+
+    /**
+     * Best-effort teardown of a call a failed attempt left behind. The instrumentation runs
+     * inside the app process, so the app cannot be force-stopped or its process killed
+     * without killing the test itself: leftover state has to be reset in place, or the next
+     * attempt inherits a call that is still active or ringing and fails the same way.
+     */
+    private fun leaveLeftoverCall(testName: String) {
         runCatching {
             StreamVideo.instanceOrNull()?.state?.let { state ->
                 state.ringingCall.value?.leave(reason = "e2e-test-retry")

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/rules/RetryRule.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/rules/RetryRule.kt
@@ -19,11 +19,13 @@ package io.getstream.video.android.rules
 import android.database.sqlite.SQLiteDatabase
 import android.os.Environment
 import androidx.test.platform.app.InstrumentationRegistry
+import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.uiautomator.allureLogcat
 import io.getstream.video.android.uiautomator.allureScreenrecord
 import io.getstream.video.android.uiautomator.allureScreenshot
 import io.getstream.video.android.uiautomator.allureWindowHierarchy
 import io.getstream.video.android.uiautomator.device
+import io.getstream.video.android.uiautomator.enableInternetConnection
 import io.qameta.allure.kotlin.Allure
 import io.qameta.allure.kotlin.model.Stage
 import io.qameta.allure.kotlin.model.TestResult
@@ -71,7 +73,15 @@ public class RetryRule(private val count: Int) : TestRule {
                 } catch (t: Throwable) {
                     System.err.println("$testName: run #$attempt failed.")
                     caughtThrowable = t
-                    databaseOperations.clearDatabases()
+                    // Every post-failure step is best-effort: an exception escaping this
+                    // catch block replaces the real failure and skips the remaining
+                    // attempts, so none of them may throw.
+                    runCatching { databaseOperations.clearDatabases() }
+                        .onFailure {
+                            System.err.println(
+                                "$testName: clearing databases failed: $it",
+                            )
+                        }
                     val recordingStopped = recordingThread?.let {
                         stopRecordingSafely(
                             testName,
@@ -79,17 +89,29 @@ public class RetryRule(private val count: Int) : TestRule {
                             it,
                         )
                     }
-                    device.allureLogcat(name = "logcat_$attempt")
-                    device.allureScreenshot(name = "screenshot_$attempt")
-                    device.allureWindowHierarchy(name = "hierarchy_$attempt")
-                    if (recordingStopped == true) {
-                        device.allureScreenrecord(
-                            name = "record_$attempt",
-                            file = File(videoFilePath),
+                    runCatching {
+                        device.allureLogcat(name = "logcat_$attempt")
+                        device.allureScreenshot(name = "screenshot_$attempt")
+                        device.allureWindowHierarchy(name = "hierarchy_$attempt")
+                        if (recordingStopped == true) {
+                            device.allureScreenrecord(
+                                name = "record_$attempt",
+                                file = File(videoFilePath),
+                            )
+                        }
+                    }.onFailure {
+                        System.err.println(
+                            "$testName: capturing failure artifacts failed: $it",
                         )
                     }
                     if (attempt < count) {
-                        writeFailedAttemptResult(attempt, t, startMillis)
+                        recoverForNextAttempt(testName)
+                        runCatching { writeFailedAttemptResult(attempt, t, startMillis) }
+                            .onFailure {
+                                System.err.println(
+                                    "$testName: writing the attempt result failed: $it",
+                                )
+                            }
                     }
                 } finally {
                     if (recordingThread != null) {
@@ -100,6 +122,25 @@ public class RetryRule(private val count: Int) : TestRule {
 
             throw caughtThrowable ?: IllegalStateException("$testName failed without a captured error")
         }
+    }
+
+    /**
+     * Best-effort recovery before the next attempt. The instrumentation runs inside the app
+     * process, so the app cannot be force-stopped or its process killed without killing the
+     * test itself: leftover state has to be reset in place. A failed attempt can leave the
+     * internet connection disabled (reconnection tests) or a call still active or ringing;
+     * without this reset, every following attempt inherits that state and fails the same way,
+     * which defeats the retries.
+     */
+    private fun recoverForNextAttempt(testName: String) {
+        runCatching { device.enableInternetConnection() }
+            .onFailure { System.err.println("$testName: restoring the connection failed: $it") }
+        runCatching {
+            StreamVideo.instanceOrNull()?.state?.let { state ->
+                state.ringingCall.value?.leave(reason = "e2e-test-retry")
+                state.activeCall.value?.leave(reason = "e2e-test-retry")
+            }
+        }.onFailure { System.err.println("$testName: leaving the leftover call failed: $it") }
     }
 
     /**

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/uiautomator/Wait.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/uiautomator/Wait.kt
@@ -114,6 +114,27 @@ public fun BySelector.waitToAppearAndClick(withIndex: Int, timeOutMillis: Long =
     }
 }
 
+/**
+ * Waits up to [timeOutMillis] for an object matching this selector to be displayed and reports
+ * the outcome. Stale reads during the lookup are absorbed and retried until the timeout;
+ * [StaleObjectException] never escapes.
+ *
+ * @param timeOutMillis Maximum time to keep polling before reporting `false`.
+ */
+public fun BySelector.waitDisplayed(timeOutMillis: Long = defaultTimeout): Boolean {
+    val endTime = System.currentTimeMillis() + timeOutMillis
+    while (System.currentTimeMillis() < endTime) {
+        try {
+            if (device.findObject(this)?.isDisplayed() == true) {
+                return true
+            }
+        } catch (_: StaleObjectException) {
+        }
+        Thread.sleep(POLL_INTERVAL_MILLIS)
+    }
+    return false
+}
+
 public fun BySelector.wait(timeOutMillis: Long = defaultTimeout): BySelector {
     device.wait(Until.hasObject(this), timeOutMillis)
     return this

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/uiautomator/Wait.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/uiautomator/Wait.kt
@@ -17,50 +17,143 @@
 package io.getstream.video.android.uiautomator
 
 import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.StaleObjectException
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
 
-public fun sleep(timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout) {
+public fun sleep(timeOutMillis: Long = defaultTimeout) {
     Thread.sleep(timeOutMillis)
 }
 
-public fun BySelector.waitToAppear(timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout): UiObject2 {
-    wait(timeOutMillis)
-    return findObject()
+/**
+ * Waits up to [timeOutMillis] for an object matching this selector and returns it.
+ *
+ * Stale reads during the lookup are absorbed and retried until the timeout;
+ * [StaleObjectException] never escapes.
+ *
+ * @param timeOutMillis Maximum time to wait before failing.
+ * @throws IllegalStateException when the timeout elapses without a matching object.
+ */
+public fun BySelector.waitToAppear(timeOutMillis: Long = defaultTimeout): UiObject2 {
+    val endTime = System.currentTimeMillis() + timeOutMillis
+    while (System.currentTimeMillis() < endTime) {
+        currentObjectOrNull()?.let { return it }
+        Thread.sleep(POLL_INTERVAL_MILLIS)
+    }
+    error("waitToAppear timed out after ${timeOutMillis}ms; no object matched selector: $this")
 }
 
-public fun BySelector.waitToAppear(withIndex: Int, timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout): UiObject2 {
-    wait(timeOutMillis)
-    return findObjects()[withIndex]
-}
-
-public fun BySelector.wait(timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout): BySelector {
-    io.getstream.video.android.uiautomator.device.wait(Until.hasObject(this), timeOutMillis)
-    return this
-}
-
-public fun BySelector.waitToDisappear(timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout): BySelector {
-    io.getstream.video.android.uiautomator.device.wait(Until.gone(this), timeOutMillis)
-    return this
-}
-
-public fun UiObject2.waitForText(
-    expectedText: String,
-    mustBeEqual: Boolean = true,
-    timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout,
+/**
+ * Waits up to [timeOutMillis] for objects matching this selector and returns the one at [withIndex].
+ *
+ * @param withIndex The zero-based index of the object to return.
+ * @param timeOutMillis Maximum time to wait before failing.
+ * @throws IllegalStateException when the timeout elapses without enough matching objects.
+ */
+public fun BySelector.waitToAppear(
+    withIndex: Int,
+    timeOutMillis: Long = defaultTimeout,
 ): UiObject2 {
     val endTime = System.currentTimeMillis() + timeOutMillis
-    var textPresent = false
-    while (!textPresent && System.currentTimeMillis() < endTime) {
-        textPresent = if (mustBeEqual) text == expectedText else text.contains(expectedText)
-        if (!textPresent) {
-            Thread.sleep(POLL_INTERVAL_MILLIS)
+    var lastCount = 0
+    while (System.currentTimeMillis() < endTime) {
+        val objects = currentObjectsOrEmpty()
+        lastCount = objects.size
+        objects.getOrNull(withIndex)?.let { return it }
+        Thread.sleep(POLL_INTERVAL_MILLIS)
+    }
+    error(
+        "waitToAppear(withIndex=$withIndex) timed out after ${timeOutMillis}ms; " +
+            "only $lastCount objects matched selector: $this",
+    )
+}
+
+/**
+ * Waits up to [timeOutMillis] for an object matching this selector and clicks it. When the click
+ * lands on a node that went stale between the find and the click (e.g. because the containing
+ * view refreshed), the object is re-found and the click retried until the timeout, after which
+ * the last [StaleObjectException] escapes. A retry started just before the deadline is granted
+ * one final poll interval past it, so the last re-find is a real attempt instead of an
+ * immediate timeout.
+ *
+ * @param timeOutMillis Maximum time to wait before failing.
+ * @throws IllegalStateException when the timeout elapses without a matching object.
+ */
+public fun BySelector.waitToAppearAndClick(timeOutMillis: Long = defaultTimeout) {
+    val endTime = System.currentTimeMillis() + timeOutMillis
+    while (true) {
+        try {
+            waitToAppear(maxOf(endTime - System.currentTimeMillis(), POLL_INTERVAL_MILLIS)).click()
+            return
+        } catch (e: StaleObjectException) {
+            if (System.currentTimeMillis() >= endTime) throw e
         }
     }
+}
+
+/**
+ * Waits up to [timeOutMillis] for objects matching this selector and clicks the one at
+ * [withIndex], with the same stale-safe retry behavior as the single-object overload.
+ *
+ * @param withIndex The zero-based index of the object to click.
+ * @param timeOutMillis Maximum time to wait before failing.
+ * @throws IllegalStateException when the timeout elapses without enough matching objects.
+ */
+public fun BySelector.waitToAppearAndClick(withIndex: Int, timeOutMillis: Long = defaultTimeout) {
+    val endTime = System.currentTimeMillis() + timeOutMillis
+    while (true) {
+        try {
+            waitToAppear(
+                withIndex,
+                maxOf(endTime - System.currentTimeMillis(), POLL_INTERVAL_MILLIS),
+            ).click()
+            return
+        } catch (e: StaleObjectException) {
+            if (System.currentTimeMillis() >= endTime) throw e
+        }
+    }
+}
+
+public fun BySelector.wait(timeOutMillis: Long = defaultTimeout): BySelector {
+    device.wait(Until.hasObject(this), timeOutMillis)
     return this
 }
 
-public fun BySelector.waitForCount(count: Int, timeOutMillis: Long = io.getstream.video.android.uiautomator.defaultTimeout): List<UiObject2> {
+public fun BySelector.waitToDisappear(timeOutMillis: Long = defaultTimeout): BySelector {
+    device.wait(Until.gone(this), timeOutMillis)
+    return this
+}
+
+/**
+ * Waits for an object matching this selector whose text matches [expectedText]. Returns the
+ * matched text, or the last observed text on timeout. Never throws: stale reads are absorbed
+ * and retried, so callers should wrap the result in an assertion to surface a mismatch or
+ * timeout.
+ *
+ * @param expectedText The text to match.
+ * @param mustBeEqual When `true`, requires exact match; otherwise a substring match.
+ * @param timeOutMillis Maximum time to keep polling before returning the last observed text.
+ */
+public fun BySelector.waitForText(
+    expectedText: String,
+    mustBeEqual: Boolean = true,
+    timeOutMillis: Long = defaultTimeout,
+): String {
+    val endTime = System.currentTimeMillis() + timeOutMillis
+    var lastText = ""
+    while (System.currentTimeMillis() < endTime) {
+        val actual = currentTextOrNull()
+        if (actual != null) {
+            lastText = actual
+            val matches = if (mustBeEqual) actual == expectedText else actual.contains(expectedText)
+            if (matches) return actual
+        }
+        Thread.sleep(POLL_INTERVAL_MILLIS)
+    }
+    return lastText
+}
+
+public fun BySelector.waitForCount(count: Int, timeOutMillis: Long = defaultTimeout): List<UiObject2> {
     val endTime = System.currentTimeMillis() + timeOutMillis
     var elements: List<UiObject2> = findObjects()
     while (elements.size != count && System.currentTimeMillis() < endTime) {
@@ -71,3 +164,23 @@ public fun BySelector.waitForCount(count: Int, timeOutMillis: Long = io.getstrea
 }
 
 private const val POLL_INTERVAL_MILLIS = 50L
+
+// Call [device] directly — the [findObject] extension lies about nullability and NPEs when the
+// selector hasn't matched yet, which is the normal case during polling.
+private fun BySelector.currentObjectOrNull(): UiObject2? = try {
+    device.findObject(this)
+} catch (_: StaleObjectException) {
+    null
+}
+
+private fun BySelector.currentObjectsOrEmpty(): List<UiObject2> = try {
+    device.findObjects(this)
+} catch (_: StaleObjectException) {
+    emptyList()
+}
+
+private fun BySelector.currentTextOrNull(): String? = try {
+    device.findObject(this)?.text
+} catch (_: StaleObjectException) {
+    null
+}

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -76,10 +76,11 @@ lane :run_e2e_test do |options|
   androidx_test_services_path = sh('adb shell pm path androidx.test.services').strip
 
   targeted_class = options[:test_class].to_s
-  # The value is interpolated into a shell command, so only a class name is accepted,
-  # optionally with a single method. A typo also fails here instead of in the shell.
+  # The value is interpolated into a shell command, so only a top-level class name is
+  # accepted, optionally with a single method. No '$' (nested classes): the shell would
+  # expand it. A typo also fails here instead of in the shell.
   UI.user_error!("Invalid test_class: #{targeted_class}") unless
-    targeted_class.empty? || targeted_class.match?(/\A[\w.$]+(#\w+)?\z/)
+    targeted_class.empty? || targeted_class.match?(/\A[\w.]+(#\w+)?\z/)
 
   test_filter =
     if targeted_class.empty?

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,16 +75,29 @@ lane :run_e2e_test do |options|
   orchestrator_package_name = 'androidx.test.orchestrator/.AndroidTestOrchestrator'
   androidx_test_services_path = sh('adb shell pm path androidx.test.services').strip
 
-  run_tests_in_batches = batch_tests(
-    batch: options[:batch],
-    batch_count: options[:batch_count],
-    test_apk_path: stream_test_path
-  )
+  targeted_class = options[:test_class].to_s
+  # The value is interpolated into a shell command, so only a class name is accepted,
+  # optionally with a single method. A typo also fails here instead of in the shell.
+  UI.user_error!("Invalid test_class: #{targeted_class}") unless
+    targeted_class.empty? || targeted_class.match?(/\A[\w.$]+(#\w+)?\z/)
+
+  test_filter =
+    if targeted_class.empty?
+      batch_tests(
+        batch: options[:batch],
+        batch_count: options[:batch_count],
+        test_apk_path: stream_test_path
+      )
+    else
+      # Targeted run: a single class and no batching, so every batch job runs it and gives an
+      # independent sample. Used to reproduce a failure that only shows on one API level.
+      "-e class #{targeted_class}"
+    end
 
   result = sh(
     "adb shell 'CLASSPATH=#{androidx_test_services_path}' " \
     'app_process / androidx.test.services.shellexecutor.ShellMain am instrument -w -e clearPackageData true ' \
-    "-e targetInstrumentation #{test_package_name}/#{runner_package_name} #{run_tests_in_batches} #{orchestrator_package_name}"
+    "-e targetInstrumentation #{test_package_name}/#{runner_package_name} #{test_filter} #{orchestrator_package_name}"
   )
 
   sh("adb exec-out sh -c 'cd #{adb_test_results_path} && tar cf - #{allure_results_path}' | tar xvf - -C .") if is_ci


### PR DESCRIPTION
### Goal

Fix AND-1445. The nightly `e2e-test-cron` was red on 11 of the last 13 runs, and PR batches fail intermittently with a rotating set of tests. Almost all recent nightly failures came from two tests: `ReconnectionTests#testReconnectionDuringCallRecording` and `RingingTests#testUserRejectsTheOutgoingAudioCall`.

### Implementation

Every reported failure means 3 consecutive `RetryRule` attempts failed. The main root cause is that the attempts were not independent. The instrumentation runs inside the app process (the test APK targets the app package), so the app cannot be killed between attempts. A failed attempt could leave the internet connection disabled (reconnection tests) or a call still active or ringing, and the next attempts inherited that state and failed the same way.

- `RetryRule` now recovers between attempts: it re-enables the internet connection and leaves any leftover active or ringing call through `StreamVideo.instanceOrNull()`. All post-failure steps (database cleanup, Allure attachments, attempt result) are now best-effort, so an error there can no longer replace the real failure or skip the remaining retries.
- The UiAutomator wait helpers are replaced with the polling, stale-safe versions from stream-chat-android (PRs 6383, 6570, 6588, 6594, 6603 there). `waitToAppear` polls and absorbs `StaleObjectException`, and a timeout now throws a clear error naming the selector and timeout instead of the misleading `findObject(...) must not be null` NPE seen in the nightly logs. All `UserRobot` clicks go through the new `waitToAppearAndClick`, which re-finds and re-clicks when the node goes stale.
- Wider wait windows on the paths that timed out in CI: joining a call (`waitForCallToStart`, 15s to 30s) and the outgoing ringing screen (20s to 30s, it failed mostly on API 28). The recording label assertion now polls, because the label briefly reads "Reconnecting.." after a network drop.
- `run_e2e_test` accepts a validated `test_class` option, and the PR workflow gets `api_level` and `test_class` dispatch inputs. Dispatching with a test class makes every batch job run only that test, giving independent samples of one flaky test on a chosen API level.
- Failure artifacts now include `fastlane/allure-results`, because TestOps deduplicates same-historyId results and the failed-attempt attachments disappear when the test passes elsewhere.
- The E2E concurrency groups are prefixed with the workflow name so different workflows on the same ref do not cancel each other.

Not covered here, tracked as follow-ups in AND-1445: a few nightly failures are app process crashes (the crash files are only on the device), and the buddy server has no status endpoints for explicit sync barriers.

### 🎨 UI Changes

Not applicable, test infrastructure only.

### Testing

Both top flaky tests pass locally on an API 35 emulator through the real fastlane flow (orchestrator, Allure runner, video-buddy participant), using the new `test_class` option:

- `ReconnectionTests#testReconnectionDuringCallRecording`: OK in 43s, including the network drop and restore.
- `RingingTests#testUserRejectsTheOutgoingAudioCall`: OK in 16.5s.

Since a flaky test passing twice is not proof by itself, the new workflow dispatch inputs are the follow-up verification tool: run the E2E workflow with `test_class` on the API levels where each test failed (32-34 for the reconnection test, 28 for the ringing one) to get repeated independent samples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional workflow inputs for selecting an Android API level and running a specific end-to-end test class.
  * Test runs now upload additional Allure results for improved reporting.

* **Bug Fixes**
  * Improved UI test stability with more reliable waits, clicks, retries, and call-state cleanup.
  * Increased select test timeouts and preserved original failures when recovery steps encounter errors.

* **Testing**
  * Enhanced support for targeted test execution and more resilient end-to-end test assertions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->