### PR TITLE
Recover the connection state when a peer connection stays NEW after a reconnect

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/RtcSession.kt
@@ -798,45 +798,25 @@ public class RtcSession internal constructor(
         }
     }
 
+    /** Applies [iceHealthTransition] to the current state. Internal for direct testing. */
+    internal fun evaluateIceHealth() {
+        val pubIce = publisher.value?.iceState?.value
+        val subIce = subscriber.value?.iceState?.value
+        val next = iceHealthTransition(
+            connection = call.state.connection.value,
+            sfuSocketConnected = _sfuSfuSocketState.value is SfuSocketState.Connected,
+            publisherIce = pubIce,
+            subscriberIce = subIce,
+        )
+        if (next != null) {
+            logger.i { "[iceMonitor] pub=$pubIce, sub=$subIce — marking $next" }
+            call.state._connection.value = next
+        }
+    }
+
     private fun startIceMonitoring() {
         if (iceMonitoringJob?.isActive == true) return
         iceMonitoringJob = coroutineScope.launch {
-            val badIceStates = setOf(
-                PeerConnection.IceConnectionState.DISCONNECTED,
-                PeerConnection.IceConnectionState.FAILED,
-            )
-            val goodIceStates = setOf(
-                PeerConnection.IceConnectionState.CONNECTED,
-                PeerConnection.IceConnectionState.COMPLETED,
-            )
-
-            fun evaluateIceHealth() {
-                val conn = call.state.connection.value
-                val pubIce = publisher.value?.iceState?.value
-                val subIce = subscriber.value?.iceState?.value
-
-                val pubBad = pubIce != null && pubIce in badIceStates
-                val subBad = subIce != null && subIce in badIceStates
-
-                if ((pubBad || subBad) && conn is RealtimeConnection.Connected) {
-                    logger.w {
-                        "[iceMonitor] ICE degraded (pub=$pubIce, sub=$subIce) — marking Reconnecting"
-                    }
-                    call.state._connection.value = RealtimeConnection.Reconnecting
-                } else if (conn is RealtimeConnection.Reconnecting &&
-                    _sfuSfuSocketState.value is SfuSocketState.Connected
-                ) {
-                    val pubOk = pubIce == null || pubIce in goodIceStates
-                    val subOk = subIce == null || subIce in goodIceStates
-                    if (pubOk && subOk) {
-                        logger.i {
-                            "[iceMonitor] ICE recovered (pub=$pubIce, sub=$subIce) — marking Connected"
-                        }
-                        call.state._connection.value = RealtimeConnection.Connected
-                    }
-                }
-            }
-
             launch {
                 publisher.collect { pub ->
                     pub?.iceState?.collect { evaluateIceHealth() }
@@ -846,6 +826,12 @@ public class RtcSession internal constructor(
                 subscriber.collect { sub ->
                     sub?.iceState?.collect { evaluateIceHealth() }
                 }
+            }
+            // The evaluation is edge-triggered by ICE changes, but after a reconnect the ICE
+            // states can settle before the SFU socket reports Connected. Re-evaluate on socket
+            // state changes too, so recovery does not depend on a later ICE transition.
+            launch {
+                _sfuSfuSocketState.collect { evaluateIceHealth() }
             }
         }
     }
@@ -2209,7 +2195,49 @@ public class RtcSession internal constructor(
     private fun connectInternalSafetyTimeoutMs(): Long =
         clientImpl.connectionTimeoutInMs * 2 + CONNECT_INTERNAL_SAFETY_GRACE_MS
 
-    private companion object {
+    internal companion object {
+        private val badIceStates = setOf(
+            PeerConnection.IceConnectionState.DISCONNECTED,
+            PeerConnection.IceConnectionState.FAILED,
+        )
+
+        /**
+         * Decides the ICE health transition for the realtime connection, or null for no change.
+         *
+         * Degrades a Connected call when either peer connection reports a bad ICE state.
+         * Recovers a Reconnecting call once the SFU socket is connected and no side is bad.
+         * NEW and CHECKING count as healthy for the recovery: a peer connection with nothing
+         * to negotiate stays NEW forever (e.g. the subscriber right after a reconnect with no
+         * inbound tracks), so requiring an established state on both sides deadlocks the
+         * recovery and the UI shows "Reconnecting" indefinitely. If a side later fails, the
+         * degraded branch marks Reconnecting again.
+         */
+        internal fun iceHealthTransition(
+            connection: RealtimeConnection,
+            sfuSocketConnected: Boolean,
+            publisherIce: PeerConnection.IceConnectionState?,
+            subscriberIce: PeerConnection.IceConnectionState?,
+        ): RealtimeConnection? {
+            val pubBad = publisherIce != null && publisherIce in badIceStates
+            val subBad = subscriberIce != null && subscriberIce in badIceStates
+            // CLOSED must also block a recovery: a closed peer connection never emits another
+            // ICE event, so recovering past it would lock in a wrong Connected state. It is
+            // deliberately not a degrade trigger, because peer connections close during
+            // legitimate teardowns and the closing flow owns the connection state there.
+            val pubBlocked = pubBad || publisherIce == PeerConnection.IceConnectionState.CLOSED
+            val subBlocked = subBad || subscriberIce == PeerConnection.IceConnectionState.CLOSED
+            return when {
+                (pubBad || subBad) && connection is RealtimeConnection.Connected ->
+                    RealtimeConnection.Reconnecting
+
+                connection is RealtimeConnection.Reconnecting && sfuSocketConnected &&
+                    !pubBlocked && !subBlocked ->
+                    RealtimeConnection.Connected
+
+                else -> null
+            }
+        }
+
         private const val CONNECT_INTERNAL_SAFETY_GRACE_MS = 1_000L
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/rtc/RtcSessionTest2.kt
@@ -24,6 +24,7 @@ import io.getstream.video.android.core.Call
 import io.getstream.video.android.core.CallState
 import io.getstream.video.android.core.MediaManagerImpl
 import io.getstream.video.android.core.ParticipantState
+import io.getstream.video.android.core.RealtimeConnection
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
@@ -70,6 +71,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import org.webrtc.PeerConnection
 import org.webrtc.SessionDescription
 import stream.video.sfu.event.ReconnectDetails
 import stream.video.sfu.models.PeerType
@@ -861,6 +863,153 @@ class RtcSessionTest2 {
             every { isReconnected } returns false
             every { this@mockk.publishOptions } returns publishOptions
         }
+    }
+
+    @Test
+    fun `iceHealthTransition recovers a reconnecting call when no ICE side is bad`() {
+        // The subscriber has nothing to negotiate after a reconnect and stays NEW; that must
+        // not block the recovery (it deadlocked the connection state as Reconnecting forever).
+        assertEquals(
+            RealtimeConnection.Connected,
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Reconnecting,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.CONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.NEW,
+            ),
+        )
+        // No peer connections at all: the connected socket is the only transport signal.
+        assertEquals(
+            RealtimeConnection.Connected,
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Reconnecting,
+                sfuSocketConnected = true,
+                publisherIce = null,
+                subscriberIce = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `iceHealthTransition does not recover while an ICE side is bad or the socket is down`() {
+        assertNull(
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Reconnecting,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.DISCONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.NEW,
+            ),
+        )
+        assertNull(
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Reconnecting,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.CONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.DISCONNECTED,
+            ),
+        )
+        assertNull(
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Reconnecting,
+                sfuSocketConnected = false,
+                publisherIce = PeerConnection.IceConnectionState.CONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.CONNECTED,
+            ),
+        )
+        // A closed peer connection never emits another ICE event, so it must block recovery.
+        assertNull(
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Reconnecting,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.CONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.CLOSED,
+            ),
+        )
+        assertNull(
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Reconnecting,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.CLOSED,
+                subscriberIce = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `iceHealthTransition degrades a connected call when an ICE side goes bad`() {
+        assertEquals(
+            RealtimeConnection.Reconnecting,
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Connected,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.FAILED,
+                subscriberIce = PeerConnection.IceConnectionState.NEW,
+            ),
+        )
+        assertEquals(
+            RealtimeConnection.Reconnecting,
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Connected,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.CONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.FAILED,
+            ),
+        )
+        assertNull(
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Connected,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.CONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.NEW,
+            ),
+        )
+        // CLOSED does not degrade: peer connections close during legitimate teardowns and
+        // the closing flow owns the connection state there.
+        assertNull(
+            RtcSession.iceHealthTransition(
+                connection = RealtimeConnection.Connected,
+                sfuSocketConnected = true,
+                publisherIce = PeerConnection.IceConnectionState.CONNECTED,
+                subscriberIce = PeerConnection.IceConnectionState.CLOSED,
+            ),
+        )
+    }
+
+    @Test
+    fun `evaluateIceHealth applies the transition to the connection state`() = runTest(
+        testDispatcher,
+    ) {
+        every { mockCallState.connection } returns
+            MutableStateFlow<RealtimeConnection>(RealtimeConnection.Connected)
+        val internalConnection = mockk<MutableStateFlow<RealtimeConnection>>(relaxed = true)
+        every { mockCallState._connection } returns internalConnection
+
+        val rtcSession = RtcSession(
+            client = mockStreamVideo,
+            powerManager = mockPowerManager,
+            call = mockCall,
+            sessionManager = CallSessionManager(),
+            sessionId = "test-session-id",
+            apiKey = "test-api-key",
+            lifecycle = mockLifecycle,
+            sfuUrl = "https://test-sfu.stream.com",
+            sfuWsUrl = "wss://test-sfu.stream.com",
+            sfuToken = "fake-sfu-token",
+            sfuName = "test-sfu-edge",
+            clientImpl = mockVideoClient,
+            coroutineScope = testScope,
+            remoteIceServers = emptyList(),
+            sfuConnectionModuleProvider = { mockk(relaxed = true) },
+            sfuAnalytics = SfuAnalytics.getFakeSfuAnalytics(),
+        )
+        every { rtcSession.subscriber.value!!.iceState } returns
+            MutableStateFlow<PeerConnection.IceConnectionState?>(
+                PeerConnection.IceConnectionState.FAILED,
+            )
+
+        rtcSession.evaluateIceHealth()
+
+        verify { internalConnection.value = RealtimeConnection.Reconnecting }
     }
 
     private fun createRtcSessionSpyWithMockSocket(): Pair<RtcSession, Publisher> {


### PR DESCRIPTION
### Goal

Fix AND-1481. After a network blip a call can stay on "Reconnecting.." forever even though everything recovered. Split out of #1788 on review request, since `RtcSession` serves every product surface and this change deserves an isolated review and revert unit.

### Implementation

`RealtimeConnection.Connected` is only restored after a reconnect by the ICE health monitor in `RtcSession`, and its recovery required both peer connections to reach an established ICE state. A peer connection with nothing to negotiate stays `NEW` forever (for example the subscriber right after a reconnect when the remote side publishes nothing), so the recovery never fired.

The evidence is the logcat of [run 33514246516](https://github.com/GetStream/stream-video-android/actions/runs/33514246516) (API 34, `testReconnectionDuringCallRecording`, all 3 attempts): network restored at 13:46:52.3, SFU socket Connected at 13:46:53.2, the monitor correctly downgrades at 13:46:53.238 because the publisher ICE is still DISCONNECTED, the publisher ICE then recovers to CONNECTED at 13:46:53.5, but the subscriber stays NEW and the state stays Reconnecting until the test gives up 19 seconds later.

The change is limited to the monitor's state decision:

- The decision is extracted into `iceHealthTransition` (a pure function): recover when the SFU socket is connected and no ICE side is bad (DISCONNECTED or FAILED), instead of requiring both sides to be established. A side that fails later still flips the state back through the existing degraded branch.
- The monitor also re-evaluates on SFU socket state changes, so recovery does not depend on a later ICE edge.
- `evaluateIceHealth` is an internal member so the wrapper is directly testable.

### 🎨 UI Changes

Not applicable. The fix removes a state where the "Reconnecting.." banner never disappeared.

### Testing

- Pure unit tests in `RtcSessionTest2` pin the contract on both ICE sides, including the exact state combination from the CI logs (Reconnecting, socket connected, publisher CONNECTED, subscriber NEW). The recovery test fails against the old predicate (verified by temporarily restoring it).
- `testReconnectionDuringCallRecording` is the E2E that fails without this patch, probabilistically: the same pre-fix code failed 3 of 3 attempts on run 33514246516 and passed the full nightly hours earlier (run 33155106721), because the trigger needs the downgrade to land in the few hundred milliseconds after the socket reconnects on a loaded emulator. CI sampling: dispatch the "E2E Tests" workflow with `test_class: io.getstream.video.android.tests.ReconnectionTests#testReconnectionDuringCallRecording` and `api_level: 34` on develop versus this branch; every dispatch gives 3 independent samples.
- Manual reproduction, if wanted: join the other side with camera and microphone off (the subscriber ICE stays NEW), then toggle the caller's network off for about 5 seconds and back, repeatedly. For a deterministic repro, add a 2 to 3 second delay before the publisher ICE restart in the fast reconnect path.
- Note on SonarCloud coverage: the uncovered lines it may report in `RtcSession` are executed by the tests (the asserts prove it), but Kover cannot attribute them because `RtcSessionTest2` spies on `RtcSession` and the MockK inline agent retransforms the class in that JVM. The extracted `iceHealthTransition` logic registers coverage normally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved call recovery after reconnects, including sessions with no inbound media tracks.
  - Calls can now recover correctly while connection checks are still initializing.
  - Recovery responds more promptly to signaling connection changes instead of waiting for another network event.
  - Calls now reliably transition to reconnecting when network connectivity becomes unhealthy, and avoid falsely recovering while connectivity remains unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->