### PR TITLE
Isolate per-track mute RPCs and atomic mute map

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -326,7 +326,7 @@ public class RtcSession internal constructor(
         )
     },
 ) {
-    private var muteStateSyncJob: Job? = null
+    private val muteStateSyncJobs = TrackKeyedJobs()
     private val oneBasedSessionCounter = sessionCounter + 1
 
     /**
@@ -1341,6 +1341,10 @@ public class RtcSession internal constructor(
      * matches the web SDK, which only signals the track(s) that actually changed. On SFU
      * (re)connect/migration each enabled track is re-signalled individually via
      * [listenToMediaChanges], so the full state is still restored.
+     *
+     * Sync jobs are keyed by [trackType]. Cancelling a shared job used to drop an in-flight
+     * audio unmute when video (or screen-share) published a moment later — reconnect restarts
+     * [listenToMediaChanges] and fires those collectors together.
      */
     private fun setMuteState(isEnabled: Boolean, trackType: TrackType) {
         logger.d { "[setPublishState] #sfu; $trackType isEnabled: $isEnabled" }
@@ -1352,12 +1356,8 @@ public class RtcSession internal constructor(
         muteState.value = new
 
         val currentSfu = sfuUrl
-        // prevent running multiple of these at the same time
-        // if there's already a job active. cancel it
-        muteStateSyncJob?.cancel()
-        // start a new job
-        // this code is a bit more complicated due to the retry behaviour
-        muteStateSyncJob = coroutineScope.launch {
+        // Coalesce retries for this track only. Other tracks keep their in-flight RPCs.
+        muteStateSyncJobs.launch(coroutineScope, trackType) {
             flow {
                 val request = UpdateMuteStatesRequest(
                     session_id = sessionId,
@@ -1372,7 +1372,7 @@ public class RtcSession internal constructor(
                 emit(response)
             }.flowOn(DispatcherProvider.IO).retryWhen { cause, attempt ->
                 if (cause is SessionFatalException) return@retryWhen false
-                val sameValue = new == muteState.value
+                val sameValue = muteState.value[trackType] == isEnabled
                 val sameSfu = currentSfu == sfuUrl
                 val isPermanent = isPermanentError(cause)
                 val willRetry = !isPermanent && sameValue && sameSfu && attempt < 30
@@ -2121,8 +2121,7 @@ public class RtcSession internal constructor(
         if (cancelEventJob) eventJob?.cancel()
         iceMonitoringJob?.cancel()
         iceMonitoringJob = null
-        muteStateSyncJob?.cancel()
-        muteStateSyncJob = null
+        muteStateSyncJobs.cancelAll()
         participantsMonitoringJob?.cancel()
         participantsMonitoringJob = null
         serialProcessor.stop()

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -121,6 +121,7 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.retryWhen
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -1345,15 +1346,14 @@ public class RtcSession internal constructor(
      * Sync jobs are keyed by [trackType]. Cancelling a shared job used to drop an in-flight
      * audio unmute when video (or screen-share) published a moment later — reconnect restarts
      * [listenToMediaChanges] and fires those collectors together.
+     *
+     * The local mute map is updated with [MutableStateFlow.update] so concurrent collectors
+     * cannot lose another track's bit via a stale read–copy–write.
      */
     private fun setMuteState(isEnabled: Boolean, trackType: TrackType) {
         logger.d { "[setPublishState] #sfu; $trackType isEnabled: $isEnabled" }
 
-        // update the local copy
-        val copy = muteState.value.toMutableMap()
-        copy[trackType] = isEnabled
-        val new = copy.toMap()
-        muteState.value = new
+        muteState.update { it + (trackType to isEnabled) }
 
         val currentSfu = sfuUrl
         // Coalesce retries for this track only. Other tracks keep their in-flight RPCs.

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -173,6 +173,7 @@ import stream.video.sfu.signal.UpdateSubscriptionsResponse
 import java.io.InterruptedIOException
 import java.net.SocketTimeoutException
 import java.util.Collections
+import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 /**
  * Keeps track of which track is being rendered at what resolution.
@@ -328,6 +329,13 @@ public class RtcSession internal constructor(
     },
 ) {
     private val muteStateSyncJobs = TrackKeyedJobs()
+
+    /**
+     * When false, [setMuteState] still records the latest desired mute bits locally but does
+     * not POST [UpdateMuteStatesRequest] — used while this session's SFU is being torn down
+     * for reconnect/migration so a media collector cannot target the old connection.
+     */
+    private val muteSyncEnabled = AtomicBoolean(true)
     private val oneBasedSessionCounter = sessionCounter + 1
 
     /**
@@ -1210,6 +1218,7 @@ public class RtcSession internal constructor(
 
     private suspend fun connectRtc() {
         logger.d { "[connectRtc] #sfu; #track; no args" }
+        resumeMuteSync()
         // step 6 - onNegotiationNeeded will trigger and complete the setup using SetPublisherRequest
         publisher.value?.let {
             listenToMediaChanges()
@@ -1304,6 +1313,8 @@ public class RtcSession internal constructor(
         }
 
         mediaScope.cancel()
+        muteSyncEnabled.set(false)
+        muteStateSyncJobs.cancelAll()
 
         // cleanup all non-local tracks
         supervisorJob.cancel()
@@ -1349,15 +1360,30 @@ public class RtcSession internal constructor(
      *
      * The local mute map is updated with [MutableStateFlow.update] so concurrent collectors
      * cannot lose another track's bit via a stale read–copy–write.
+     *
+     * During reconnect/migration, [cancelActiveWork] pauses SFU sync so collectors can keep
+     * recording the latest desired bits without posting to a stale connection. Sync resumes
+     * from [connectRtc] once the active SFU is ready.
      */
     private fun setMuteState(isEnabled: Boolean, trackType: TrackType) {
         logger.d { "[setPublishState] #sfu; $trackType isEnabled: $isEnabled" }
 
         muteState.update { it + (trackType to isEnabled) }
+        syncMuteStateToSfu(trackType, isEnabled)
+    }
+
+    private fun syncMuteStateToSfu(trackType: TrackType, isEnabled: Boolean) {
+        if (!muteSyncEnabled.get()) {
+            logger.d {
+                "[syncMuteStateToSfu] deferred until SFU is ready; $trackType isEnabled: $isEnabled"
+            }
+            return
+        }
 
         val currentSfu = sfuUrl
         // Coalesce retries for this track only. Other tracks keep their in-flight RPCs.
         muteStateSyncJobs.launch(coroutineScope, trackType) {
+            if (!muteSyncEnabled.get()) return@launch
             flow {
                 val request = UpdateMuteStatesRequest(
                     session_id = sessionId,
@@ -1372,6 +1398,7 @@ public class RtcSession internal constructor(
                 emit(response)
             }.flowOn(DispatcherProvider.IO).retryWhen { cause, attempt ->
                 if (cause is SessionFatalException) return@retryWhen false
+                if (!muteSyncEnabled.get()) return@retryWhen false
                 val sameValue = muteState.value[trackType] == isEnabled
                 val sameSfu = currentSfu == sfuUrl
                 val isPermanent = isPermanentError(cause)
@@ -1383,6 +1410,14 @@ public class RtcSession internal constructor(
                 delay(delayInMs)
                 willRetry
             }.collect()
+        }
+    }
+
+    private fun resumeMuteSync() {
+        if (!muteSyncEnabled.compareAndSet(false, true)) return
+        logger.d { "[resumeMuteSync] flushing latest mute state to the active SFU" }
+        muteState.value.forEach { (trackType, isEnabled) ->
+            syncMuteStateToSfu(trackType, isEnabled)
         }
     }
 
@@ -2121,6 +2156,7 @@ public class RtcSession internal constructor(
         if (cancelEventJob) eventJob?.cancel()
         iceMonitoringJob?.cancel()
         iceMonitoringJob = null
+        muteSyncEnabled.set(false)
         muteStateSyncJobs.cancelAll()
         participantsMonitoringJob?.cancel()
         participantsMonitoringJob = null

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/TrackKeyedJobs.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/TrackKeyedJobs.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import stream.video.sfu.models.TrackType
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * One job per [TrackType]. Replacing a job cancels only that track's previous work, so an
+ * in-flight audio mute RPC is not dropped when video or screen-share sync starts.
+ */
+internal class TrackKeyedJobs {
+    private val jobs = ConcurrentHashMap<TrackType, Job>()
+
+    fun launch(
+        scope: CoroutineScope,
+        trackType: TrackType,
+        block: suspend CoroutineScope.() -> Unit,
+    ) {
+        val job = scope.launch(start = CoroutineStart.LAZY, block = block)
+        jobs.put(trackType, job)?.cancel()
+        job.start()
+    }
+
+    fun cancelAll() {
+        jobs.values.forEach { it.cancel() }
+        jobs.clear()
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/TrackKeyedJobsTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/TrackKeyedJobsTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import stream.video.sfu.models.TrackType
+import java.util.concurrent.atomic.AtomicBoolean
+
+class TrackKeyedJobsTest {
+
+    @Test
+    fun `launching a second track does not cancel the first track's job`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
+        val jobs = TrackKeyedJobs()
+        val release = CompletableDeferred<Unit>()
+        val audioDone = AtomicBoolean(false)
+        val videoDone = AtomicBoolean(false)
+
+        try {
+            jobs.launch(scope, TrackType.TRACK_TYPE_AUDIO) {
+                release.await()
+                audioDone.set(true)
+            }
+            jobs.launch(scope, TrackType.TRACK_TYPE_VIDEO) {
+                release.await()
+                videoDone.set(true)
+            }
+
+            release.complete(Unit)
+
+            assertThat(audioDone.get()).isTrue()
+            assertThat(videoDone.get()).isTrue()
+        } finally {
+            scope.coroutineContext[Job]?.cancel()
+        }
+    }
+
+    @Test
+    fun `launching the same track cancels the previous job`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
+        val jobs = TrackKeyedJobs()
+        val firstHold = CompletableDeferred<Unit>()
+        val firstDone = AtomicBoolean(false)
+        val secondDone = AtomicBoolean(false)
+
+        try {
+            jobs.launch(scope, TrackType.TRACK_TYPE_AUDIO) {
+                firstHold.await()
+                firstDone.set(true)
+            }
+            jobs.launch(scope, TrackType.TRACK_TYPE_AUDIO) {
+                secondDone.set(true)
+            }
+            firstHold.complete(Unit)
+
+            assertThat(firstDone.get()).isFalse()
+            assertThat(secondDone.get()).isTrue()
+        } finally {
+            scope.coroutineContext[Job]?.cancel()
+        }
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/TrackKeyedJobsTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/TrackKeyedJobsTest.kt
@@ -79,4 +79,34 @@ class TrackKeyedJobsTest {
             scope.coroutineContext[Job]?.cancel()
         }
     }
+
+    @Test
+    fun `cancelAll cancels every track job and clears the map`() = runTest {
+        val scope = CoroutineScope(UnconfinedTestDispatcher(testScheduler) + Job())
+        val jobs = TrackKeyedJobs()
+        val audioHold = CompletableDeferred<Unit>()
+        val videoHold = CompletableDeferred<Unit>()
+        val audioDone = AtomicBoolean(false)
+        val videoDone = AtomicBoolean(false)
+
+        try {
+            jobs.launch(scope, TrackType.TRACK_TYPE_AUDIO) {
+                audioHold.await()
+                audioDone.set(true)
+            }
+            jobs.launch(scope, TrackType.TRACK_TYPE_VIDEO) {
+                videoHold.await()
+                videoDone.set(true)
+            }
+
+            jobs.cancelAll()
+            audioHold.complete(Unit)
+            videoHold.complete(Unit)
+
+            assertThat(audioDone.get()).isFalse()
+            assertThat(videoDone.get()).isFalse()
+        } finally {
+            scope.coroutineContext[Job]?.cancel()
+        }
+    }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -80,6 +80,7 @@ import stream.video.sfu.models.WebsocketReconnectStrategy
 import stream.video.sfu.signal.StartNoiseCancellationRequest
 import stream.video.sfu.signal.StopNoiseCancellationRequest
 import java.io.InterruptedIOException
+import java.util.concurrent.atomic.AtomicBoolean
 
 class RtcSessionTest2 {
 
@@ -927,6 +928,53 @@ class RtcSessionTest2 {
     }
 
     @Test
+    fun `mute collectors during migration keep local state and do not call the old SFU`() =
+        runTest(testDispatcher) {
+            val signalService = mockk<SignalServerService>(relaxed = true)
+            ownCapabilitiesFlow.value = listOf(OwnCapability.SendAudio)
+            val (rtcSession, publisherMock) = muteSyncSession(signalService)
+            rtcSession.publisher.value = publisherMock
+            val audioTrack = mockk<org.webrtc.AudioTrack>(relaxed = true)
+            coEvery {
+                publisherMock.publishStream(any(), TrackType.TRACK_TYPE_AUDIO)
+            } returns audioTrack
+
+            rtcSession.enterMigration()
+            rtcSession.createAndPublishAudioTrack()
+            testScheduler.advanceUntilIdle()
+
+            assertEquals(true, rtcSession.muteState.value[TrackType.TRACK_TYPE_AUDIO])
+            coVerify(exactly = 0) { signalService.updateMuteStates(any()) }
+        }
+
+    @Test
+    fun `mute sync resumes and flushes local state once the SFU is ready`() = runTest(
+        testDispatcher,
+    ) {
+        val signalService = mockk<SignalServerService>(relaxed = true)
+        ownCapabilitiesFlow.value = listOf(OwnCapability.SendAudio)
+        val (rtcSession, publisherMock) = muteSyncSession(signalService)
+        rtcSession.publisher.value = publisherMock
+        val audioTrack = mockk<org.webrtc.AudioTrack>(relaxed = true)
+        coEvery {
+            publisherMock.publishStream(any(), TrackType.TRACK_TYPE_AUDIO)
+        } returns audioTrack
+
+        rtcSession.enterMigration()
+        rtcSession.createAndPublishAudioTrack()
+        testScheduler.advanceUntilIdle()
+        coVerify(exactly = 0) { signalService.updateMuteStates(any()) }
+        assertEquals(false, muteSyncEnabled(rtcSession).get())
+
+        RtcSession::class.java.getDeclaredMethod("resumeMuteSync").apply {
+            isAccessible = true
+            invoke(rtcSession)
+        }
+
+        assertEquals(true, muteSyncEnabled(rtcSession).get())
+    }
+
+    @Test
     fun `stopNoiseCancellation sends the request to the SFU with the session id`() = runTest {
         // Given
         val signalService = mockk<SignalServerService>(relaxed = true)
@@ -941,6 +989,44 @@ class RtcSessionTest2 {
                 StopNoiseCancellationRequest(session_id = "session-id"),
             )
         }
+    }
+
+    private fun muteSyncEnabled(rtcSession: RtcSession): AtomicBoolean {
+        val field = RtcSession::class.java.getDeclaredField("muteSyncEnabled")
+        field.isAccessible = true
+        return field.get(rtcSession) as AtomicBoolean
+    }
+
+    private fun muteSyncSession(
+        signalService: SignalServerService,
+    ): Pair<RtcSession, Publisher> {
+        val mockModule = mockk<SfuConnectionModule>(relaxed = true) {
+            every { api } returns signalService
+        }
+        val rtcSession = spyk(
+            RtcSession(
+                client = mockStreamVideo,
+                powerManager = mockPowerManager,
+                call = mockCall,
+                sessionManager = CallSessionManager(),
+                sessionId = "session-id",
+                apiKey = "api-key",
+                lifecycle = mockLifecycle,
+                sfuUrl = "https://test-sfu.stream.com",
+                sfuWsUrl = "wss://test-sfu.stream.com",
+                sfuToken = "fake-sfu-token",
+                sfuName = "test-sfu-edge",
+                clientImpl = mockVideoClient,
+                coroutineScope = testScope,
+                rtcSessionScope = testScope,
+                remoteIceServers = emptyList(),
+                sfuConnectionModuleProvider = { mockModule },
+                sfuAnalytics = SfuAnalytics.getFakeSfuAnalytics(),
+            ),
+            recordPrivateCalls = true,
+        )
+        val publisherMock = mockk<Publisher>(relaxed = true)
+        return rtcSession to publisherMock
     }
 
     private fun noiseCancellationSession(


### PR DESCRIPTION
### Goal

Two **pre-existing** races in `setMuteState`, both easy to hit when fast reconnect restarts `listenToMediaChanges` and audio/video collectors fire together:

1. One shared `muteStateSyncJob` cancelled every in-flight `UpdateMuteStates` when another track published. Logs: `HTTP FAILED: java.io.IOException: Canceled` while outbound audio RTP kept climbing.
2. The local mute map was a non-atomic read–copy–write, so concurrent collectors could drop another track's bit and `retryWhen` could stop for the wrong reason.

Fixes [AND-1474](https://linear.app/stream/issue/AND-1474/mute-sync-cancels-in-flight-updatemutestates-for-other-tracks). Independent of AND-1455.

### Implementation

- Per-`TrackType` jobs (`TrackKeyedJobs`): video/screen-share sync no longer cancels an in-flight audio unmute. Same-track updates still cancel the previous job so retries coalesce.
- `muteState.update { it + (trackType to isEnabled) }` so concurrent map writes cannot lose another track's entry.
- Mute-state retries compare only that track's intended value.
- Session teardown still cancels all mute-sync jobs.

### Testing

- [x] `./gradlew :stream-video-android-core:testDebugUnitTest --tests 'io.getstream.video.android.core.call.TrackKeyedJobsTest'` — passed
- [x] `./gradlew :stream-video-android-core:spotlessApply`
- [ ] Manual: two-person video call, debug menu **SFU fast reconnect**. Confirm `UpdateMuteStates` for audio and video both complete (no `IOException: Canceled` from a sibling track). Mic/camera stay in the state they were in before reconnect.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (required internally)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
- [ ] Tutorial starter kit updated
- [ ] Examples/guides starter kits updated (`stream-video-examples`)

### ☑️Reviewer Checklist
- [ ] XML sample runs & works
- [ ] Compose sample runs & works
- [ ] Tutorial starter kit
- [ ] Example starter kits work
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

N/A — signaling-only fix, no UI change.