### PR TITLE
Suppress the last participant auto leave while the call is reconnecting

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,6 +49,7 @@ streamProject {
     coverage {
         includedModules = setOf(
             "stream-video-android-core",
+            "stream-video-android-ui-core",
             "stream-video-android-ui-compose",
         )
         sonarExclusions = listOf(

--- a/stream-video-android-ui-core/build.gradle.kts
+++ b/stream-video-android-ui-core/build.gradle.kts
@@ -52,4 +52,10 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
 
     implementation(libs.stream.log)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.mockk)
+    testImplementation(libs.turbine)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.kotlin.test.junit)
 }

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -78,9 +78,9 @@ import io.getstream.video.android.ui.common.StreamCallActivity.Companion.callInt
 import io.getstream.video.android.ui.common.models.StreamCallActivityException
 import io.getstream.video.android.ui.common.permission.PermissionManager
 import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
+import io.getstream.video.android.ui.common.util.lastParticipantSignal
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -88,7 +88,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -1478,15 +1477,17 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
     /**
      * Processes participant leave events for the given [call].
      *
-     * Observes [cachedCall.state.participants] and triggers [onLastParticipant] if only
-     * one or fewer participants remain. Debouncing is applied to handle quick network
-     * disconnect/reconnect scenarios.
+     * Observes [cachedCall.state.participants] together with the connection state and triggers
+     * [onLastParticipant] if only one or fewer participants remain while the connection is
+     * settled. Debouncing is applied to handle quick network disconnect/reconnect scenarios,
+     * and the check is suppressed while the connection is reconnecting or migrating, because
+     * the roster is unreliable then and leaving would cancel the reconnect. See
+     * [lastParticipantSignal].
      *
      * @param call the active [Call] associated with the event.
      * @param event the [VideoEvent] that triggered this processing, typically a [ParticipantLeftEvent]
      *              or [CallSessionParticipantLeftEvent].
      */
