### PR TITLE
Build the coordinator HTTP client on the first request

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/CoordinatorConnectionModule.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/CoordinatorConnectionModule.kt
@@ -64,25 +64,31 @@ internal class CoordinatorConnectionModule(
         Retrofit.Builder().baseUrl(apiUrl)
             .addConverterFactory(ScalarsConverterFactory.create())
             .addConverterFactory(MoshiConverterFactory.create(Serializer.moshi))
-            .client(http).build()
+            // Not `client(http)`: that would build the client right here. See `http`.
+            .callFactory { request -> http.newCall(request) }
+            .build()
     }
 
     // API
 
-    override val http: OkHttpClient = OkHttpClient.Builder().addInterceptor(
-        HeadersInterceptor(HeadersUtil()),
-    )
-        .addInterceptor(authInterceptor).addInterceptor(
-            HttpLoggingInterceptor {
-                streamLog(tag = "Video:Http") { it }
-            }.apply {
-                level = loggingLevel.httpLoggingLevel.level
-            },
-        ).retryOnConnectionFailure(true)
-        .connectTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
-        .writeTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
-        .readTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
-        .callTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS).build()
+    // Lazy so Compose previews can build the SDK: layoutlib identifies itself as Dalvik, which makes
+    // OkHttp pick its Android platform, and layoutlib lacks the conscrypt classes that needs.
+    override val http: OkHttpClient by lazy {
+        OkHttpClient.Builder().addInterceptor(
+            HeadersInterceptor(HeadersUtil()),
+        )
+            .addInterceptor(authInterceptor).addInterceptor(
+                HttpLoggingInterceptor {
+                    streamLog(tag = "Video:Http") { it }
+                }.apply {
+                    level = loggingLevel.httpLoggingLevel.level
+                },
+            ).retryOnConnectionFailure(true)
+            .connectTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+            .writeTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+            .readTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS)
+            .callTimeout(connectionTimeoutInMs, TimeUnit.MILLISECONDS).build()
+    }
     override val networkStateProvider: NetworkStateProvider by lazy {
         NetworkStateProvider(
             scope,


### PR DESCRIPTION
### Goal

Compose previews in Android Studio fail with `NoClassDefFoundError: com/android/org/conscrypt/TrustManagerImpl` as soon as a preview calls `StreamPreviewDataUtils.initializeStreamVideo`. Layoutlib reports the VM as Dalvik, so OkHttp selects its Android platform, but layoutlib does not ship the conscrypt classes that platform needs. Previews never send a request, so the client should not be built while the SDK is constructed.

Linear: AND-1501

### Implementation

`CoordinatorConnectionModule.http` is now `by lazy`, and Retrofit uses `callFactory { http.newCall(it) }` instead of `client(http)`. The second change is needed because `StreamVideoBuilder.build()` reads the Retrofit API during construction, which would otherwise still build the client.

The other OkHttp clients (socket connections, latency probe) are created on connect or join and are not on the preview path.

This targets `develop-v2` only. On `develop` the module also builds the coordinator socket connection eagerly with the same client, so this change alone would not fix previews there.

### 🎨 UI Changes

None.

### Testing

- Android Studio: the `CallLobby` previews render again (verified by the author).
- `:stream-video-android-core:compileDebugKotlin`, `apiCheck` (internal class, no API change).
- Core unit tests `StreamVideoClientTest`, `StreamVideoClientCleanupTest`, `CallConnectivityMonitorTest`: 38 tests green.
- `:stream-video-android-ui-compose:verifyPaparazziDebug`: 165 tests green, goldens unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Android Studio layout previews can now render without initializing the networking client.
  * Network requests continue to use the configured interceptors, retry behavior, and timeout settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->