### PR TITLE
Distribute v2 demo app builds to Firebase App Distribution

### DIFF
--- a/.github/workflows/app-distribute-v2.yml
+++ b/.github/workflows/app-distribute-v2.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   build_v2_demo_app:
     permissions:
-      actions: write
       contents: read
     name: Build and Distribute V2 Demo App
     runs-on: ubuntu-24.04
@@ -27,15 +26,23 @@ jobs:
           RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
           RELEASE_KEYSTORE_PROPERTIES: ${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}
         run: |
-          echo "${{ env.RELEASE_KEYSTORE }}" > .sign/release.keystore.asc
-          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/release.keystore.asc > .sign/release.keystore
-          echo "${{ env.RELEASE_KEYSTORE_PROPERTIES }}" > .sign/keystore.properties.asc
-          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/keystore.properties.asc > .sign/keystore.properties
-          echo "${{ env.ENV_PROPERTIES }}" > .env.properties
+          echo "$RELEASE_KEYSTORE" > .sign/release.keystore.asc
+          gpg -d --batch --pinentry-mode loopback --passphrase-fd 0 \
+            .sign/release.keystore.asc > .sign/release.keystore <<< "$PASSPHRASE"
+          echo "$RELEASE_KEYSTORE_PROPERTIES" > .sign/keystore.properties.asc
+          gpg -d --batch --pinentry-mode loopback --passphrase-fd 0 \
+            .sign/keystore.properties.asc > .sign/keystore.properties <<< "$PASSPHRASE"
+          echo "$ENV_PROPERTIES" > .env.properties
       - name: Assemble
         run: bash ./gradlew :demo-app:assembleDevelopmentRelease --stacktrace
+      - name: Remove signing material
+        if: always()
+        run: |
+          rm -f .sign/release.keystore .sign/release.keystore.asc \
+                .sign/keystore.properties .sign/keystore.properties.asc \
+                .env.properties
       - name: Upload APK
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: demo-app-development-release
           path: demo-app/build/outputs/apk/development/release/

--- a/.github/workflows/app-distribute-v2.yml
+++ b/.github/workflows/app-distribute-v2.yml
@@ -8,6 +8,10 @@ on:
   push:
     branches:
       - develop-v2
+      # TEMPORARY, remove before merging this PR. A push trigger reads the workflow file from
+      # the branch being pushed, so this is the only way to verify the pipeline before it
+      # reaches develop-v2. workflow_dispatch is not available until the file is on develop.
+      - andrerego/and-1497-distribute-v2-demo-app-builds-via-firebase-app-distribution
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/app-distribute-v2.yml
+++ b/.github/workflows/app-distribute-v2.yml
@@ -1,0 +1,48 @@
+name: App Distribute CI v2
+
+# Temporary workflow to publish the v2 demo app to Firebase App Distribution in the shared
+# stream-android-32afb project. When v2 is released and `develop-v2` becomes `develop`, remove
+# this workflow and update the main `app-distribute.yml` instead.
+
+on:
+  push:
+    branches:
+      - develop-v2
+  workflow_dispatch:
+
+jobs:
+  build_v2_demo_app:
+    permissions:
+      actions: write
+      contents: read
+    name: Build and Distribute V2 Demo App
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: GetStream/android-ci-actions/actions/setup-java@cb46e4f44d105a68738bfd2a1cfd156bb768665b
+      - name: Prepare environment
+        env:
+          ENV_PROPERTIES: ${{ secrets.ENV_PROPERTIES }}
+          PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEYSTORE_PROPERTIES: ${{ secrets.RELEASE_KEYSTORE_PROPERTIES }}
+        run: |
+          echo "${{ env.RELEASE_KEYSTORE }}" > .sign/release.keystore.asc
+          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/release.keystore.asc > .sign/release.keystore
+          echo "${{ env.RELEASE_KEYSTORE_PROPERTIES }}" > .sign/keystore.properties.asc
+          gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/keystore.properties.asc > .sign/keystore.properties
+          echo "${{ env.ENV_PROPERTIES }}" > .env.properties
+      - name: Assemble
+        run: bash ./gradlew :demo-app:assembleDevelopmentRelease --stacktrace
+      - name: Upload APK
+        uses: actions/upload-artifact@v7
+        with:
+          name: demo-app-development-release
+          path: demo-app/build/outputs/apk/development/release/
+      - name: Upload artifact to Firebase App Distribution
+        uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6
+        with:
+          appId: ${{ secrets.FIREBASE_V2_DEMO_APP_ID }}
+          serviceCredentialsFileContent: ${{ secrets.STREAM_ANDROID_FIREBASE_CREDENTIALS_APP_CONTENT }}
+          groups: stream-testers
+          file: demo-app/build/outputs/apk/development/release/demo-app-development-release.apk

