### PR TITLE
Fix the outgoing ringing state stuck on Connecting in join-and-ring

### DIFF
--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -16,12 +16,15 @@
 
 package io.getstream.video.android.robots
 
+import android.app.Notification
+import android.app.NotificationManager
 import androidx.test.uiautomator.BySelector
 import io.getstream.video.android.pages.CallPage
 import io.getstream.video.android.pages.CallPage.SettingsMenu
 import io.getstream.video.android.pages.RingPage
 import io.getstream.video.android.robots.UserControls.DISABLE
 import io.getstream.video.android.robots.UserControls.ENABLE
+import io.getstream.video.android.uiautomator.appContext
 import io.getstream.video.android.uiautomator.defaultTimeout
 import io.getstream.video.android.uiautomator.device
 import io.getstream.video.android.uiautomator.findObject
@@ -302,6 +305,30 @@ fun UserRobot.assertOutgoingCall(audioOnly: Boolean = true, isDisplayed: Boolean
             RingPage.declineCallButton.waitToDisappear().isDisplayed(),
         )
     }
+    return this
+}
+
+/**
+ * Asserts the presence of the outgoing call notification, which the outgoing call foreground
+ * service posts with the "Calling..." title (on the ongoing calls channel, see
+ * getSimpleOngoingCallNotification). The instrumentation runs inside the app process, so the
+ * check reads NotificationManager.activeNotifications directly instead of matching text in
+ * the notification shade, where the outgoing screen shows the same "Calling..." text.
+ * The service start and stop are asynchronous, so both directions poll.
+ */
+fun UserRobot.assertOutgoingCallNotification(isDisplayed: Boolean): UserRobot {
+    val title = appContext.getString(
+        io.getstream.video.android.core.R.string.stream_video_outgoing_call_notification_title,
+    )
+    val notificationManager = appContext.getSystemService(NotificationManager::class.java)
+    fun displayed() = notificationManager.activeNotifications.any {
+        it.notification.extras.getCharSequence(Notification.EXTRA_TITLE)?.toString() == title
+    }
+    val endTime = System.currentTimeMillis() + defaultTimeout
+    while (displayed() != isDisplayed && System.currentTimeMillis() < endTime) {
+        Thread.sleep(250)
+    }
+    assertEquals("Outgoing call notification displayed", isDisplayed, displayed())
     return this
 }
 

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -71,15 +71,23 @@ fun UserRobot.assertThatCallIsEnded(): UserRobot {
 }
 
 fun UserRobot.assertUserMicrophone(isEnabled: Boolean, videoCall: Boolean = true): UserRobot {
+    // The participant view icon updates slightly after the control toggle, so both
+    // checks poll instead of asserting the icon at the instant the toggle appears.
     if (isEnabled) {
-        assertTrue(CallPage.microphoneEnabledToggle.waitToAppear().isDisplayed())
+        assertTrue("Microphone enabled toggle", CallPage.microphoneEnabledToggle.waitDisplayed())
         if (videoCall) {
-            assertTrue(CallPage.ParticipantView.microphoneEnabledIcon.isDisplayed())
+            assertTrue(
+                "Participant microphone enabled icon",
+                CallPage.ParticipantView.microphoneEnabledIcon.waitDisplayed(),
+            )
         }
     } else {
-        assertTrue(CallPage.microphoneDisabledToggle.waitToAppear().isDisplayed())
+        assertTrue("Microphone disabled toggle", CallPage.microphoneDisabledToggle.waitDisplayed())
         if (videoCall) {
-            assertTrue(CallPage.ParticipantView.microphoneDisabledIcon.isDisplayed())
+            assertTrue(
+                "Participant microphone disabled icon",
+                CallPage.ParticipantView.microphoneDisabledIcon.waitDisplayed(),
+            )
         }
     }
     return this

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -29,6 +29,7 @@ import io.getstream.video.android.uiautomator.findObjects
 import io.getstream.video.android.uiautomator.isDisplayed
 import io.getstream.video.android.uiautomator.retryOnStaleObjectException
 import io.getstream.video.android.uiautomator.seconds
+import io.getstream.video.android.uiautomator.waitDisplayed
 import io.getstream.video.android.uiautomator.waitForCount
 import io.getstream.video.android.uiautomator.waitForText
 import io.getstream.video.android.uiautomator.waitToAppear
@@ -271,14 +272,17 @@ fun UserRobot.assertOutgoingCall(audioOnly: Boolean = true, isDisplayed: Boolean
             "Decline call button",
             RingPage.declineCallButton.waitToAppear(timeOutMillis = 30.seconds).isDisplayed(),
         )
-        assertTrue("Call label", RingPage.outgoingCallLabel.isDisplayed())
-        assertTrue("Avatar", RingPage.callParticipantAvatar.isDisplayed())
-        assertTrue("Microphone", RingPage.microphoneEnabledToggle.isDisplayed())
-        assertEquals(
-            "Camera should be displayed: ${!audioOnly}",
-            !audioOnly,
-            RingPage.cameraEnabledToggle.isDisplayed(),
-        )
+        // The control toggles reflect async call state (the microphone can still show the
+        // muted state right after the screen renders), so poll instead of instant asserts.
+        assertTrue("Call label", RingPage.outgoingCallLabel.waitDisplayed())
+        assertTrue("Avatar", RingPage.callParticipantAvatar.waitDisplayed())
+        assertTrue("Microphone", RingPage.microphoneEnabledToggle.waitDisplayed())
+        if (audioOnly) {
+            assertFalse("Camera enabled toggle", RingPage.cameraEnabledToggle.isDisplayed())
+            assertFalse("Camera disabled toggle", RingPage.cameraDisabledToggle.isDisplayed())
+        } else {
+            assertTrue("Camera", RingPage.cameraEnabledToggle.waitDisplayed())
+        }
     } else {
         assertFalse(
             "Decline call button",

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -206,7 +206,12 @@ fun UserRobot.assertRecordingView(isDisplayed: Boolean): UserRobot {
     if (isDisplayed) {
         // The backend composite recorder can take 20-30s to actually start and emit
         // call.recording_started, so the icon needs a longer window than the 5s default.
-        assertTrue(CallPage.recordingIcon.waitToAppear(timeOutMillis = 30.seconds).isDisplayed())
+        // waitDisplayed also absorbs stale reads: the node returned by waitToAppear could
+        // go stale before isDisplayed() and leak a StaleObjectException.
+        assertTrue(
+            "Recording icon",
+            CallPage.recordingIcon.waitDisplayed(timeOutMillis = 30.seconds),
+        )
         // After a network drop the label can briefly read "Reconnecting.." before it settles
         // back to "Recording", so poll instead of asserting on the first read.
         val callInfoText = CallPage.callInfoView.waitForText(

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/ReconnectionTests.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/ReconnectionTests.kt
@@ -113,9 +113,14 @@ class ReconnectionTests : StreamTestCase() {
             userRobot.joinCall()
         }
         step("AND participant joins the call") {
+            // The recording window counts from the participant's start request, and the
+            // composite recorder alone can take 20-30s to start. The window has to outlive
+            // the drop, the reconnect and the final polling assert on a slow CI emulator,
+            // otherwise the participant stops the recording on schedule before the assert
+            // and the test fails on a recording that legitimately ended.
             participantRobot
                 .setUserCount(participants)
-                .setCallRecordingDuration(30)
+                .setCallRecordingDuration(90)
                 .joinCall(callId, actions = arrayOf(Actions.RECORD_CALL))
         }
         step("AND participant starts recording a call") {

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/RingingTests.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/RingingTests.kt
@@ -21,6 +21,7 @@ import io.getstream.video.android.robots.assertAudioCallControls
 import io.getstream.video.android.robots.assertConnectingView
 import io.getstream.video.android.robots.assertIncomingCall
 import io.getstream.video.android.robots.assertOutgoingCall
+import io.getstream.video.android.robots.assertOutgoingCallNotification
 import io.getstream.video.android.robots.assertThatCallIsEnded
 import io.getstream.video.android.robots.assertVideoCallControls
 import io.qameta.allure.kotlin.Allure.step
@@ -80,11 +81,17 @@ class RingingTests : StreamTestCase() {
         step("THEN the outgoing call starts") {
             userRobot.assertOutgoingCall(audioOnly = true, isDisplayed = true)
         }
+        step("AND the outgoing call notification is displayed") {
+            userRobot.assertOutgoingCallNotification(isDisplayed = true)
+        }
         step("WHEN user rejects the outgoing call") {
             userRobot.declineOutgoingCall()
         }
         step("THEN the outgoing call ends") {
             userRobot.assertOutgoingCall(isDisplayed = false)
+        }
+        step("AND the outgoing call notification is dismissed") {
+            userRobot.assertOutgoingCallNotification(isDisplayed = false)
         }
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -1430,6 +1430,11 @@ public class CallState(
         } else {
             if (_ringingState.value is RingingState.Incoming && !acceptedOnThisDevice) {
                 RingingState.TimeoutNoAnswer
+            } else if (isJoinAndRingInProgress.get() && _ringingState.value is RingingState.Outgoing) {
+                // During join-and-ring the SFU join sets Outgoing before the ring request has
+                // registered this call in client.state.ringingCall, so hasRingingCall is still
+                // false here. Falling back to Idle would hide the outgoing ringing UI.
+                _ringingState.value
             } else {
                 RingingState.Idle
             }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/CallState.kt
@@ -86,6 +86,7 @@ import io.getstream.video.android.core.call.CallType
 import io.getstream.video.android.core.call.RtcSession
 import io.getstream.video.android.core.closedcaptions.ClosedCaptionManager
 import io.getstream.video.android.core.closedcaptions.ClosedCaptionsSettings
+import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.events.AudioLevelChangedEvent
 import io.getstream.video.android.core.events.CallEndedSfuEvent
 import io.getstream.video.android.core.events.ConnectionQualityChangeEvent
@@ -131,7 +132,6 @@ import io.getstream.video.android.core.utils.toUser
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.User
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.currentCoroutineContext
@@ -1354,7 +1354,6 @@ public class CallState(
             _session.value?.participants?.find { it.user.id == client.userId } != null
         val outgoingMembersCount = _members.value.filter { it.value.user.id != client.userId }.size
         val isCallEnded: Boolean = _endedAt.value != null
-        val createdBySelf = createdBy?.id == client.userId
 
         ringingLogger.d { "Current: ${_ringingState.value}, call_id: ${call.cid}" }
 
@@ -1903,12 +1902,12 @@ public class CallState(
     private fun observeTelecomHold(repo: JetpackTelecomRepository) {
         telecomHoldObserverJob?.cancel()
 
-        telecomHoldObserverJob = scope.launch(Dispatchers.Default) {
+        telecomHoldObserverJob = scope.launch(DispatcherProvider.Default) {
             repo.currentCall
                 .map { (it as? TelecomCall.Registered)?.isOnHold == true }
                 .distinctUntilChanged()
                 .filter { it }
-                .collect { isOnHold ->
+                .collect { _ ->
                     when (ringingState.value) {
                         is RingingState.Active -> {
                             call.leave(CallLeaveReason.SdkDriven(cause = SdkCause.CALL_ON_HOLD))

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
@@ -327,7 +327,11 @@ internal class CallJoinCoordinator(
             logger.d { "[joinAndRing] Joined #ringing; #track; ring: $members" }
             apiClient.ring(RingCallRequest(isVideoEnabled(), members)).map {
                 logger.d { "[joinAndRing] Ringed #ringing; #track; ring: $members" }
-                callRegistry.markRinging()
+                // registerOutgoingRing registers the ringing call AND starts the outgoing call
+                // foreground service, like the create-with-ring path does. markRinging alone
+                // never started the service here, so the caller had no outgoing notification
+                // (setActiveCall logs "Outgoing call service should already be running").
+                callRegistry.registerOutgoingRing()
                 // An event that arrived before the ring completed (e.g. call.session_started)
                 // computed the ringing state without the ringing call registered. Recompute so
                 // the state cannot stay Idle when no further coordinator event arrives.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
@@ -328,6 +328,10 @@ internal class CallJoinCoordinator(
             apiClient.ring(RingCallRequest(isVideoEnabled(), members)).map {
                 logger.d { "[joinAndRing] Ringed #ringing; #track; ring: $members" }
                 callRegistry.markRinging()
+                // An event that arrived before the ring completed (e.g. call.session_started)
+                // computed the ringing state without the ringing call registered. Recompute so
+                // the state cannot stay Idle when no further coordinator event arrives.
+                state.updateRingingState()
                 rtcSession
             }.onError {
                 logger.e { "[joinAndRing] Ring failed #ringing; #track; error: $it" }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
@@ -347,10 +347,8 @@ internal class CallJoinCoordinator(
     }
 
     fun isPermanentError(error: Any): Boolean {
-        if (error is Error.ThrowableError) {
-            if (error.message.contains("Unable to resolve host")) {
-                return false
-            }
+        if (error is Error.ThrowableError && error.message.contains("Unable to resolve host")) {
+            return false
         }
         return true
     }
@@ -501,17 +499,17 @@ internal class CallJoinCoordinator(
                     }
                 }
 
-                if (sfuConnectionResult.cause != SfuConnectFailureCause.TerminalSocketFailure) {
-                    if (!didReconnectSucceed()) {
-                        logger.e { "[_join] Could not recover. Error : $sfuConnectionResult" }
-                        sendJoinErrorAnalytics(sfuConnectionResult)
-                        discardFailedSession(localSession)
-                        return Failure(
-                            Error.GenericError(
-                                sfuConnectionResult.error.message ?: "SFU connection failed",
-                            ),
-                        )
-                    }
+                if (sfuConnectionResult.cause != SfuConnectFailureCause.TerminalSocketFailure &&
+                    !didReconnectSucceed()
+                ) {
+                    logger.e { "[_join] Could not recover. Error : $sfuConnectionResult" }
+                    sendJoinErrorAnalytics(sfuConnectionResult)
+                    discardFailedSession(localSession)
+                    return Failure(
+                        Error.GenericError(
+                            sfuConnectionResult.error.message ?: "SFU connection failed",
+                        ),
+                    )
                 }
             }
         }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinator.kt
@@ -503,9 +503,9 @@ internal class CallJoinCoordinator(
                     }
                 }
 
-                if (sfuConnectionResult.cause != SfuConnectFailureCause.TerminalSocketFailure &&
-                    !didReconnectSucceed()
-                ) {
+                // A terminal failure already returned above, so only recoverable causes
+                // reach this point and the recovery outcome is the only condition left.
+                if (!didReconnectSucceed()) {
                     logger.e { "[_join] Could not recover. Error : $sfuConnectionResult" }
                     sendJoinErrorAnalytics(sfuConnectionResult)
                     discardFailedSession(localSession)

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallStateTelecomHoldTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/CallStateTelecomHoldTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core
+
+import io.getstream.android.video.generated.models.VideoEvent
+import io.getstream.video.android.core.base.TestBase
+import io.getstream.video.android.core.base.toResponse
+import io.getstream.video.android.core.notifications.internal.telecom.jetpack.JetpackTelecomRepository
+import io.getstream.video.android.core.notifications.internal.telecom.jetpack.TelecomCall
+import io.getstream.video.android.core.utils.toResponse
+import io.getstream.video.android.model.User
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.test.assertTrue
+
+/**
+ * Verifies the telecom hold observer: when Android Telecom puts the call on hold while it is
+ * active, the SDK leaves the call with [SdkCause.CALL_ON_HOLD].
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class CallStateTelecomHoldTest : TestBase() {
+
+    private val scope = CoroutineScope(dispatcherRule.testDispatcher)
+
+    private val user = User(id = "caller", createdAt = nowUtc, updatedAt = nowUtc)
+
+    private val activeCall = MutableStateFlow<Call?>(null)
+    private val ringingCall = MutableStateFlow<Call?>(null)
+
+    private val clientState = mockk<ClientState>(relaxed = true) {
+        every { activeCall } returns this@CallStateTelecomHoldTest.activeCall
+        every { ringingCall } returns this@CallStateTelecomHoldTest.ringingCall
+    }
+    private val client = mockk<StreamVideoClient>(relaxed = true) {
+        every { userId } returns this@CallStateTelecomHoldTest.user.id
+        every { state } returns clientState
+    }
+    private val call = mockk<Call>(relaxed = true) {
+        every { type } returns "default"
+        every { id } returns "telecom-hold-test"
+        every { cid } returns "default:telecom-hold-test"
+        every { events } returns MutableSharedFlow<VideoEvent>()
+    }
+
+    @After
+    fun tearDownScope() {
+        scope.cancel()
+    }
+
+    @Test
+    fun `putting an active call on hold leaves the call with CALL_ON_HOLD`() {
+        val callState = CallState(client, call, user, scope)
+        callState.updateFromResponse(call.toResponse(user.toResponse()))
+        activeCall.value = call
+        callState.updateRingingState()
+        assertTrue(callState.ringingState.value is RingingState.Active)
+
+        val heldCall = mockk<TelecomCall.Registered> { every { isOnHold } returns true }
+        callState.jetpackTelecomRepository = mockk<JetpackTelecomRepository> {
+            every { currentCall } returns MutableStateFlow<TelecomCall>(heldCall)
+        }
+
+        // The observer runs on DispatcherProvider.Default (a real dispatcher here), so the
+        // verification has to wait for it.
+        verify(timeout = 5_000L) {
+            call.leave(
+                match<CallLeaveReason> {
+                    it is CallLeaveReason.SdkDriven && it.cause == SdkCause.CALL_ON_HOLD
+                },
+            )
+        }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/RingingStateJoinAndRingTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/RingingStateJoinAndRingTest.kt
@@ -113,6 +113,20 @@ internal class RingingStateJoinAndRingTest : TestBase() {
     }
 
     @Test
+    fun `a recompute before the SFU join sets Outgoing still yields Idle`() {
+        val callState = CallState(client, call, user, scope)
+        callState.updateFromResponse(call.toResponse(user.toResponse()))
+        callState.toggleJoinAndRingProgress(true)
+        activeCall.value = call
+
+        // Join-and-ring is in progress but nothing set Outgoing yet, so the guard must not
+        // apply and the state stays Idle (the UI legitimately shows the loading screen).
+        callState.updateRingingState()
+
+        assertTrue(callState.ringingState.value is RingingState.Idle)
+    }
+
+    @Test
     fun `an event arriving before the ring request completes keeps the Outgoing state`() {
         val callState = callStateInJoinAndRingWindow()
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/RingingStateJoinAndRingTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/RingingStateJoinAndRingTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core
+
+import io.getstream.android.video.generated.models.VideoEvent
+import io.getstream.video.android.core.base.TestBase
+import io.getstream.video.android.core.base.toResponse
+import io.getstream.video.android.core.events.JoinCallResponseEvent
+import io.getstream.video.android.core.events.ParticipantCount
+import io.getstream.video.android.core.utils.toResponse
+import io.getstream.video.android.model.User
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineExceptionHandler
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.concurrent.CopyOnWriteArrayList
+import kotlin.test.assertTrue
+
+/**
+ * Regression tests for the ringing state during the join-and-ring flow.
+ *
+ * In join-and-ring the SFU join response sets the ringing state to [RingingState.Outgoing]
+ * directly, but the ring request that registers the call in `client.state.ringingCall` completes
+ * later. A coordinator event landing in that window (e.g. `call.session_started`) recomputes the
+ * ringing state with `hasRingingCall = false` and used to downgrade Outgoing back to Idle, leaving
+ * the caller stuck on the loading UI (AND-1454).
+ */
+@RunWith(RobolectricTestRunner::class)
+internal class RingingStateJoinAndRingTest : TestBase() {
+
+    // Coroutines launched by CallState land here instead of the global uncaught handler,
+    // where the test framework would attribute them to whichever runTest enters next.
+    private val uncaughtExceptions = CopyOnWriteArrayList<Throwable>()
+    private val scope = CoroutineScope(
+        SupervisorJob() +
+            dispatcherRule.testDispatcher +
+            CoroutineExceptionHandler { _, e -> uncaughtExceptions += e },
+    )
+
+    private val user = User(id = "caller", createdAt = nowUtc, updatedAt = nowUtc)
+
+    private val activeCall = MutableStateFlow<Call?>(null)
+    private val ringingCall = MutableStateFlow<Call?>(null)
+
+    private val clientState = mockk<ClientState>(relaxed = true) {
+        every { activeCall } returns this@RingingStateJoinAndRingTest.activeCall
+        every { ringingCall } returns this@RingingStateJoinAndRingTest.ringingCall
+    }
+    private val client = mockk<StreamVideoClient>(relaxed = true) {
+        every { userId } returns this@RingingStateJoinAndRingTest.user.id
+        every { state } returns clientState
+    }
+    private val call = mockk<Call>(relaxed = true) {
+        every { type } returns "default"
+        every { id } returns "join-and-ring-test"
+        every { cid } returns "default:join-and-ring-test"
+        // A real flow: SharedFlow.collect returns Nothing, so collecting the relaxed
+        // mock would throw KotlinNothingValueException from CallState's sorter coroutine.
+        every { events } returns MutableSharedFlow<VideoEvent>()
+    }
+
+    @After
+    fun tearDownScope() {
+        scope.cancel()
+        assertTrue(
+            uncaughtExceptions.isEmpty(),
+            "CallState coroutines threw: $uncaughtExceptions",
+        )
+    }
+
+    private fun callStateInJoinAndRingWindow(): CallState {
+        val callState = CallState(client, call, user, scope)
+        // The call was created by us; nobody accepted or rejected yet.
+        callState.updateFromResponse(call.toResponse(user.toResponse()))
+        // joinAndRing() toggled the flag and the join completed (active call registered),
+        // but the ring request has not completed yet, so ringingCall is still null.
+        callState.toggleJoinAndRingProgress(true)
+        activeCall.value = call
+        // The SFU join response transitions the ringing state to Outgoing directly.
+        callState.handleEvent(
+            JoinCallResponseEvent(
+                callState = stream.video.sfu.models.CallState(),
+                participantCount = ParticipantCount(total = 1, anonymous = 0),
+                fastReconnectDeadlineSeconds = 0,
+                isReconnected = false,
+                publishOptions = emptyList(),
+            ),
+        )
+        assertTrue(callState.ringingState.value is RingingState.Outgoing)
+        return callState
+    }
+
+    @Test
+    fun `an event arriving before the ring request completes keeps the Outgoing state`() {
+        val callState = callStateInJoinAndRingWindow()
+
+        // A coordinator event (e.g. call.session_started) recomputes the ringing state while
+        // ringingCall is still null. It used to downgrade Outgoing -> Idle.
+        callState.updateRingingState()
+
+        assertTrue(callState.ringingState.value is RingingState.Outgoing)
+    }
+
+    @Test
+    fun `recomputing after the ring request registers the ringing call yields Outgoing`() {
+        val callState = callStateInJoinAndRingWindow()
+        // Simulate the clobber the old code produced, so the recovery path is exercised even
+        // if the guard above changes.
+        callState.updateRingingState()
+
+        // joinAndRing() registers the ringing call on ring success and recomputes.
+        ringingCall.value = call
+        callState.updateRingingState()
+
+        val state = callState.ringingState.value
+        assertTrue(state is RingingState.Outgoing && !state.acceptedByCallee)
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinatorTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinatorTest.kt
@@ -677,6 +677,9 @@ class CallJoinCoordinatorTest {
 
         assertThat(result).isInstanceOf(Success::class.java)
         coVerify { apiClient.ring(any<RingCallRequest>()) }
+        // registerOutgoingRing (not markRinging) so the outgoing call foreground service
+        // starts and the caller gets the outgoing call notification, like create-with-ring.
+        verify { callRegistry.registerOutgoingRing() }
     }
 
     @Test

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinatorTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallJoinCoordinatorTest.kt
@@ -285,9 +285,11 @@ class CallJoinCoordinatorTest {
     ) {
         val coordinator = coordinator()
         val transient = Error.ThrowableError("Unable to resolve host", Exception("dns"))
+        val permanentThrowable = Error.ThrowableError("socket reset", Exception("io"))
         val permanent = Error.GenericError("server error")
 
         assertThat(coordinator.isPermanentError(transient)).isFalse()
+        assertThat(coordinator.isPermanentError(permanentThrowable)).isTrue()
         assertThat(coordinator.isPermanentError(permanent)).isTrue()
     }
 
@@ -639,6 +641,28 @@ class CallJoinCoordinatorTest {
         verify { mockSession.cleanup() }
         verify { replacement.cleanup() }
         assertThat(sessionFlow.value).isNull()
+    }
+
+    @Test
+    fun `join succeeds when a recoverable socket failure recovers`() = runTest(
+        testDispatcher,
+    ) {
+        stubJoinCall(Success(mockJoinResponse))
+        coEvery { mockSession.connectInternal() } coAnswers {
+            // The reconnect settled as Connected before recovery was evaluated.
+            connectionFlow.value = RealtimeConnection.Connected
+            SfuConnectionResult.Failure(
+                Exception("recoverable socket failure"),
+                cause = SfuConnectFailureCause.RecoverableSocketFailure,
+            )
+        }
+
+        val result = coordinator().joinInternal(
+            joinAnalyticsModel = JoinAnalyticsModel(0, JoinReason.FirstAttempt),
+        )
+        advanceUntilIdle()
+
+        assertThat(result).isInstanceOf(Success::class.java)
     }
 
     @Test


### PR DESCRIPTION
### Goal

Fix AND-1454. After #1782 the nightly E2E run is green on API 28, 31 and 32, but [run 33062751723](https://github.com/GetStream/stream-video-android/actions/runs/33062751723) still fails on API 33, 34 and 35 with two issues in the outgoing ringing tests.

### Implementation

**Issue 1: the outgoing call UI stays on "Connecting..." while the call is already connected.** The run artifacts show the exact sequence. In the join-and-ring flow the SFU `JoinCallResponseEvent` sets the ringing state to `Outgoing` directly, but the ring request registers the call in `client.state.ringingCall` only later. In the failing attempts a `call.session_started` coordinator event landed in that window, re-ran `updateRingingState()` with `hasRingingCall = false`, and downgraded Outgoing back to Idle (logcat: `Updating ringing state Outgoing -> Idle`). Nothing recomputed the state afterwards and no `CallRingEvent` is delivered to the caller, so the state stayed Idle and the UI rendered the full screen "Connecting..." (`LoadingContent`) until the 30s wait for `Stream_DeclineCallButton` timed out. Passing runs recovered only because some later event happened to re-run `updateRingingState()` after the ring completed.

Two changes in the core:

- `CallState.updateRingingState()` keeps the current Outgoing state instead of falling back to Idle while join-and-ring is in progress and the ringing call is not registered yet.
- `CallJoinCoordinator.joinAndRing()` recomputes the ringing state right after the ring request succeeds, so the state recovers deterministically without depending on a later coordinator event.

**Issue 2: instant asserts in `assertOutgoingCall` race the async control state.** On API 34 the outgoing screen was rendered but the microphone toggle still showed the muted state at the instant the check ran. The label, avatar, microphone and camera checks now poll with `waitDisplayed`, the same pattern AND-1445 applied to the settings menu guards.

The `testUserAcceptsTheIncomingVideoCall` failure seen on #1776 is a different bucket (leave-when-last-in-call firing during an SFU reconnect) and is tracked in AND-1455.

**Further nightly buckets fixed on this branch** (found while verifying the fix with nightly runs on the branch):

- `assertUserMicrophone` polled the control toggle but checked the participant view icon with an instant `isDisplayed()`. The hierarchy dumps taken right after the failures already contained the expected icon, so the state arrives and only the instant check misses it. Both checks poll now. This bucket failed `testCameraAndMicrophoneConfigurationInLobby` (all 3 attempts, API 32) and `testUserMicrophone` (all 3 attempts on PR #1764, plus single attempts on several API levels).
- `assertRecordingView` could leak a raw `StaleObjectException` from `waitToAppear(...).isDisplayed()` and hide the real failure. It uses the stale-safe `waitDisplayed` now.
- The caller had no outgoing call notification in the join-and-ring flow: the notification is posted by the foreground service started with `TRIGGER_OUTGOING_CALL`, which only `registerOutgoingRing()` starts, and only the create-with-ring path called it. On develop this was sometimes masked when the ringing state flapped to Idle and the ongoing service started instead; with the deterministic Outgoing state it never rendered. `joinAndRing` now calls `registerOutgoingRing()` on ring success, and the outgoing ringing E2E test asserts the notification is shown while ringing and dismissed after the decline.
- A second cause behind the reconnection test flake (the connection state staying "Reconnecting.." after a recovered reconnect) is fixed separately in #1802, split out on review request because it changes `RtcSession`. Until #1802 merges, that bucket can still occasionally exhaust a Test compose batch here; a re-run covers it.
- `testReconnectionDuringCallRecording` raced its own recording window: the buddy stops the recording 30s after its start request, the composite recorder needs 20-30s to start, and the drop plus reconnect plus asserts consumed the rest on slow emulators. The recording actually survives the reconnect fine (it is server side and the recording participant stays online). The window is now 90s. For comparison, neither the JS nor the Swift SDK has a reconnect-plus-recording scenario or any reconnect-time recording handling, so no SDK change is needed for this one.

For the core change, the Swift SDK confirms the approach: its `joinAndRingCall` sets the outgoing state explicitly and suppresses competing call state updates while the ring is in flight (`skipCallStateUpdates` in `CallViewModel`), which is the same principle as keeping Outgoing authoritative during join-and-ring here. The JS SDK avoids the bug class entirely by using explicit state transitions instead of recomputing from flags.

### 🎨 UI Changes

Not applicable. No visual changes, the fix removes a state where the outgoing ringing UI never appeared.

### Testing

- New `RingingStateJoinAndRingTest` reproduces the race on a real `CallState` with a mocked client: one test asserts that a recompute in the pre-ring window keeps Outgoing, one asserts that the recompute after `markRinging()` yields `Outgoing(acceptedByCallee = false)`. Both fail without the fix and pass with it.
- Full `:stream-video-android-core` unit test suite and `apiCheck` pass locally, and the E2E androidTest source set compiles.
- `CallStateTelecomHoldTest` and the `CallJoinCoordinatorTest` additions cover the remaining touched branches.
- Verified locally on an API 35 emulator through the real fastlane flow: the outgoing ringing test fails at the notification assert with the old code and passes with the fix.
- CI verification: dispatch the E2E workflow on this branch with `test_class: io.getstream.video.android.tests.RingingTests` on API 33, 34 and 35, where the nightly failed. The full branch nightly (run 33155106721) was green on 5 of 6 API levels before the notification and ICE fixes; the remaining bucket is AND-1455.

### How to reproduce the issues and verify the fixes

**The stuck "Connecting..." bug (state race).** It rarely fires naturally on a fast local emulator, so either use CI sampling or widen the window locally:

- CI: dispatch the "E2E Tests" workflow with `test_class: io.getstream.video.android.tests.RingingTests#testUserRejectsTheOutgoingAudioCall` and `api_level: 35`. On develop it failed 3 of 3 batch jobs (runs 33062751723 and 33142442425, where API 28 failed 3 of 3 too). On this branch the same dispatch passes, and the full branch nightly (run 33155106721) is green on all six API levels for the ringing tests.
- Manual: on develop, apply the patch below to make the race deterministic, then start a Direct Call (the "Join first" checkbox is on by default). The caller sticks on the full screen "Connecting..." forever. Same patch on this branch shows the outgoing screen.

<details>
<summary>Patch to make the race deterministic</summary>

```kotlin
// CallJoinCoordinator.joinAndRing: delay the ring request so call.session_started
// always lands in the window between the SFU join response and the ring completion.
).flatMap { rtcSession ->
    logger.d { "[joinAndRing] Joined #ringing; #track; ring: $members" }
    delay(3_000) // repro only
    apiClient.ring(RingCallRequest(isVideoEnabled(), members)).map {
```

</details>

**The missing outgoing call notification.** Deterministic, no patch needed: on develop (or this branch before commit e6c6ad9cee), start a Direct Call with "Join first" checked. No caller notification appears, and logcat prints `Outgoing call service should already be running`. With the fix the "Calling..." notification appears while ringing and disappears after the decline. The E2E test now asserts exactly that, verified locally on an API 35 emulator through the real fastlane flow: the test fails at the notification assert with the old code and passes with the fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved outgoing call behavior so the ringing interface remains visible while a join-and-ring call is being established.
  - Ensured ringing state updates correctly after the call request is registered.
  - Improved call controls’ display behavior, including correct camera visibility for audio-only calls.
  - Reduced timing-related issues when displaying outgoing call labels, avatars, and microphone controls.

- **Tests**
  - Added regression coverage for join-and-ring state handling and outgoing call controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->




