### PR TITLE
Wait for the SDK re-initialization before joining a call after re-login

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinViewModel.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/join/CallJoinViewModel.kt
@@ -31,6 +31,7 @@ import io.getstream.video.android.model.User
 import io.getstream.video.android.model.mapper.isValidCallCid
 import io.getstream.video.android.model.mapper.toTypeAndId
 import io.getstream.video.android.tooling.util.StreamBuildFlavorUtil
+import io.getstream.video.android.util.InitializedState
 import io.getstream.video.android.util.NetworkMonitor
 import io.getstream.video.android.util.StreamVideoInitHelper
 import io.getstream.video.android.util.fcmToken
@@ -41,6 +42,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.shareIn
@@ -69,7 +71,11 @@ class CallJoinViewModel @Inject constructor(
                 }
                 is CallJoinEvent.JoinCall -> {
                     val call = joinCall(event.callId)
-                    flowOf(CallJoinUiState.JoinCompleted(callId = call.cid))
+                    if (call != null) {
+                        flowOf(CallJoinUiState.JoinCompleted(callId = call.cid))
+                    } else {
+                        flowOf(CallJoinUiState.GoBackToLogin)
+                    }
                 }
                 is CallJoinEvent.JoinCompleted -> flowOf(
                     CallJoinUiState.JoinCompleted(event.callId),
@@ -110,8 +116,18 @@ class CallJoinViewModel @Inject constructor(
         viewModelScope.launch { this@CallJoinViewModel.event.emit(event) }
     }
 
-    private fun joinCall(callId: String? = null): Call {
-        val streamVideo = StreamVideo.instance()
+    private suspend fun joinCall(callId: String? = null): Call? {
+        // A fast re-login lands on this screen while StreamVideoInitHelper.loadSdk, started in
+        // init, is still rebuilding the SDK, so the instance may not be installed yet at tap
+        // time. loadSdk returns early when another initialization is already in flight, so the
+        // helper's terminal state must be awaited before reading the instance.
+        if (!StreamVideo.isInstalled) {
+            StreamVideoInitHelper.loadSdk(dataStore = dataStore)
+            StreamVideoInitHelper.initializedState.first {
+                it == InitializedState.FINISHED || it == InitializedState.FAILED
+            }
+        }
+        val streamVideo = StreamVideo.instanceOrNull() ?: return null
         val newCallId = callId ?: "default:${UUID.randomUUID()}"
         val (type, id) = if (newCallId.isValidCallCid()) {
             newCallId.toTypeAndId()


### PR DESCRIPTION
### Goal

Stop the demo app from crashing when a call join is attempted while the SDK is still re-initializing after a fast logout and re-login. Found while verifying the AND-1466 fix on the develop-v2 merge PR #1790: the process crash also pollutes the following E2E tests, which then cannot find the sign-in screen.

Resolves AND-1467.

### Implementation

After a logout and quick re-login, the join screen's ViewModel starts `StreamVideoInitHelper.loadSdk()` from its init block, and that takes seconds (mostly the token fetch). The join UI is fully interactive during that window, and `joinCall` called `StreamVideo.instance()`, which throws when the instance is not installed yet. The exception escaped through the `flatMapLatest` flow on the UI scope and killed the process.

Changes, all in `CallJoinViewModel`:

- `joinCall` is now suspend and null-safe: when `StreamVideo` is not installed it triggers `loadSdk` and awaits `StreamVideoInitHelper.initializedState` reaching FINISHED or FAILED, then reads `instanceOrNull()`. The await matters because `loadSdk` returns early when another initialization is already in flight, without waiting for it.
- The `JoinCall` branch of the `uiState` flow maps a null call (initialization failed) to `GoBackToLogin` instead of crashing.

The race is latent on develop today. It surfaces on the develop-v2 merge branch because the AND-1466 fix (#1792) makes logout and re-login fast enough to hit it, and it will reach develop-v2 through the next merge-down.

### 🎨 UI Changes

No visual changes. On an SDK initialization failure the join tap now navigates back to the login screen instead of crashing the app.

### Testing

- Verified end to end on an API 35 emulator against the #1790 merge branch plus #1792 plus this fix: `CallLifecycleTests#testUserReentersTheCallAsAnotherUser` (crashed before this change) and `testUserReentersTheCallAsTheSameUserAfterLoggingOut` both pass.
- `:demo-app:spotlessCheck` and the E2E-flavor compilation pass on this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved call joining when the Video SDK has not finished loading.
  * Automatically completes SDK initialization before attempting to join a call.
  * Returns users to the login screen when call setup cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->