--- a/.github/workflows/app-distribute-v2.yml
+++ b/.github/workflows/app-distribute-v2.yml
@@ -8,10 +8,6 @@ on:
   push:
     branches:
       - develop-v2
-      # TEMPORARY, remove before merging this PR. A push trigger reads the workflow file from
-      # the branch being pushed, so this is the only way to verify the pipeline before it
-      # reaches develop-v2. workflow_dispatch is not available until the file is on develop.
-      - andrerego/and-1497-distribute-v2-demo-app-builds-via-firebase-app-distribution
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/upload-artifact@v7
         with:
           name: demo-app-release
-          path: demo-app/build/outputs/apk/demo-app/release/
+          path: demo-app/build/outputs/apk/development/release/
       - name: Upload artifact to Firebase App Distribution
         uses: wzieba/Firebase-Distribution-Github-Action@bd494989dd4bec0343f78adee87fe66e48279ad6
         with:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -29,7 +29,7 @@ jobs:
           gpg -d --passphrase "${{ env.PASSPHRASE }}" --batch .sign/keystore.properties.asc > .sign/keystore.properties
           echo "${{ env.ENV_PROPERTIES }}" > .env.properties
       - name: Assemble
-        run: bash ./gradlew :demo-app:assembleRelease --stacktrace
+        run: bash ./gradlew :demo-app:assembleDevelopmentRelease --stacktrace
       - name: Upload APK
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
### Goal

Closes [AND-1497](https://linear.app/stream/issue/AND-1497/distribute-v2-demo-app-builds-via-firebase-app-distribution)

Nothing was distributed from `develop-v2`, so the team had no way to test v2 work. `app-distribute.yml` (Firebase) triggers on `main` only, and `internal-app-distribute.yml` (Google Play) triggers on `develop` and `main`. This adds a Firebase App Distribution pipeline for `develop-v2`.

### Implementation

- New `.github/workflows/app-distribute-v2.yml`. It triggers on pushes to `develop-v2`, runs `:demo-app:assembleDevelopmentRelease`, and uploads the APK to the `stream-testers` group in the shared `stream-android-32afb` Firebase project, the same project the chat SDK uses.
- The App ID and the service account credentials come from two new repo secrets, `FIREBASE_V2_DEMO_APP_ID` and `STREAM_ANDROID_FIREBASE_CREDENTIALS_APP_CONTENT`. Both are already set.
- `demo-app/google-services.json` is not changed. It stays on `stream-video-9b586` so push and Crashlytics keep working. App Distribution only needs the APK package name to match the app registered in the project.
- The workflow is hardened beyond a copy of the existing one: it requests only `contents: read`, reads the gpg passphrase from stdin rather than the command line, references secrets as shell variables instead of expanding them into the run script, deletes the decrypted signing material before the third-party Firebase action runs, and pins `actions/upload-artifact` to a commit SHA.
- One commit fixes the `Upload APK` step in `app-distribute.yml`. It pointed at `build/outputs/apk/demo-app/release`, but AGP writes to `build/outputs/apk/<flavor>/<buildType>`, so that directory never existed. `upload-artifact` only warns when it finds no files, so the step passed while uploading nothing.

Follow-up for when v2 becomes develop: delete `app-distribute-v2.yml`, move the new App ID and credentials into `app-distribute.yml`, and add `develop` to its trigger. The chat SDK skipped this cleanup and still has a dead `app-distribute-v7.yml` pointing at a branch that no longer exists.

### Testing

The pipeline was run end to end before merging. The branch was temporarily added to the `push` trigger, the workflow ran, and the temporary trigger was then reverted. This was necessary because `workflow_dispatch` is not available until the workflow file reaches the default branch, and the `push` trigger is otherwise limited to `develop-v2`.

Run [34132353521](https://github.com/GetStream/stream-video-android/actions/runs/34132353521) passed every step:

- The keystore and keystore properties decrypted with the new stdin passphrase handling.
- `:demo-app:assembleDevelopmentRelease` built and signed the APK.
- `Remove signing material` ran before the Firebase step.
- `Upload APK` produced a 72,520,380 byte artifact using only `contents: read`, which also confirms the corrected artifact path. The previous path yielded 0 artifacts on every run.
- Firebase reported `uploaded new release 1.32.0 (1)` on `io.getstream.video.android.dogfooding` in `stream-android-32afb`, followed by `distributed to testers/groups successfully`.

Note that `stream-testers` received a real build from that verification run, and will receive another when this merges.

Also verified locally: `./gradlew spotlessCheck` passes, and both workflow files parse as YAML. CI runs `actionlint` over them as well.

`detekt`, `apiCheck`, and `testDebugUnitTest` were not run locally. The diff is two workflow YAML files with no Kotlin or API surface changes, and CI runs them anyway.