-    @OptIn(FlowPreview::class)
     private fun processParticipantLeftEvent(call: Call, event: VideoEvent) {
         /**
          * - participantCountJob will be null when activity is newly created
@@ -1494,25 +1495,23 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
          */
         if (participantCountJob == null) {
             participantCountJob = lifecycleScope.launch(supervisorJob) {
-                cachedCall.state.participants
-                    /**
-                     * A debounce is applied here to handle quick disconnect/reconnect scenarios
-                     * caused by unstable network conditions. Without the debounce, other devices
-                     * may receive a [ParticipantLeftEvent] prematurely, which could trigger
-                     * unintended reactions in the call flow.
-                     */
-                    .debounce(getParticipantUpdateDebounce(call))
-                    .collect {
-                        logger.d { "Participant left, remaining: ${it.size}" }
+                lastParticipantSignal(
+                    participants = cachedCall.state.participants,
+                    connection = cachedCall.state.connection,
+                    debounceMs = getParticipantUpdateDebounce(call),
+                    onEvaluated = { roster, connection ->
+                        logger.d {
+                            "Participant left, remaining: ${roster.size}, connection: $connection"
+                        }
                         lifecycleScope.launch(Dispatchers.Default) {
-                            it.forEachIndexed { i, v ->
+                            roster.forEachIndexed { i, v ->
                                 logger.d { "Participant [$i]=${v.name.value}" }
                             }
                         }
-                        if (it.size <= 1) {
-                            onLastParticipant(call)
-                        }
-                    }
+                    },
+                ).collect {
+                    onLastParticipant(call)
+                }
             }
         }
     }

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/StreamCallActivity.kt
@@ -1479,10 +1479,10 @@ public abstract class StreamCallActivity : ComponentActivity(), ActivityCallOper
      *
      * Observes [cachedCall.state.participants] together with the connection state and triggers
      * [onLastParticipant] if only one or fewer participants remain while the connection is
-     * settled. Debouncing is applied to handle quick network disconnect/reconnect scenarios,
-     * and the check is suppressed while the connection is reconnecting or migrating, because
-     * the roster is unreliable then and leaving would cancel the reconnect. See
-     * [lastParticipantSignal].
+     * [RealtimeConnection.Connected]. Debouncing is applied to handle quick network
+     * disconnect/reconnect scenarios, and the check requires a connected state because the
+     * roster is unreliable while a join or reconnect is running and leaving would cancel it.
+     * See [lastParticipantSignal].
      *
      * @param call the active [Call] associated with the event.
      * @param event the [VideoEvent] that triggered this processing, typically a [ParticipantLeftEvent]

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignal.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignal.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.ui.common.util
+
+import io.getstream.video.android.core.ParticipantState
+import io.getstream.video.android.core.RealtimeConnection
+import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+
+/**
+ * Emits the participant roster whenever the local user has become the last participant in the
+ * call while the connection is settled.
+ *
+ * Roster changes are debounced by [debounceMs] to absorb quick disconnect/reconnect flaps.
+ * Emissions are suppressed while the connection is [RealtimeConnection.Reconnecting] or
+ * [RealtimeConnection.Migrating]: during a reconnect the roster is unreliable (the rejoin
+ * removes the previous local participant record, and remote participants of the failing SFU
+ * may not have rejoined yet), and acting on it would leave the call and cancel the reconnect
+ * that is still running in the call scope. The connection state is part of the combined
+ * stream, so the roster is re-evaluated once the reconnect settles and a genuine
+ * last-participant state still emits.
+ *
+ * @param participants the participant roster of the call.
+ * @param connection the realtime connection state of the call.
+ * @param debounceMs debounce applied to the combined stream before evaluation.
+ * @param onEvaluated invoked for every debounced evaluation, regardless of the outcome.
+ */
+@OptIn(FlowPreview::class)
+internal fun lastParticipantSignal(
+    participants: Flow<List<ParticipantState>>,
+    connection: Flow<RealtimeConnection>,
+    debounceMs: Long,
+    onEvaluated: suspend (List<ParticipantState>, RealtimeConnection) -> Unit = { _, _ -> },
+): Flow<List<ParticipantState>> =
+    combine(participants, connection) { roster, connectionState -> roster to connectionState }
+        .debounce(debounceMs)
+        .onEach { (roster, connectionState) -> onEvaluated(roster, connectionState) }
+        .filter { (roster, connectionState) ->
+            roster.size <= 1 && !connectionState.isReconnectInProgress()
+        }
+        .map { (roster, _) -> roster }
+
+private fun RealtimeConnection.isReconnectInProgress(): Boolean =
+    this is RealtimeConnection.Reconnecting || this is RealtimeConnection.Migrating

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignal.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignal.kt
@@ -22,10 +22,9 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
-import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.runningFold
 
 /**
  * Emits the participant roster whenever the local user has become the last participant in the
@@ -39,8 +38,12 @@ import kotlinx.coroutines.flow.onEach
  * join or reconnect that is still running in the call scope. Terminal states need no signal
  * from here: the reconnector leaves the call itself when retries are exhausted. The
  * connection state is part of the combined stream, so the roster is re-evaluated once the
- * connection settles and a genuine last-participant state still emits, while an unchanged
- * roster is not emitted twice across connection transitions.
+ * connection settles and a genuine last-participant state still emits.
+ *
+ * The signal is a rising edge of the roster, not of the combined condition: becoming the last
+ * participant arms it, and it fires on the first connected evaluation after that. A connection
+ * transition with an unchanged roster therefore does not repeat the signal, while a remote
+ * participant joining and leaving again re-arms it and does signal a second time.
  *
  * @param participants the participant roster of the call.
  * @param connection the realtime connection state of the call.
@@ -57,8 +60,33 @@ internal fun lastParticipantSignal(
     combine(participants, connection) { roster, connectionState -> roster to connectionState }
         .debounce(debounceMs)
         .onEach { (roster, connectionState) -> onEvaluated(roster, connectionState) }
-        .filter { (roster, connectionState) ->
-            roster.size <= 1 && connectionState is RealtimeConnection.Connected
+        .runningFold(LastParticipantState()) { previous, (roster, connectionState) ->
+            val isLast = roster.size <= 1
+            // Arm on the rising edge of the roster and stay armed until a connected
+            // evaluation consumes it, so a signal found mid-reconnect is not lost.
+            val armed = when {
+                !isLast -> false
+                !previous.wasLast -> true
+                else -> previous.armed
+            }
+            val connected = connectionState is RealtimeConnection.Connected
+            LastParticipantState(
+                wasLast = isLast,
+                armed = armed && !connected,
+                signal = roster.takeIf { armed && connected },
+            )
         }
-        .map { (roster, _) -> roster }
-        .distinctUntilChanged()
+        .mapNotNull { it.signal }
+
+/**
+ * Fold state of [lastParticipantSignal].
+ *
+ * @param wasLast whether the previous evaluation saw a last-participant roster.
+ * @param armed whether a last-participant roster is waiting for a connected evaluation.
+ * @param signal the roster to emit for this evaluation, or null when there is nothing to emit.
+ */
+private data class LastParticipantState(
+    val wasLast: Boolean = false,
+    val armed: Boolean = false,
+    val signal: List<ParticipantState>? = null,
+)

--- a/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignal.kt
+++ b/stream-video-android-ui-core/src/main/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignal.kt
@@ -22,22 +22,25 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 
 /**
  * Emits the participant roster whenever the local user has become the last participant in the
- * call while the connection is settled.
+ * call while the connection is [RealtimeConnection.Connected].
  *
  * Roster changes are debounced by [debounceMs] to absorb quick disconnect/reconnect flaps.
- * Emissions are suppressed while the connection is [RealtimeConnection.Reconnecting] or
- * [RealtimeConnection.Migrating]: during a reconnect the roster is unreliable (the rejoin
- * removes the previous local participant record, and remote participants of the failing SFU
- * may not have rejoined yet), and acting on it would leave the call and cancel the reconnect
- * that is still running in the call scope. The connection state is part of the combined
- * stream, so the roster is re-evaluated once the reconnect settles and a genuine
- * last-participant state still emits.
+ * Emissions require a connected state because the roster is unreliable at any other point:
+ * during the initial join it is still being populated, and during a reconnect the rejoin
+ * removes the previous local participant record and remote participants of the failing SFU
+ * may not have rejoined yet. Acting on the roster then would leave the call and cancel the
+ * join or reconnect that is still running in the call scope. Terminal states need no signal
+ * from here: the reconnector leaves the call itself when retries are exhausted. The
+ * connection state is part of the combined stream, so the roster is re-evaluated once the
+ * connection settles and a genuine last-participant state still emits, while an unchanged
+ * roster is not emitted twice across connection transitions.
  *
  * @param participants the participant roster of the call.
  * @param connection the realtime connection state of the call.
@@ -55,9 +58,7 @@ internal fun lastParticipantSignal(
         .debounce(debounceMs)
         .onEach { (roster, connectionState) -> onEvaluated(roster, connectionState) }
         .filter { (roster, connectionState) ->
-            roster.size <= 1 && !connectionState.isReconnectInProgress()
+            roster.size <= 1 && connectionState is RealtimeConnection.Connected
         }
         .map { (roster, _) -> roster }
-
-private fun RealtimeConnection.isReconnectInProgress(): Boolean =
-    this is RealtimeConnection.Reconnecting || this is RealtimeConnection.Migrating
+        .distinctUntilChanged()

--- a/stream-video-android-ui-core/src/test/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignalTest.kt
+++ b/stream-video-android-ui-core/src/test/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignalTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.ui.common.util
+
+import app.cash.turbine.test
+import io.getstream.video.android.core.ParticipantState
+import io.getstream.video.android.core.RealtimeConnection
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * Regression tests for the [lastParticipantSignal] gating (AND-1455): with
+ * `leaveWhenLastInCall = true`, a leave triggered while an SFU reconnect is in flight cancels
+ * the reconnect loop in the call scope and leaves the UI stuck on "Connecting...". The signal
+ * must stay silent while the connection is reconnecting or migrating and re-evaluate the
+ * roster once the connection settles.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class LastParticipantSignalTest {
+
+    private val debounceMs = 1_000L
+    private val local = mockk<ParticipantState>()
+    private val remote = mockk<ParticipantState>()
+
+    @Test
+    fun `emits when the last participant remains while connected`() = runTest {
+        val participants = MutableStateFlow(listOf(local, remote))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            participants.value = listOf(local)
+
+            advanceTimeBy(debounceMs + 1)
+            assertEquals(1, awaitItem().size)
+        }
+    }
+
+    @Test
+    fun `does not emit while more than one participant is in the call`() = runTest {
+        val participants = MutableStateFlow(listOf(local, remote))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `does not emit while the connection is reconnecting`() = runTest {
+        val participants = MutableStateFlow(listOf(local, remote))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            connection.value = RealtimeConnection.Reconnecting
+            participants.value = listOf(local)
+
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `does not emit while the connection is migrating`() = runTest {
+        val participants = MutableStateFlow(listOf(local, remote))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            connection.value = RealtimeConnection.Migrating
+            participants.value = listOf(local)
+
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `emits after the reconnect settles with the local user still alone`() = runTest {
+        val participants = MutableStateFlow(listOf(local, remote))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            connection.value = RealtimeConnection.Reconnecting
+            participants.value = listOf(local)
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+
+            connection.value = RealtimeConnection.Connected
+            advanceTimeBy(debounceMs + 1)
+            assertEquals(1, awaitItem().size)
+        }
+    }
+
+    @Test
+    fun `does not emit after the reconnect settles with the roster restored`() = runTest {
+        val participants = MutableStateFlow(listOf(local, remote))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            connection.value = RealtimeConnection.Reconnecting
+            participants.value = listOf(local)
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+
+            participants.value = listOf(local, remote)
+            connection.value = RealtimeConnection.Connected
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `debounce absorbs a quick roster flap`() = runTest {
+        val participants = MutableStateFlow(listOf(local, remote))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            participants.value = listOf(local)
+            advanceTimeBy(debounceMs - 1)
+            participants.value = listOf(local, remote)
+
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `invokes onEvaluated for suppressed evaluations`() = runTest {
+        val participants = MutableStateFlow(listOf(local))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Reconnecting)
+        val evaluations = mutableListOf<Pair<Int, RealtimeConnection>>()
+
+        lastParticipantSignal(
+            participants = participants,
+            connection = connection,
+            debounceMs = debounceMs,
+            onEvaluated = { roster, connectionState ->
+                evaluations += roster.size to connectionState
+            },
+        ).test {
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+
+        assertEquals(
+            listOf(1 to RealtimeConnection.Reconnecting as RealtimeConnection),
+            evaluations,
+        )
+    }
+}

--- a/stream-video-android-ui-core/src/test/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignalTest.kt
+++ b/stream-video-android-ui-core/src/test/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignalTest.kt
@@ -29,10 +29,10 @@ import kotlin.test.assertEquals
 
 /**
  * Regression tests for the [lastParticipantSignal] gating (AND-1455): with
- * `leaveWhenLastInCall = true`, a leave triggered while an SFU reconnect is in flight cancels
- * the reconnect loop in the call scope and leaves the UI stuck on "Connecting...". The signal
- * must stay silent while the connection is reconnecting or migrating and re-evaluate the
- * roster once the connection settles.
+ * `leaveWhenLastInCall = true`, a leave triggered while an SFU join or reconnect is running
+ * cancels the work in the call scope and leaves the UI stuck on "Connecting...". The signal
+ * must only act while the connection is connected, re-evaluate the roster once the connection
+ * settles, and not repeat an unchanged roster across connection transitions.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class LastParticipantSignalTest {
@@ -88,6 +88,52 @@ internal class LastParticipantSignalTest {
             connection.value = RealtimeConnection.Migrating
             participants.value = listOf(local)
 
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `does not emit while the join is in progress`() = runTest {
+        val participants = MutableStateFlow(listOf(local))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.PreJoin)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+
+            connection.value = RealtimeConnection.InProgress
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `does not emit when the reconnect fails terminally`() = runTest {
+        val participants = MutableStateFlow(listOf(local))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Reconnecting)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            connection.value = RealtimeConnection.ReconnectingFailed
+
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `does not emit the same roster again after a reconnect flap`() = runTest {
+        val roster = listOf(local)
+        val participants = MutableStateFlow(roster)
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            advanceTimeBy(debounceMs + 1)
+            assertEquals(1, awaitItem().size)
+
+            connection.value = RealtimeConnection.Reconnecting
+            advanceTimeBy(debounceMs + 1)
+            connection.value = RealtimeConnection.Connected
             advanceTimeBy(debounceMs + 1)
             expectNoEvents()
         }

--- a/stream-video-android-ui-core/src/test/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignalTest.kt
+++ b/stream-video-android-ui-core/src/test/kotlin/io/getstream/video/android/ui/common/util/LastParticipantSignalTest.kt
@@ -140,6 +140,25 @@ internal class LastParticipantSignalTest {
     }
 
     @Test
+    fun `emits again when a remote participant joins and leaves again`() = runTest {
+        val participants = MutableStateFlow(listOf(local))
+        val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+
+        lastParticipantSignal(participants, connection, debounceMs).test {
+            advanceTimeBy(debounceMs + 1)
+            assertEquals(1, awaitItem().size)
+
+            participants.value = listOf(local, remote)
+            advanceTimeBy(debounceMs + 1)
+            expectNoEvents()
+
+            participants.value = listOf(local)
+            advanceTimeBy(debounceMs + 1)
+            assertEquals(1, awaitItem().size)
+        }
+    }
+
+    @Test
     fun `emits after the reconnect settles with the local user still alone`() = runTest {
         val participants = MutableStateFlow(listOf(local, remote))
         val connection = MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)


### PR DESCRIPTION
### Goal

Fixes AND-1455.

This PR targets `develop-v2`. The fix changes when the last-participant auto leave fires (only while the connection is `Connected`). The video team considers that a behavior change that some customers might see as breaking, so it ships with the next major version instead of a patch release on `develop`.

`RingingTests#testUserAcceptsTheIncomingVideoCallWithCameraAndMicrophoneEnabled` fails on CI when the SFU websocket drops right after the callee accepts (for example run 33070269061 on PR #1776, and the API 34 job of run 33155106721). The chain is:

1. The SFU socket drops during the join and `CallReconnector` starts a REJOIN.
2. While the reconnect is running, the participant roster is unreliable: the rejoin removes our previous participant record and the remote participant of the failing SFU is gone. The roster falls to 1 or less.
3. `StreamCallActivity` observes the roster with `leaveWhenLastInCall = true`, sees "last participant", and fires `LeaveCall`.
4. The leave cancels `call.scope`. The reconnect loop runs in that scope, so it dies in the middle of its retry.
5. The screen stays on "Connecting..." until the test times out.

### Implementation

- Extracted the last participant detection from `StreamCallActivity.processParticipantLeftEvent` into an internal `lastParticipantSignal` flow helper (`LastParticipantSignal.kt`).
- The helper combines the participant roster with `call.state.connection`, keeps the existing debounce, and only emits while the connection is `Connected`. It is an allowlist, not a list of bad states: the roster is also unreliable during the initial join (`Joined` is set before `connectInternal` runs), and new `RealtimeConnection` subtypes stay covered. This mirrors the Swift SDK's `LastParticipantAutoLeavePolicy`, which only acts when the reconnection status is connected.
- The signal is a rising edge of the roster, not of the combined condition. Becoming the last participant arms it, and it fires on the first connected evaluation after that. A reconnect flap with an unchanged roster does not call `onLastParticipant` again. A remote participant joining and leaving again re-arms it and signals a second time.
- Because the connection state is part of the combined stream, the roster is re-evaluated when the reconnect settles:
  - The reconnect succeeds and the roster is restored: no leave. This is the CI failure case.
  - The reconnect succeeds but the user is really alone: the leave still fires.
  - The reconnect fails terminally: the helper stays silent. `CallReconnector` already leaves the call itself when retries are exhausted, so there is no stuck screen and no duplicate leave.
- The diagnostic logging of every roster evaluation is kept and now also logs the connection state.
- `stream-video-android-ui-core` is added to `coverage.includedModules` in the root build file so its unit tests run in CI. This also un-skips the module in Sonar for the first time, so the Sonar check reports the module's legacy findings. Proper Sonar onboarding of the module is tracked in AND-1470.

### 🎨 UI Changes

No UI changes.

### Testing

- New `LastParticipantSignalTest` (12 tests, Turbine with virtual time) in a new unit test source set for `stream-video-android-ui-core`. The module had no unit tests before, so the test dependencies were added to its build file.
- Mutation checks, so the tests catch the exact regressions:
  - Removing the connection gate (`connected = true`) fails 7 of the 12 tests.
  - Replacing the rising edge with `armed = isLast` fails the reconnect flap test.
- `spotlessCheck`, `testDebugUnitTest`, `apiCheck` and the debug and release compilations are green on `develop-v2`. The helper is internal, so the public API dump is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when the last participant leaves a call.
  * Prevented premature end-of-call behavior while reconnecting or migrating.
  * Ensured the call state is re-evaluated after reconnection settles.
  * Reduced incorrect triggers caused by brief participant roster changes.

* **Tests**
  * Added coverage for connection transitions, participant changes, and debounced updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

