### PR TITLE
Surface coordinator error body from apiCall

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -317,23 +317,27 @@ internal class StreamVideoClient internal constructor(
         try {
             apiCall()
         } catch (e: HttpException) {
-            // Retry once with a new token if the token is expired
-            if (e.isAuthError()) {
+            // parseError consumes the body, so this has to happen once. Rethrowing the raw
+            // HttpException would leave callers with only "HTTP 400" and drop the
+            // coordinator's actual reason.
+            val failure = parseError(e)
+            val networkError = failure.value as? Error.NetworkError
+            if (networkError != null && networkError.isAuthError()) {
                 val newToken = tokenProvider.loadToken()
                 tokenRepository.updateToken(newToken)
                 token = newToken
                 coordinatorConnectionModule.updateToken(newToken)
                 apiCall()
             } else {
-                throw e
+                val serverMessage = networkError?.message ?: e.message
+                logger.e { "[apiCall] HTTP ${e.code()}: $serverMessage" }
+                throw Exception(serverMessage, e)
             }
         }
     }
 
-    private fun HttpException.isAuthError(): Boolean {
-        val failure = parseError(this)
-        val parsedError = failure.value as Error.NetworkError
-        return when (parsedError.serverErrorCode) {
+    private fun Error.NetworkError.isAuthError(): Boolean {
+        return when (serverErrorCode) {
             VideoErrorCode.AUTHENTICATION_ERROR.code,
             VideoErrorCode.TOKEN_EXPIRED.code,
             VideoErrorCode.TOKEN_NOT_VALID.code,

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/StreamVideoClient.kt
@@ -302,7 +302,7 @@ internal class StreamVideoClient internal constructor(
      */
     internal suspend fun <T : Any> apiCall(
         apiCall: suspend () -> T,
-    ): Result<T> = safeSuspendingCallWithResult {
+    ): Result<T> {
         // Guest users have an asynchronous setup (createGuest) that fetches their JWT.
         // Any authenticated request that fires before that completes goes out without
         // an Authorization header and stream-auth-type "anonymous", so the backend
@@ -313,27 +313,56 @@ internal class StreamVideoClient internal constructor(
         // await throw if setupGuestUser failed — safeSuspendingCallWithResult turns
         // it into Result.Failure, which is the right outcome (the caller didn't get
         // a valid guest session, so the request can't proceed).
-        guestUserJob?.takeIf { currentCoroutineContext()[Job] !== it }?.await()
-        try {
-            apiCall()
-        } catch (e: HttpException) {
-            // parseError consumes the body, so this has to happen once. Rethrowing the raw
-            // HttpException would leave callers with only "HTTP 400" and drop the
-            // coordinator's actual reason.
-            val failure = parseError(e)
-            val networkError = failure.value as? Error.NetworkError
-            if (networkError != null && networkError.isAuthError()) {
-                val newToken = tokenProvider.loadToken()
-                tokenRepository.updateToken(newToken)
-                token = newToken
-                coordinatorConnectionModule.updateToken(newToken)
-                apiCall()
-            } else {
-                val serverMessage = networkError?.message ?: e.message
-                logger.e { "[apiCall] HTTP ${e.code()}: $serverMessage" }
-                throw Exception(serverMessage, e)
+        val prepared = safeSuspendingCallWithResult {
+            guestUserJob?.takeIf { currentCoroutineContext()[Job] !== it }?.await()
+            Unit
+        }
+        if (prepared is Failure) return prepared
+
+        return try {
+            try {
+                Success(apiCall())
+            } catch (e: HttpException) {
+                handleCoordinatorHttpFailure(e, apiCall)
+            }
+        } catch (e: Exception) {
+            safeSuspendingCallWithResult<T> { throw e }
+        }
+    }
+
+    /**
+     * parseError consumes the body, so each HttpException is parsed once. The failure
+     * keeps [HttpException] as [Error.ThrowableError.cause] so callers that classify
+     * HTTP errors by type still work. Wrapping it in a generic Exception would break
+     * that contract. The retry is parsed the same way — a second HttpException after
+     * token refresh must not fall through as a raw "HTTP 4xx".
+     */
+    private suspend fun <T : Any> handleCoordinatorHttpFailure(
+        first: HttpException,
+        apiCall: suspend () -> T,
+    ): Result<T> {
+        val firstError = parseError(first).value as Error.NetworkError
+        if (firstError.isAuthError()) {
+            val newToken = tokenProvider.loadToken()
+            tokenRepository.updateToken(newToken)
+            token = newToken
+            coordinatorConnectionModule.updateToken(newToken)
+            return try {
+                Success(apiCall())
+            } catch (retry: HttpException) {
+                coordinatorHttpFailure(retry)
             }
         }
+        return coordinatorHttpFailure(first, firstError)
+    }
+
+    private fun coordinatorHttpFailure(
+        exception: HttpException,
+        parsed: Error.NetworkError? = null,
+    ): Failure {
+        val networkError = parsed ?: parseError(exception).value as Error.NetworkError
+        logger.e { "[apiCall] HTTP ${exception.code()}: ${networkError.message}" }
+        return Failure(Error.ThrowableError(networkError.message, exception))
     }
 
     private fun Error.NetworkError.isAuthError(): Boolean {
@@ -377,23 +406,30 @@ internal class StreamVideoClient internal constructor(
                     ignoreUnknownKeys = true
                 }
                 format.decodeFromString<ErrorResponse>(errorBody)
-            } catch (e: Exception) {
+            } catch (parseException: Exception) {
                 return Failure(
                     Error.NetworkError(
-                        "failed to parse error response from server: ${e.message}",
-                        VideoErrorCode.PARSER_ERROR.code,
+                        message = "failed to parse error response from server: ${parseException.message}",
+                        serverErrorCode = VideoErrorCode.PARSER_ERROR.code,
+                        statusCode = e.code(),
+                        cause = e,
                     ),
                 )
             }
         } ?: return Failure(
-            Error.NetworkError("failed to parse error response from server", e.code()),
+            Error.NetworkError(
+                message = "failed to parse error response from server",
+                serverErrorCode = e.code(),
+                statusCode = e.code(),
+                cause = e,
+            ),
         )
         return Failure(
             Error.NetworkError(
                 message = error.message,
                 serverErrorCode = error.code,
                 statusCode = error.statusCode,
-                cause = Throwable(error.moreInfo),
+                cause = e,
             ),
         )
     }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
@@ -25,11 +25,13 @@ import io.getstream.android.video.generated.models.CallSessionStartedEvent
 import io.getstream.android.video.generated.models.CreateGuestResponse
 import io.getstream.android.video.generated.models.UserResponse
 import io.getstream.android.video.generated.models.VideoEvent
+import io.getstream.result.Result
 import io.getstream.video.android.core.call.CallBusyHandler
 import io.getstream.video.android.core.call.RtcSession
 import io.getstream.video.android.core.events.VideoEventListener
 import io.getstream.video.android.core.internal.module.CoordinatorConnectionModule
 import io.getstream.video.android.core.notifications.internal.StreamNotificationManager
+import io.getstream.video.android.core.socket.common.token.TokenProvider
 import io.getstream.video.android.core.socket.common.token.TokenRepository
 import io.getstream.video.android.core.sounds.RingingCallVibrationConfig
 import io.getstream.video.android.core.sounds.Sounds
@@ -50,9 +52,13 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.After
 import org.junit.Before
 import org.threeten.bp.OffsetDateTime
+import retrofit2.HttpException
+import retrofit2.Response
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -80,7 +86,9 @@ class StreamVideoClientTest {
         unmockkAll()
     }
 
-    private fun prepareClient(): StreamVideoClient {
+    private fun prepareClient(
+        tokenProvider: TokenProvider = mockk(relaxed = true),
+    ): StreamVideoClient {
         val context = mockk<Context>(relaxed = true)
         val lifecycle = mockk<Lifecycle>(relaxed = true)
         val coordinator = mockk<CoordinatorConnectionModule>(relaxed = true)
@@ -98,6 +106,7 @@ class StreamVideoClientTest {
                 lifecycle = lifecycle,
                 coordinatorConnectionModule = coordinator,
                 tokenRepository = tokenRepo,
+                tokenProvider = tokenProvider,
                 streamNotificationManager = notificationManager,
                 enableCallNotificationUpdates = false,
                 sounds = sounds,
@@ -356,9 +365,51 @@ class StreamVideoClientTest {
 
         assertFalse(blockRan, "apiCall must not invoke the request block when guest setup failed")
         assertTrue(
-            result is io.getstream.result.Result.Failure,
+            result is Result.Failure,
             "expected Result.Failure, got $result",
         )
+    }
+
+    // parseError consumes the response body. The old path parsed it only to decide
+    // whether to refresh the token, then rethrew the raw HttpException — callers
+    // saw "HTTP 400" and lost the coordinator's reason.
+    @Test
+    fun `apiCall surfaces the coordinator error message instead of a raw HTTP status`() = runTest {
+        val reason = "User 'marcelo' with role 'user' is not allowed to perform action UpdateCall"
+        val result = client.apiCall<String> {
+            throw coordinatorHttpException(code = 403, message = reason, serverCode = 4)
+        }
+
+        assertTrue(result is Result.Failure, "expected Failure, got $result")
+        val error = (result as Result.Failure).value
+        assertTrue(
+            error.message.contains(reason),
+            "expected coordinator reason in ${error.message}",
+        )
+    }
+
+    @Test
+    fun `apiCall retries once after an auth error`() = runTest {
+        val tokenProvider = mockk<TokenProvider>()
+        coEvery { tokenProvider.loadToken() } returns "refreshed-token"
+        val client = prepareClient(tokenProvider = tokenProvider)
+        var attempts = 0
+
+        val result = client.apiCall {
+            attempts++
+            if (attempts == 1) {
+                throw coordinatorHttpException(
+                    code = 401,
+                    message = "token expired",
+                    serverCode = 40,
+                )
+            }
+            "ok"
+        }
+
+        assertEquals("ok", (result as Result.Success).value)
+        assertEquals(2, attempts)
+        coVerify(exactly = 1) { tokenProvider.loadToken() }
     }
 
     // Regression: StreamNotificationManager.createDevice() calls api.createDevice() directly
@@ -444,5 +495,15 @@ class StreamVideoClientTest {
         // adopted identity automatically — no separate mirror to keep in sync.
         assertEquals("server_normalized_id", client.state.user.value?.id)
         assertEquals(UserType.Guest, client.state.user.value?.type)
+    }
+
+    private fun coordinatorHttpException(
+        code: Int,
+        message: String,
+        serverCode: Int,
+    ): HttpException {
+        val json = """{"code":$serverCode,"message":"$message","StatusCode":$code,"more_info":""}"""
+        val body = json.toResponseBody("application/json".toMediaType())
+        return HttpException(Response.error<Unit>(code, body))
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/StreamVideoClientTest.kt
@@ -25,6 +25,7 @@ import io.getstream.android.video.generated.models.CallSessionStartedEvent
 import io.getstream.android.video.generated.models.CreateGuestResponse
 import io.getstream.android.video.generated.models.UserResponse
 import io.getstream.android.video.generated.models.VideoEvent
+import io.getstream.result.Error
 import io.getstream.result.Result
 import io.getstream.video.android.core.call.CallBusyHandler
 import io.getstream.video.android.core.call.RtcSession
@@ -376,16 +377,21 @@ class StreamVideoClientTest {
     @Test
     fun `apiCall surfaces the coordinator error message instead of a raw HTTP status`() = runTest {
         val reason = "User 'marcelo' with role 'user' is not allowed to perform action UpdateCall"
-        val result = client.apiCall<String> {
-            throw coordinatorHttpException(code = 403, message = reason, serverCode = 4)
-        }
+        val thrown = coordinatorHttpException(code = 403, message = reason, serverCode = 4)
+        val result = client.apiCall<String> { throw thrown }
 
         assertTrue(result is Result.Failure, "expected Failure, got $result")
-        val error = (result as Result.Failure).value
+        val error = result.value
+        assertTrue(error is Error.ThrowableError, "expected ThrowableError, got $error")
         assertTrue(
             error.message.contains(reason),
             "expected coordinator reason in ${error.message}",
         )
+        assertTrue(
+            error.cause is HttpException,
+            "HTTP failures must keep HttpException as the cause, got ${error.cause}",
+        )
+        assertEquals(thrown, error.cause)
     }
 
     @Test
@@ -408,6 +414,41 @@ class StreamVideoClientTest {
         }
 
         assertEquals("ok", (result as Result.Success).value)
+        assertEquals(2, attempts)
+        coVerify(exactly = 1) { tokenProvider.loadToken() }
+    }
+
+    @Test
+    fun `apiCall surfaces coordinator message when the post-refresh request also fails`() = runTest {
+        val tokenProvider = mockk<TokenProvider>()
+        coEvery { tokenProvider.loadToken() } returns "refreshed-token"
+        val client = prepareClient(tokenProvider = tokenProvider)
+        val reason = "User 'marcelo' with role 'user' is not allowed to perform action UpdateCall"
+        var attempts = 0
+
+        val result = client.apiCall<String> {
+            attempts++
+            if (attempts == 1) {
+                throw coordinatorHttpException(
+                    code = 401,
+                    message = "token expired",
+                    serverCode = 40,
+                )
+            }
+            throw coordinatorHttpException(code = 403, message = reason, serverCode = 4)
+        }
+
+        assertTrue(result is Result.Failure, "expected Failure, got $result")
+        val error = result.value
+        assertTrue(error is Error.ThrowableError, "expected ThrowableError, got $error")
+        assertTrue(
+            error.message.contains(reason),
+            "expected coordinator reason after refresh in ${error.message}",
+        )
+        assertTrue(
+            error.cause is HttpException,
+            "post-refresh HTTP failures must keep HttpException as the cause, got ${error.cause}",
+        )
         assertEquals(2, attempts)
         coVerify(exactly = 1) { tokenProvider.loadToken() }
     }


### PR DESCRIPTION
### Goal
Fixes [AND-1478](https://linear.app/stream/issue/AND-1478/surface-coordinator-error-body-from-streamvideoclientapicall) — Coordinator rejections from `StreamVideoClient.apiCall` should expose the server message, not a bare HTTP status.

`parseError` consumes the response body. The old path used it only for the auth-retry check, then rethrew the raw `HttpException`, so callers only saw `HTTP 400`.

### Implementation
- Parse the error body once in `apiCall`.
- Use the parsed `NetworkError` for the auth-retry check.
- On non-auth failures, log and throw the coordinator message.
- Add unit tests for the surfaced message and the auth retry.

### Testing
- `./gradlew :stream-video-android-core:testDebugUnitTest --tests "io.getstream.video.android.core.StreamVideoClientTest"`
- `./gradlew spotlessApply`
- Trigger a coordinator 403/400 (for example a `user` calling `UpdateCall`) and confirm the log/result includes the server reason.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of network errors by surfacing clearer server-provided error messages.
  * Authentication failures now trigger a single token refresh and retry.
  * Prevented duplicate parsing of error responses for more reliable error handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->