### PR TITLE
Fix the logout main-thread freeze in StreamVideoClient cleanup

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -174,6 +174,12 @@ internal const val defaultAudioUsage = AudioAttributes.USAGE_VOICE_COMMUNICATION
 /**
  * @param lifecycle The lifecycle used to observe changes in the process
  */
+// Upper bound for the StreamClient disconnect during cleanup(), so a disconnect that never
+// completes cannot keep the detached teardown coroutine, and with it this client, alive
+// forever. Generous compared to the internal 5 second main-looper latch it may legitimately
+// wait on when cleanup() runs off the main thread.
+private const val CLEANUP_DISCONNECT_TIMEOUT_MS = 10_000L
+
 internal class StreamVideoClient internal constructor(
     override val context: Context,
     internal val scope: CoroutineScope = ClientScope(),
@@ -288,8 +294,14 @@ internal class StreamVideoClient internal constructor(
         // self-deadlocks until that timeout fires and freezes the UI for the whole wait. The
         // suspend call is bridged because cleanup() is non-suspending public API.
         val disconnectStreamClientThenCancelScope: suspend () -> Unit = {
-            runCatching { streamClient.disconnect().getOrThrow() }
-                .onFailure { logger.e(it) { "[cleanup] StreamClient.disconnect failed" } }
+            runCatching {
+                withTimeoutOrNull(CLEANUP_DISCONNECT_TIMEOUT_MS) {
+                    streamClient.disconnect().getOrThrow()
+                } ?: logger.e {
+                    "[cleanup] StreamClient.disconnect timed out " +
+                        "after ${CLEANUP_DISCONNECT_TIMEOUT_MS}ms"
+                }
+            }.onFailure { logger.e(it) { "[cleanup] StreamClient.disconnect failed" } }
             scope.cancel()
         }
         val mainLooper = Looper.getMainLooper()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -18,6 +18,7 @@ package io.getstream.video.android.core
 
 import android.content.Context
 import android.media.AudioAttributes
+import android.os.Looper
 import androidx.collection.LruCache
 import androidx.lifecycle.Lifecycle
 import io.getstream.android.core.api.StreamClient
@@ -90,6 +91,7 @@ import io.getstream.result.Result.Success
 import io.getstream.video.android.core.analytics.AnalyticsModule
 import io.getstream.video.android.core.audio.AudioExecutionContext
 import io.getstream.video.android.core.call.CallBusyHandler
+import io.getstream.video.android.core.dispatchers.DispatcherProvider
 import io.getstream.video.android.core.errors.VideoErrorCode
 import io.getstream.video.android.core.events.VideoEventListener
 import io.getstream.video.android.core.filter.Filters
@@ -143,6 +145,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancel
@@ -277,11 +280,23 @@ internal class StreamVideoClient internal constructor(
         // cancel the StreamClient subscription before tearing down the socket
         streamClientSubscription?.cancel()
         streamClientSubscription = null
-        // disconnect the StreamClient socket before cancelling the scope; suspend bridged via
-        // runBlocking because cleanup() is non-suspending public API.
-        runBlocking {
+        // Disconnect the StreamClient socket before cancelling the scope. The suspend call is
+        // bridged because cleanup() is non-suspending public API, but it must not park the main
+        // thread: StreamClient.disconnect() stops its lifecycle monitor by posting to the main
+        // looper and blocking on it with a 5 second safety timeout, so a runBlocking on the main
+        // thread deadlocks until that timeout fires and freezes the UI for the whole wait.
+        val disconnectStreamClient: suspend () -> Unit = {
             runCatching { streamClient.disconnect() }
                 .onFailure { logger.e(it) { "[cleanup] StreamClient.disconnect failed" } }
+        }
+        val mainLooper = Looper.getMainLooper()
+        if (mainLooper != null && Looper.myLooper() === mainLooper) {
+            CoroutineScope(SupervisorJob() + DispatcherProvider.IO)
+                .launch(CoroutineName("cleanup#streamClient.disconnect")) {
+                    disconnectStreamClient()
+                }
+        } else {
+            runBlocking { disconnectStreamClient() }
         }
         // stop all running coroutines
         scope.cancel()
@@ -293,11 +308,11 @@ internal class StreamVideoClient internal constructor(
         val runCallServiceInForeground = callConfig.runCallServiceInForeground
         if (runCallServiceInForeground) {
             safeCall {
-                val serviceIntent = ServiceIntentBuilder().buildStopIntent(
+                // buildStopIntent returns null when the service is not running.
+                ServiceIntentBuilder().buildStopIntent(
                     context = context,
                     StopServiceParam(callServiceConfiguration = callConfig),
-                )
-                serviceIntent.let {
+                )?.let { serviceIntent ->
                     context.stopService(serviceIntent)
                 }
             }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -214,6 +214,7 @@ internal class StreamVideoClient internal constructor(
         coordinatorConnectionModule.api,
         scope,
     ),
+    internal val cleanupDisconnectTimeoutMs: Long = CLEANUP_DISCONNECT_TIMEOUT_MS,
 ) : StreamVideo, NotificationHandler by streamNotificationManager {
 
     private var locationJob: Deferred<Result<String>>? = null
@@ -295,11 +296,11 @@ internal class StreamVideoClient internal constructor(
         // suspend call is bridged because cleanup() is non-suspending public API.
         val disconnectStreamClientThenCancelScope: suspend () -> Unit = {
             runCatching {
-                withTimeoutOrNull(CLEANUP_DISCONNECT_TIMEOUT_MS) {
+                withTimeoutOrNull(cleanupDisconnectTimeoutMs) {
                     streamClient.disconnect().getOrThrow()
                 } ?: logger.e {
                     "[cleanup] StreamClient.disconnect timed out " +
-                        "after ${CLEANUP_DISCONNECT_TIMEOUT_MS}ms"
+                        "after ${cleanupDisconnectTimeoutMs}ms"
                 }
             }.onFailure { logger.e(it) { "[cleanup] StreamClient.disconnect failed" } }
             scope.cancel()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -280,26 +280,27 @@ internal class StreamVideoClient internal constructor(
         // cancel the StreamClient subscription before tearing down the socket
         streamClientSubscription?.cancel()
         streamClientSubscription = null
-        // Disconnect the StreamClient socket before cancelling the scope. The suspend call is
-        // bridged because cleanup() is non-suspending public API, but it must not park the main
-        // thread: StreamClient.disconnect() stops its lifecycle monitor by posting to the main
-        // looper and blocking on it with a 5 second safety timeout, so a runBlocking on the main
-        // thread deadlocks until that timeout fires and freezes the UI for the whole wait.
-        val disconnectStreamClient: suspend () -> Unit = {
-            runCatching { streamClient.disconnect() }
+        // Disconnect the StreamClient socket, then cancel the scope. Two constraints shape this:
+        // the StreamClient runs its internals (the disconnect included) on this same `scope`, so
+        // the scope must stay alive until the disconnect has finished; and the disconnect must
+        // not run inside runBlocking on the main thread, because it stops its lifecycle monitor
+        // by posting to the main looper and blocking on it with a 5 second safety timeout, which
+        // self-deadlocks until that timeout fires and freezes the UI for the whole wait. The
+        // suspend call is bridged because cleanup() is non-suspending public API.
+        val disconnectStreamClientThenCancelScope: suspend () -> Unit = {
+            runCatching { streamClient.disconnect().getOrThrow() }
                 .onFailure { logger.e(it) { "[cleanup] StreamClient.disconnect failed" } }
+            scope.cancel()
         }
         val mainLooper = Looper.getMainLooper()
         if (mainLooper != null && Looper.myLooper() === mainLooper) {
             CoroutineScope(SupervisorJob() + DispatcherProvider.IO)
                 .launch(CoroutineName("cleanup#streamClient.disconnect")) {
-                    disconnectStreamClient()
+                    disconnectStreamClientThenCancelScope()
                 }
         } else {
-            runBlocking { disconnectStreamClient() }
+            runBlocking { disconnectStreamClientThenCancelScope() }
         }
-        // stop all running coroutines
-        scope.cancel()
         // call cleanup on the active call
         val activeCall = state.activeCall.value
         // Stop the call service if it was running

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientCleanupTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientCleanupTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core
+
+import android.content.Context
+import androidx.lifecycle.Lifecycle
+import io.getstream.android.core.api.StreamClient
+import io.getstream.android.core.api.model.connection.StreamConnectionState
+import io.getstream.android.core.api.subscribe.StreamSubscription
+import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
+import io.getstream.video.android.model.User
+import io.getstream.video.android.model.UserType
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.After
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import kotlin.system.measureTimeMillis
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Runs under Robolectric so a real main looper exists and the test thread is the main thread,
+ * which is exactly the situation an app is in when it calls StreamVideo.removeClient() from
+ * a logout button handler.
+ */
+@RunWith(RobolectricTestRunner::class)
+class StreamVideoClientCleanupTest {
+
+    @After
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun buildClient(streamClient: StreamClient): StreamVideoClient = StreamVideoClient(
+        context = mockk<Context>(relaxed = true),
+        initialUser = User(id = "user-1", type = UserType.Authenticated),
+        apiKey = "apikey",
+        token = "token",
+        lifecycle = mockk<Lifecycle>(relaxed = true),
+        coordinatorConnectionModule = mockk<CoordinatorConnectionModule>(relaxed = true),
+        streamClient = streamClient,
+        tokenRepository = mockk(relaxed = true),
+        streamNotificationManager = mockk(relaxed = true),
+        enableCallNotificationUpdates = false,
+        sounds = mockk(relaxed = true),
+        vibrationConfig = mockk(relaxed = true),
+        analytics = mockk(relaxed = true),
+    )
+
+    // Regression for AND-1466: cleanup() used to bridge streamClient.disconnect() with
+    // runBlocking even on the main thread. StreamClient.disconnect() stops its lifecycle
+    // monitor by posting to the main looper and blocking on it with a 5 second safety
+    // timeout, so a logout from the main thread froze the UI for those 5 seconds.
+    @Test
+    fun `cleanup on the main thread returns without waiting for the disconnect`() {
+        val streamClient = mockk<StreamClient>(relaxed = true)
+        every { streamClient.subscribe(any()) } returns
+            Result.success(mockk<StreamSubscription>(relaxed = true))
+        every { streamClient.connectionState } returns
+            MutableStateFlow(StreamConnectionState.Idle)
+        coEvery { streamClient.disconnect() } coAnswers {
+            delay(6_000)
+            Result.success(Unit)
+        }
+        val client = buildClient(streamClient)
+
+        val elapsed = measureTimeMillis { client.cleanup() }
+
+        assertTrue(
+            elapsed < 3_000,
+            "cleanup must not park the main thread on the disconnect; took ${elapsed}ms",
+        )
+        // The disconnect must still happen, detached from the calling thread.
+        coVerify(timeout = 3_000, exactly = 1) { streamClient.disconnect() }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientCleanupTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientCleanupTest.kt
@@ -31,11 +31,13 @@ import io.mockk.mockk
 import io.mockk.unmockkAll
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.isActive
 import org.junit.After
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import kotlin.system.measureTimeMillis
 import kotlin.test.Test
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -92,5 +94,38 @@ class StreamVideoClientCleanupTest {
         )
         // The disconnect must still happen, detached from the calling thread.
         coVerify(timeout = 3_000, exactly = 1) { streamClient.disconnect() }
+    }
+
+    // The StreamClient executes its internals, the disconnect included, on the same scope the
+    // video client owns, so cancelling that scope before the disconnect finishes turns the
+    // disconnect into a silent no-op and leaks the coordinator socket.
+    @Test
+    fun `cleanup on the main thread cancels the client scope only after the disconnect finishes`() {
+        val streamClient = mockk<StreamClient>(relaxed = true)
+        every { streamClient.subscribe(any()) } returns
+            Result.success(mockk<StreamSubscription>(relaxed = true))
+        every { streamClient.connectionState } returns
+            MutableStateFlow(StreamConnectionState.Idle)
+        coEvery { streamClient.disconnect() } coAnswers {
+            delay(2_000)
+            Result.success(Unit)
+        }
+        val client = buildClient(streamClient)
+
+        client.cleanup()
+
+        assertTrue(
+            client.scope.isActive,
+            "the scope must stay alive while the disconnect is still in flight",
+        )
+        coVerify(timeout = 3_000, exactly = 1) { streamClient.disconnect() }
+        val deadline = System.currentTimeMillis() + 5_000
+        while (client.scope.isActive && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20)
+        }
+        assertFalse(
+            client.scope.isActive,
+            "the scope must be cancelled once the disconnect has completed",
+        )
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientCleanupTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientCleanupTest.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.isActive
 import org.junit.After
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import kotlin.concurrent.thread
 import kotlin.system.measureTimeMillis
 import kotlin.test.Test
 import kotlin.test.assertFalse
@@ -53,7 +54,30 @@ class StreamVideoClientCleanupTest {
         unmockkAll()
     }
 
-    private fun buildClient(streamClient: StreamClient): StreamVideoClient = StreamVideoClient(
+    private fun mockStreamClient(): StreamClient {
+        val streamClient = mockk<StreamClient>(relaxed = true)
+        every { streamClient.subscribe(any()) } returns
+            Result.success(mockk<StreamSubscription>(relaxed = true))
+        every { streamClient.connectionState } returns
+            MutableStateFlow(StreamConnectionState.Idle)
+        return streamClient
+    }
+
+    private fun awaitScopeCancelled(client: StreamVideoClient) {
+        val deadline = System.currentTimeMillis() + 5_000
+        while (client.scope.isActive && System.currentTimeMillis() < deadline) {
+            Thread.sleep(20)
+        }
+        assertFalse(
+            client.scope.isActive,
+            "the scope must be cancelled after the disconnect step",
+        )
+    }
+
+    private fun buildClient(
+        streamClient: StreamClient,
+        cleanupDisconnectTimeoutMs: Long = 10_000L,
+    ): StreamVideoClient = StreamVideoClient(
         context = mockk<Context>(relaxed = true),
         initialUser = User(id = "user-1", type = UserType.Authenticated),
         apiKey = "apikey",
@@ -67,6 +91,7 @@ class StreamVideoClientCleanupTest {
         sounds = mockk(relaxed = true),
         vibrationConfig = mockk(relaxed = true),
         analytics = mockk(relaxed = true),
+        cleanupDisconnectTimeoutMs = cleanupDisconnectTimeoutMs,
     )
 
     // Regression for AND-1466: cleanup() used to bridge streamClient.disconnect() with
@@ -127,5 +152,57 @@ class StreamVideoClientCleanupTest {
             client.scope.isActive,
             "the scope must be cancelled once the disconnect has completed",
         )
+    }
+
+    // A failed disconnect is logged but must not stop the teardown: the scope is cancelled
+    // regardless, otherwise a transient socket error would leak the whole client.
+    @Test
+    fun `cleanup still cancels the scope when the disconnect fails`() {
+        val streamClient = mockStreamClient()
+        coEvery { streamClient.disconnect() } returns Result.failure(RuntimeException("socket down"))
+        val client = buildClient(streamClient)
+
+        client.cleanup()
+
+        coVerify(timeout = 3_000, exactly = 1) { streamClient.disconnect() }
+        awaitScopeCancelled(client)
+    }
+
+    // Off the main thread there is no deadlock risk, so cleanup keeps the synchronous
+    // contract: the disconnect has completed and the scope is cancelled by the time it returns.
+    @Test
+    fun `cleanup off the main thread disconnects before returning`() {
+        val streamClient = mockStreamClient()
+        coEvery { streamClient.disconnect() } returns Result.success(Unit)
+        val client = buildClient(streamClient)
+
+        val worker = thread { client.cleanup() }
+        worker.join(10_000)
+
+        assertFalse(worker.isAlive, "cleanup must complete on a background thread")
+        coVerify(exactly = 1) { streamClient.disconnect() }
+        assertFalse(
+            client.scope.isActive,
+            "the scope must already be cancelled when cleanup returns off the main thread",
+        )
+    }
+
+    // A disconnect that never completes must not hold the teardown hostage: after the
+    // configured bound the scope is cancelled anyway.
+    @Test
+    fun `cleanup gives up on a disconnect that exceeds the timeout`() {
+        val streamClient = mockStreamClient()
+        coEvery { streamClient.disconnect() } coAnswers {
+            delay(60_000)
+            Result.success(Unit)
+        }
+        val client = buildClient(streamClient, cleanupDisconnectTimeoutMs = 200)
+
+        client.cleanup()
+
+        coVerify(timeout = 3_000, exactly = 1) { streamClient.disconnect() }
+        // The mock is still suspended in its delay, so reaching cancellation here proves the
+        // timeout branch ran instead of waiting for the disconnect.
+        awaitScopeCancelled(client)
     }
 }


### PR DESCRIPTION
### Goal

Fix the 5 second UI freeze on logout that makes the E2E tests on the develop-v2 merge PR #1790 fail deterministically on the sign-in screen waits, and remove a swallowed NPE in the same code path.

Resolves AND-1466.

### Implementation

`StreamVideoClient.cleanup()` bridged the suspend `streamClient.disconnect()` with `runBlocking`. When an app calls `StreamVideo.removeClient()` from the main thread (the demo app's logout does), this self-deadlocks: `disconnect()` stops its lifecycle monitor through `runOnMainLooper`, which posts to the main looper and blocks on a CountDownLatch with a 5 second safety timeout (stream-android-core `Threading.kt`). The main looper is parked by the `runBlocking`, so the post never runs and every logout freezes the UI for the full 5 seconds. As a side effect the lifecycle observer was never removed.

Changes in `StreamVideoClient.cleanup()`:

- When called on the main thread, the disconnect now runs on a detached IO scope instead of `runBlocking`. Other threads keep the existing synchronous ordering. The main-looper check is null-guarded because plain JVM unit tests get null loopers (`isReturnDefaultValues = true`).
- `buildStopIntent(...)` legitimately returns null when the service is not running; the result is now handled with `?.let` instead of passing null into `context.stopService(...)`, which threw a swallowed `NullPointerException` on every logout without a running call service.

### 🎨 UI Changes

No visual changes. Behavior change: logout no longer freezes the UI for 5 seconds.

### Testing

- New Robolectric regression test `StreamVideoClientCleanupTest` runs `cleanup()` on a real main-looper thread against a mocked 6 second disconnect: it fails on the old code ("took 6218ms") and passes with the fix while verifying the disconnect is still dispatched.
- Full `:stream-video-android-core:testDebugUnitTest` suite passes.
- Verified end to end on an API 35 emulator against the #1790 merge branch plus this fix: `CallLifecycleTests#testUserReentersTheCallAsAnotherUser` now gets past the sign-in wait that failed on both CI attempts. It then hits a separate demo-app re-login race, tracked as AND-1467.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup behavior so disconnect operations no longer block the main thread.
  * Preserved synchronous cleanup when running outside the main thread.
  * Improved handling of service-stop requests when no intent is provided.

* **Tests**
  * Added coverage verifying that main-thread cleanup returns promptly while disconnection continues safely in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->