### PR TITLE
Fix concurrency grouping in the distribution workflows

### DIFF
--- a/.github/workflows/app-distribute-v2.yml
+++ b/.github/workflows/app-distribute-v2.yml
@@ -11,7 +11,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/app-distribute-v2.yml
+++ b/.github/workflows/app-distribute-v2.yml
@@ -10,6 +10,10 @@ on:
       - develop-v2
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   build_v2_demo_app:
     permissions:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -6,6 +6,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_dogfooding_sample_app:
     permissions:

--- a/.github/workflows/internal-app-distribute.yml
+++ b/.github/workflows/internal-app-distribute.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !contains(github.ref, 'main')}}
 
 env:

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### Goal

Refs [AND-1497](https://linear.app/stream/issue/AND-1497/distribute-v2-demo-app-builds-via-firebase-app-distribution)

Follow-up to #1813. The distribution workflows either had no concurrency group or shared one across refs, so runs could cancel or overtake each other.

The worst case is `internal-app-distribute.yml`, which publishes to Google Play. It triggers on both `develop` (internal track) and `main` (alpha track) and put every run in one group. `cancel-in-progress` is evaluated on the incoming run, where a `develop` push resolves it to `true`, so a push to `develop` could cancel an in-progress `main` run and interrupt `publishBundle` mid-upload. The existing `!contains(github.ref, 'main')` guard stops a `main` run from cancelling others, but nothing stopped others from cancelling a `main` run.

`app-distribute-v2.yml` had no group at all, which was raised in review on #1813 and did not make that merge. `app-distribute.yml` had none either, so two pushes to `main` could distribute in parallel and let the older run reach testers last. `sdk-size-updates.yml` had the same unscoped group as the Play workflow.

### Implementation

Every one of these workflows now groups on `${{ github.workflow }}-${{ github.ref }}`, matching `android.yml`, `e2e-test.yml`, `e2e-test-cron.yml`, `pr-quality.yml` and `sdk-size-checks.yml`.

| Workflow | Triggers | Change | `cancel-in-progress` |
|---|---|---|---|
| `app-distribute-v2.yml` | `develop-v2` | group added, then scoped to the ref | `true` |
| `app-distribute.yml` | `main` | group added | `true` |
| `internal-app-distribute.yml` | `develop`, `main` | group scoped to the ref | `${{ !contains(github.ref, 'main')}}`, unchanged |
| `sdk-size-updates.yml` | `develop` | group scoped to the ref | `true`, unchanged |

Each file keeps its own `cancel-in-progress` rather than being made uniform. On `internal-app-distribute.yml` the guard still earns its place once the group is ref-scoped: two `main` pushes queue instead of one cancelling a live Play publish.

### Testing

Concurrency is only observable with two overlapping runs, so it cannot be demonstrated by a single run. `actionlint` in CI covers the syntax, and all four files were confirmed to parse with the expected `concurrency` block.

Nothing here changes what any workflow builds or where it publishes. `app-distribute-v2.yml` itself was proven end to end in #1813, and the first real run from `develop-v2` after that merge, [34201013732](https://github.com/GetStream/stream-video-android/actions/runs/34201013732), succeeded and distributed to `stream-testers`.

Note for reviewers: this PR grew after the first approval. It started as one line in `app-distribute-v2.yml` and now touches four workflows, including the Google Play publish pipeline, so it is worth another look.