### PR TITLE
Harden the racy signal assertions in NoiseCancellationSignalTest

### DIFF
--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/NoiseCancellationSignalTest.kt
@@ -32,6 +32,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import stream.video.sfu.signal.StartNoiseCancellationResponse
 import stream.video.sfu.signal.StopNoiseCancellationResponse
+import java.util.concurrent.CopyOnWriteArrayList
 import kotlin.test.assertEquals
 
 @RunWith(RobolectricTestRunner::class)
@@ -39,6 +40,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
 
     private companion object {
         const val SIGNAL_TIMEOUT_MS = 5_000L
+        const val SIGNAL_POLL_MS = 10L
     }
 
     /**
@@ -80,8 +82,8 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
     }
 
     /** Records the state of every signal the SFU receives, in the order it receives them. */
-    private fun record(session: RtcSession): MutableList<Boolean> {
-        val signalled = mutableListOf<Boolean>()
+    private fun record(session: RtcSession): List<Boolean> {
+        val signalled = CopyOnWriteArrayList<Boolean>()
         coEvery { session.startNoiseCancellation() } coAnswers {
             signalled += true
             Result.Success(mockk<StartNoiseCancellationResponse>(relaxed = true))
@@ -91,6 +93,29 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
             Result.Success(mockk<StopNoiseCancellationResponse>(relaxed = true))
         }
         return signalled
+    }
+
+    /**
+     * MockK records the mocked call before the answer body runs, and the append to the list
+     * happens on the signal coroutine, so right after a passing coVerify the recorded signals
+     * may not be visible to the test thread yet. Polls until they match instead of asserting
+     * on a snapshot.
+     */
+    private fun awaitSignalled(signalled: List<Boolean>, expected: List<Boolean>) {
+        val deadline = System.currentTimeMillis() + SIGNAL_TIMEOUT_MS
+        while (signalled != expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(SIGNAL_POLL_MS)
+        }
+        assertEquals(expected, signalled.toList())
+    }
+
+    /** Same visibility caveat as [awaitSignalled], for a test where only the final state matters. */
+    private fun awaitFinalSignal(signalled: List<Boolean>, expected: Boolean) {
+        val deadline = System.currentTimeMillis() + SIGNAL_TIMEOUT_MS
+        while (signalled.lastOrNull() != expected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(SIGNAL_POLL_MS)
+        }
+        assertEquals(expected, signalled.lastOrNull())
     }
 
     @Test
@@ -158,7 +183,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
         call.injectSession(session)
 
         coVerify(timeout = SIGNAL_TIMEOUT_MS) { session.startNoiseCancellation() }
-        assertEquals(listOf(true), signalled)
+        awaitSignalled(signalled, listOf(true))
     }
 
     @Test
@@ -174,7 +199,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
         call.injectSession(replacement)
 
         coVerify(timeout = SIGNAL_TIMEOUT_MS) { replacement.startNoiseCancellation() }
-        assertEquals(listOf(true), signalled)
+        awaitSignalled(signalled, listOf(true))
     }
 
     @Test
@@ -190,7 +215,7 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
 
         // Waiting on the stop means every signal before it has already landed.
         coVerify(timeout = SIGNAL_TIMEOUT_MS) { session.stopNoiseCancellation() }
-        assertEquals(false, signalled.last())
+        awaitFinalSignal(signalled, expected = false)
     }
 
     @Test
@@ -212,6 +237,6 @@ class NoiseCancellationSignalTest : IntegrationTestBase(connectCoordinatorWS = f
         call.injectSession(session)
 
         coVerify(timeout = SIGNAL_TIMEOUT_MS) { session.startNoiseCancellation() }
-        assertEquals(listOf(true), signalled)
+        awaitSignalled(signalled, listOf(true))
     }
 }


### PR DESCRIPTION
### Goal

Fix the test that fails deterministically on the develop-v2 merge PR #1790: `NoiseCancellationSignalTest > a replacement session is told the current state` fails there with `expected:<[true]> but was:<[]>` on every attempt of the [Android CI run](https://github.com/GetStream/stream-video-android/actions/runs/33366592143), while it passes on develop.

Resolves AND-1465.

### Implementation

The failure is a race in the test, not in the production code. The `record` helper collects the signalled states into a plain `mutableListOf` from the mock's `coAnswers` block, which runs on the signal coroutine. The tests assert on that list right after a `coVerify(timeout = ...)`. MockK records the invocation before the answer block finishes, and the list is not thread safe, so the assert can run before the append is visible to the test thread. develop's coroutines 1.9.0 happens to give the timing the test needs; develop-v2's coroutines 1.10.2 consistently does not.

Changes, all in `NoiseCancellationSignalTest.kt`:

- `record()` now collects into a `CopyOnWriteArrayList`, so writes from the signal coroutine are visible to the test thread.
- The four instant asserts on the recorded list are replaced with polling helpers that wait for the expected content with the existing 5s deadline: `awaitSignalled` for the exact-content checks and `awaitFinalSignal` for the "rapid changes" test where only the last state matters.

No production code change.

### 🎨 UI Changes

Not applicable, test-only change.

### Testing

- Ran the test class 4 times locally (once normally, 3 times with `--rerun-tasks`): 8 tests, 0 failures each time.
- The definitive proof will be the next develop merge into develop-v2, where the previous version failed on both CI attempts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved signal-related test reliability by accommodating asynchronous event recording.
  * Replaced immediate snapshot checks with polling assertions and timeout handling.
  * Added thread-safe recording for mocked signal events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->