### PR TITLE
Show the local microphone level in the lobby before joining

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/Call.kt
@@ -415,7 +415,8 @@ public class Call(
      * and will then gradually over 250ms return back to 0 or next measured value. This value
      * can be used directly in your UI for displaying a volume/speaking indicator for the local
      * participant.
-     * Note: Doesn't return any values until the session is established!
+     * The microphone is also read before the call is joined, so a lobby screen can show the level
+     * as soon as the microphone is enabled and the RECORD_AUDIO permission is granted.
      */
     val localMicrophoneAudioLevel: StateFlow<Float> get() = media.localMicrophoneAudioLevel
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
@@ -150,8 +150,10 @@ internal class CallMediaManager(
      * Reads the microphone while the call has no session, so the lobby shows a live level.
      *
      * WebRTC and this recorder must never hold the microphone at the same time, so this one runs
-     * only while there is no session. The session is installed before WebRTC starts capturing, so
-     * the level hands over to the samples callback there, and back when the session is cleared.
+     * only while there is no session. The session is installed before WebRTC starts capturing, and
+     * stopping waits for the microphone to be released, so the device is free by the time WebRTC
+     * asks for it. The level hands over to the samples callback there, and back when the session
+     * is cleared.
      *
      * Muting keeps the WebRTC capture running on purpose (it is what detects speaking while
      * muted), but there is nothing to detect before the call is joined, so a disabled microphone
@@ -407,7 +409,9 @@ internal class CallMediaManager(
         // The wanted state must not outlive the call: a reused Call would otherwise re-apply it
         // to the factory built for the next session.
         resetDesiredAudioProcessing()
-        preJoinMicrophoneRecorder.stop()
+        // Not the awaiting stop: teardown runs after the call scope is cancelled, so there is no
+        // coroutine left to wait in and nothing is queuing up for the microphone.
+        preJoinMicrophoneRecorder.stopWithoutWaiting()
         mediaManager.cleanup()
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/CallMediaManager.kt
@@ -26,15 +26,19 @@ import io.getstream.video.android.core.CallState
 import io.getstream.video.android.core.CameraDirection
 import io.getstream.video.android.core.DeviceStatus
 import io.getstream.video.android.core.MediaManagerImpl
+import io.getstream.video.android.core.MicrophoneManager
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.audio.StreamAudioDevice
 import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
+import io.getstream.video.android.core.call.utils.PreJoinMicrophoneRecorder
 import io.getstream.video.android.core.call.utils.SoundInputProcessor
 import io.getstream.video.android.core.utils.RampValueUpAndDownHelper
 import io.getstream.webrtc.EglBase
 import io.getstream.webrtc.audio.JavaAudioDeviceModule.AudioSamples
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -48,6 +52,8 @@ import kotlinx.coroutines.launch
  * isn't created until the media manager / factory actually needs it.
  * @param mediaManagerFactory creates the [MediaManagerImpl]; owned by the Call facade so the
  * public type's `call` dependency never leaks into this component.
+ * @param preJoinMicrophoneRecorderFactory creates the recorder that meters the microphone before
+ * the call is joined; injected so tests never open a real microphone.
  */
 internal class CallMediaManager(
     private val type: String,
@@ -58,6 +64,10 @@ internal class CallMediaManager(
     private val sessionManager: CallSessionManager,
     private val eglBase: () -> EglBase,
     private val mediaManagerFactory: MediaManagerFactory,
+    preJoinMicrophoneRecorderFactory: PreJoinMicrophoneRecorderFactory =
+        PreJoinMicrophoneRecorderFactory { onSamples ->
+            PreJoinMicrophoneRecorder(clientImpl.context, scope, onSamples)
+        },
 ) {
     private val logger by taggedLogger("Call:MediaManager:$type:$id")
 
@@ -67,6 +77,14 @@ internal class CallMediaManager(
         }
     })
     private val audioLevelOutputHelper = RampValueUpAndDownHelper()
+
+    /**
+     * Feeds the same processor the WebRTC samples callback feeds, so the level reaches
+     * [localMicrophoneAudioLevel] through one path whether or not the call is joined.
+     */
+    private val preJoinMicrophoneRecorder = preJoinMicrophoneRecorderFactory.create { pcm ->
+        soundInputProcessor.processSoundInput(pcm)
+    }
 
     /** Smoothed local microphone volume level (0..1). */
     val localMicrophoneAudioLevel: StateFlow<Float> = audioLevelOutputHelper.currentLevel
@@ -112,7 +130,11 @@ internal class CallMediaManager(
         mediaManagerFactory.create(
             audioUsage = clientImpl.callServiceConfigRegistry.get(type).audioUsage,
             audioUsageProvider = { clientImpl.callServiceConfigRegistry.get(type).audioUsage },
-        )
+        ).also {
+            // Observed here and not from the call's init: reading the microphone state there
+            // would build the media manager up front, and with it the native EGL context.
+            observePreJoinMicrophone(it.microphone)
+        }
     }
 
     /** Starts streaming smoothed microphone audio levels into [localMicrophoneAudioLevel]. */
@@ -122,6 +144,32 @@ internal class CallMediaManager(
                 audioLevelOutputHelper.rampToValue(it)
             }
         }
+    }
+
+    /**
+     * Reads the microphone while the call has no session, so the lobby shows a live level.
+     *
+     * WebRTC and this recorder must never hold the microphone at the same time, so this one runs
+     * only while there is no session. The session is installed before WebRTC starts capturing, so
+     * the level hands over to the samples callback there, and back when the session is cleared.
+     *
+     * Muting keeps the WebRTC capture running on purpose (it is what detects speaking while
+     * muted), but there is nothing to detect before the call is joined, so a disabled microphone
+     * stops the recorder instead.
+     */
+    private fun observePreJoinMicrophone(microphone: MicrophoneManager) {
+        combine(
+            microphone.isEnabled,
+            sessionManager.session,
+        ) { microphoneEnabled, session ->
+            microphoneEnabled && session == null
+        }.distinctUntilChanged().onEach { shouldRecord ->
+            if (shouldRecord) {
+                preJoinMicrophoneRecorder.start()
+            } else {
+                preJoinMicrophoneRecorder.stop()
+            }
+        }.launchIn(scope)
     }
 
     fun processAudioSample(audioSample: AudioSamples) {
@@ -359,6 +407,7 @@ internal class CallMediaManager(
         // The wanted state must not outlive the call: a reused Call would otherwise re-apply it
         // to the factory built for the next session.
         resetDesiredAudioProcessing()
+        preJoinMicrophoneRecorder.stop()
         mediaManager.cleanup()
     }
 }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/PreJoinMicrophoneRecorderFactory.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/components/PreJoinMicrophoneRecorderFactory.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.components
+
+import io.getstream.video.android.core.call.utils.PreJoinMicrophoneRecorder
+
+/**
+ * Creates the [PreJoinMicrophoneRecorder] a call meters the microphone with before it is joined.
+ *
+ * Injected into [CallMediaManager] so tests can drive the start / stop handover without opening a
+ * real microphone.
+ *
+ * @param onSamples receives 16 bit PCM buffers read from the microphone.
+ */
+internal fun interface PreJoinMicrophoneRecorderFactory {
+    fun create(onSamples: (ByteArray) -> Unit): PreJoinMicrophoneRecorder
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.utils
+
+import android.Manifest
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
+import androidx.core.content.ContextCompat
+import io.getstream.log.taggedLogger
+import io.getstream.video.android.core.dispatchers.DispatcherProvider
+import io.getstream.video.android.core.utils.safeCall
+import io.getstream.video.android.core.utils.safeCallWithDefault
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+
+/** Mono 16 bit PCM, the format [SoundInputProcessor] expects. */
+private const val CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_MONO
+private const val AUDIO_ENCODING = AudioFormat.ENCODING_PCM_16BIT
+
+/** Enough for a level meter, and a fraction of the samples a call records. */
+private const val SAMPLE_RATE_HZ = 16_000
+
+/**
+ * The window WebRTC reads the microphone in once the call is joined, matched here on purpose.
+ *
+ * The level is smoothed by a ramp that takes about 250ms to rise and fall, so the indicator sags
+ * between updates that arrive more slowly than that. Reading in longer windows measures the same
+ * peaks but shows a visibly lower bar, because the bar spends its time falling rather than held
+ * at the peak.
+ */
+private const val READ_WINDOW_MS = 10
+private const val BYTES_PER_SAMPLE = 2
+private const val BYTES_PER_WINDOW = SAMPLE_RATE_HZ * BYTES_PER_SAMPLE * READ_WINDOW_MS / 1000
+
+/**
+ * Reads raw microphone samples while the call has no [io.getstream.video.android.core.call.RtcSession].
+ *
+ * WebRTC only records once a peer connection sends the audio track, so nothing feeds
+ * [SoundInputProcessor] before a call is joined and the lobby sound indicator stays at rest. This
+ * recorder fills that gap with a plain [AudioRecord] and hands the same 16 bit PCM buffers to
+ * [onSamples], the way iOS meters an `AVAudioRecorder` in its pre-join view.
+ *
+ * Only one recorder may hold the microphone, so the caller must [stop] this one before the session
+ * starts capturing.
+ */
+internal class PreJoinMicrophoneRecorder(
+    private val context: Context,
+    private val scope: CoroutineScope,
+    private val onSamples: (ByteArray) -> Unit,
+) {
+    private val logger by taggedLogger("Call:PreJoinMicRecorder")
+
+    private var job: Job? = null
+
+    /** Starts reading the microphone. Does nothing when already reading or without permission. */
+    fun start() {
+        if (job?.isActive == true) return
+        if (!hasRecordAudioPermission()) {
+            logger.w { "[start] RECORD_AUDIO is not granted, the microphone level stays at zero" }
+            return
+        }
+        logger.d { "[start] reading the microphone before the call is joined" }
+        job = scope.launch(DispatcherProvider.IO) { read() }
+    }
+
+    /**
+     * Stops reading and releases the microphone. The read in flight returns first, so the device is
+     * free at most [READ_WINDOW_MS] later.
+     */
+    fun stop() {
+        job?.let {
+            logger.d { "[stop] releasing the microphone" }
+            it.cancel()
+        }
+        job = null
+    }
+
+    private suspend fun read() {
+        val recorder = createRecorder() ?: return
+        try {
+            safeCall { recorder.startRecording() }
+            if (recorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
+                logger.w { "[read] the microphone did not start recording" }
+                return
+            }
+            val buffer = ByteArray(BYTES_PER_WINDOW)
+            while (currentCoroutineContext().isActive) {
+                val bytesRead = recorder.read(buffer, 0, buffer.size)
+                if (bytesRead > 0) {
+                    onSamples(buffer.copyOf(bytesRead))
+                } else if (bytesRead < 0) {
+                    logger.w { "[read] the microphone returned error $bytesRead, stopping" }
+                    break
+                }
+            }
+        } finally {
+            safeCall { recorder.stop() }
+            safeCall { recorder.release() }
+        }
+    }
+
+    /**
+     * Opens the microphone, preferring the source a call uses so the recorder follows the device
+     * the user picked in the lobby, and falling back to the plain one where that is unavailable.
+     */
+    @SuppressLint("MissingPermission") // checked in start()
+    private fun createRecorder(): AudioRecord? {
+        val minBufferSize = AudioRecord.getMinBufferSize(
+            SAMPLE_RATE_HZ,
+            CHANNEL_CONFIG,
+            AUDIO_ENCODING,
+        )
+        if (minBufferSize <= 0) {
+            logger.w { "[createRecorder] no buffer size for ${SAMPLE_RATE_HZ}Hz: $minBufferSize" }
+            return null
+        }
+        val bufferSize = maxOf(minBufferSize, BYTES_PER_WINDOW)
+        val sources = intArrayOf(
+            MediaRecorder.AudioSource.VOICE_COMMUNICATION,
+            MediaRecorder.AudioSource.MIC,
+        )
+        for (source in sources) {
+            val recorder = safeCallWithDefault(null) {
+                AudioRecord(source, SAMPLE_RATE_HZ, CHANNEL_CONFIG, AUDIO_ENCODING, bufferSize)
+            } ?: continue
+            if (recorder.state == AudioRecord.STATE_INITIALIZED) return recorder
+            safeCall { recorder.release() }
+        }
+        logger.w { "[createRecorder] could not open the microphone" }
+        return null
+    }
+
+    private fun hasRecordAudioPermission(): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.RECORD_AUDIO,
+    ) == PackageManager.PERMISSION_GRANTED
+}

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
@@ -110,13 +110,8 @@ internal class PreJoinMicrophoneRecorder(
     }
 
     private suspend fun read() {
-        val recorder = createRecorder() ?: return
+        val recorder = openRecording() ?: return
         try {
-            safeCall { recorder.startRecording() }
-            if (recorder.recordingState != AudioRecord.RECORDSTATE_RECORDING) {
-                logger.w { "[read] the microphone did not start recording" }
-                return
-            }
             val buffer = ByteArray(BYTES_PER_WINDOW)
             while (currentCoroutineContext().isActive) {
                 val bytesRead = recorder.read(buffer, 0, buffer.size)
@@ -134,18 +129,23 @@ internal class PreJoinMicrophoneRecorder(
     }
 
     /**
-     * Opens the microphone, preferring the source a call uses so the recorder follows the device
-     * the user picked in the lobby, and falling back to the plain one where that is unavailable.
+     * Opens the microphone and starts it, preferring the source a call uses so the recorder follows
+     * the device the user picked in the lobby, and falling back to the plain one where that is
+     * unavailable.
+     *
+     * Starting is part of what each source is tried for: a source can be constructed and still
+     * refuse to record, for example while another app holds the device, and that has to fall
+     * through to the next source rather than give up.
      */
     @SuppressLint("MissingPermission") // checked in start()
-    private fun createRecorder(): AudioRecord? {
+    private fun openRecording(): AudioRecord? {
         val minBufferSize = AudioRecord.getMinBufferSize(
             SAMPLE_RATE_HZ,
             CHANNEL_CONFIG,
             AUDIO_ENCODING,
         )
         if (minBufferSize <= 0) {
-            logger.w { "[createRecorder] no buffer size for ${SAMPLE_RATE_HZ}Hz: $minBufferSize" }
+            logger.w { "[openRecording] no buffer size for ${SAMPLE_RATE_HZ}Hz: $minBufferSize" }
             return null
         }
         val bufferSize = maxOf(minBufferSize, BYTES_PER_WINDOW)
@@ -157,10 +157,15 @@ internal class PreJoinMicrophoneRecorder(
             val recorder = safeCallWithDefault(null) {
                 AudioRecord(source, SAMPLE_RATE_HZ, CHANNEL_CONFIG, AUDIO_ENCODING, bufferSize)
             } ?: continue
-            if (recorder.state == AudioRecord.STATE_INITIALIZED) return recorder
+            if (recorder.state == AudioRecord.STATE_INITIALIZED) {
+                safeCall { recorder.startRecording() }
+                if (recorder.recordingState == AudioRecord.RECORDSTATE_RECORDING) return recorder
+                logger.w { "[openRecording] source $source did not start recording" }
+                safeCall { recorder.stop() }
+            }
             safeCall { recorder.release() }
         }
-        logger.w { "[createRecorder] could not open the microphone" }
+        logger.w { "[openRecording] could not open the microphone" }
         return null
     }
 

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
@@ -92,9 +92,12 @@ internal class PreJoinMicrophoneRecorder(
      */
     suspend fun stop() {
         val running = job ?: return
-        job = null
         logger.d { "[stop] releasing the microphone" }
         running.cancelAndJoin()
+        // Cleared only after the join: clearing it first would let a [start] in between open a
+        // second recorder while this one still holds the microphone. Compared by identity so a
+        // recorder started in the meantime is left alone.
+        if (job === running) job = null
     }
 
     /**

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorder.kt
@@ -30,6 +30,7 @@ import io.getstream.video.android.core.utils.safeCall
 import io.getstream.video.android.core.utils.safeCallWithDefault
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -61,8 +62,8 @@ private const val BYTES_PER_WINDOW = SAMPLE_RATE_HZ * BYTES_PER_SAMPLE * READ_WI
  * recorder fills that gap with a plain [AudioRecord] and hands the same 16 bit PCM buffers to
  * [onSamples], the way iOS meters an `AVAudioRecorder` in its pre-join view.
  *
- * Only one recorder may hold the microphone, so the caller must [stop] this one before the session
- * starts capturing.
+ * Only one recorder may hold the microphone, so the caller must [stop] this one and wait for it to
+ * return before the session starts capturing.
  */
 internal class PreJoinMicrophoneRecorder(
     private val context: Context,
@@ -85,14 +86,23 @@ internal class PreJoinMicrophoneRecorder(
     }
 
     /**
-     * Stops reading and releases the microphone. The read in flight returns first, so the device is
-     * free at most [READ_WINDOW_MS] later.
+     * Stops reading and returns once the microphone has been released, so the caller can hand the
+     * device to WebRTC. The read in flight has to return first, which takes at most
+     * [READ_WINDOW_MS].
      */
-    fun stop() {
-        job?.let {
-            logger.d { "[stop] releasing the microphone" }
-            it.cancel()
-        }
+    suspend fun stop() {
+        val running = job ?: return
+        job = null
+        logger.d { "[stop] releasing the microphone" }
+        running.cancelAndJoin()
+    }
+
+    /**
+     * Stops reading without waiting for the release. For call teardown, which runs after the call
+     * scope is cancelled and has nothing waiting to take the microphone.
+     */
+    fun stopWithoutWaiting() {
+        job?.cancel()
         job = null
     }
 

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
@@ -32,6 +32,7 @@ import io.getstream.video.android.core.call.utils.PreJoinMicrophoneRecorder
 import io.getstream.webrtc.ManagedAudioProcessingFactory
 import io.getstream.webrtc.audio.JavaAudioDeviceModule.AudioSamples
 import io.mockk.clearMocks
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -327,7 +328,7 @@ class CallMediaManagerTest {
         session.value = mockk(relaxed = true)
         advanceUntilIdle()
 
-        verify { preJoinMicrophoneRecorder.stop() }
+        coVerify { preJoinMicrophoneRecorder.stop() }
     }
 
     @Test
@@ -340,13 +341,13 @@ class CallMediaManagerTest {
         microphoneEnabled.value = false
         advanceUntilIdle()
 
-        verify { preJoinMicrophoneRecorder.stop() }
+        coVerify { preJoinMicrophoneRecorder.stop() }
     }
 
     @Test
     fun `cleanup releases the microphone`() {
         managerObservingMicrophone().cleanup()
 
-        verify { preJoinMicrophoneRecorder.stop() }
+        verify { preJoinMicrophoneRecorder.stopWithoutWaiting() }
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/components/CallMediaManagerTest.kt
@@ -23,11 +23,15 @@ import io.getstream.android.video.generated.models.OwnCapability
 import io.getstream.video.android.core.CallState
 import io.getstream.video.android.core.DeviceStatus
 import io.getstream.video.android.core.MediaManagerImpl
+import io.getstream.video.android.core.MicrophoneManager
 import io.getstream.video.android.core.StreamVideoClient
 import io.getstream.video.android.core.audio.StreamAudioDevice
+import io.getstream.video.android.core.call.RtcSession
 import io.getstream.video.android.core.call.connection.StreamPeerConnectionFactory
+import io.getstream.video.android.core.call.utils.PreJoinMicrophoneRecorder
 import io.getstream.webrtc.ManagedAudioProcessingFactory
 import io.getstream.webrtc.audio.JavaAudioDeviceModule.AudioSamples
+import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -56,6 +60,10 @@ class CallMediaManagerTest {
     private lateinit var state: CallState
     private lateinit var sessionManager: CallSessionManager
     private lateinit var mediaManager: MediaManagerImpl
+    private lateinit var microphone: MicrophoneManager
+    private lateinit var microphoneEnabled: MutableStateFlow<Boolean>
+    private lateinit var session: MutableStateFlow<RtcSession?>
+    private lateinit var preJoinMicrophoneRecorder: PreJoinMicrophoneRecorder
 
     @Before
     fun setup() {
@@ -63,7 +71,13 @@ class CallMediaManagerTest {
         state = mockk(relaxed = true)
         sessionManager = mockk(relaxed = true)
         mediaManager = mockk(relaxed = true)
-        every { sessionManager.session } returns MutableStateFlow(null)
+        microphone = mockk(relaxed = true)
+        preJoinMicrophoneRecorder = mockk(relaxed = true)
+        microphoneEnabled = MutableStateFlow(false)
+        session = MutableStateFlow(null)
+        every { microphone.isEnabled } returns microphoneEnabled
+        every { mediaManager.microphone } returns microphone
+        every { sessionManager.session } returns session
     }
 
     private fun manager() = CallMediaManager(
@@ -75,7 +89,14 @@ class CallMediaManagerTest {
         sessionManager = sessionManager,
         eglBase = { mockk(relaxed = true) },
         mediaManagerFactory = MediaManagerFactory { _, _ -> mediaManager },
+        preJoinMicrophoneRecorderFactory = { preJoinMicrophoneRecorder },
     )
+
+    /**
+     * The pre-join recorder is only observed once the media manager exists, so touching it is
+     * what a lobby reading the microphone state does.
+     */
+    private fun managerObservingMicrophone() = manager().also { it.mediaManager }
 
     @Test
     fun `startScreenSharing enables screen share when the capability is granted`() {
@@ -270,5 +291,62 @@ class CallMediaManagerTest {
         manager.peerConnectionFactory
 
         verify { processor.isEnabled = true }
+    }
+
+    @Test
+    fun `the pre-join recorder runs while the microphone is on and no session exists`() = runTest(
+        testDispatcher,
+    ) {
+        managerObservingMicrophone()
+
+        microphoneEnabled.value = true
+        advanceUntilIdle()
+
+        verify { preJoinMicrophoneRecorder.start() }
+    }
+
+    @Test
+    fun `the pre-join recorder does not run while the microphone is off`() = runTest(
+        testDispatcher,
+    ) {
+        managerObservingMicrophone()
+
+        advanceUntilIdle()
+
+        verify(exactly = 0) { preJoinMicrophoneRecorder.start() }
+    }
+
+    @Test
+    fun `installing a session hands the level over to the samples callback`() = runTest(
+        testDispatcher,
+    ) {
+        managerObservingMicrophone()
+        microphoneEnabled.value = true
+        advanceUntilIdle()
+
+        session.value = mockk(relaxed = true)
+        advanceUntilIdle()
+
+        verify { preJoinMicrophoneRecorder.stop() }
+    }
+
+    @Test
+    fun `disabling the microphone stops the pre-join recorder`() = runTest(testDispatcher) {
+        managerObservingMicrophone()
+        microphoneEnabled.value = true
+        advanceUntilIdle()
+        clearMocks(preJoinMicrophoneRecorder)
+
+        microphoneEnabled.value = false
+        advanceUntilIdle()
+
+        verify { preJoinMicrophoneRecorder.stop() }
+    }
+
+    @Test
+    fun `cleanup releases the microphone`() {
+        managerObservingMicrophone().cleanup()
+
+        verify { preJoinMicrophoneRecorder.stop() }
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorderTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorderTest.kt
@@ -29,6 +29,10 @@ import io.mockk.mockkConstructor
 import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.unmockkAll
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -36,6 +40,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Unit tests for [PreJoinMicrophoneRecorder], which reads the microphone while the call has no
@@ -123,7 +130,43 @@ class PreJoinMicrophoneRecorderTest {
     }
 
     @Test
-    fun `stop is safe before anything was started`() {
+    fun `stop is safe before anything was started`() = runTest(testDispatcher) {
         recorder().stop()
+    }
+
+    /**
+     * The session takes the microphone as soon as the recorder lets go, so [
+     * PreJoinMicrophoneRecorder.stop] has to return after the device is released rather than
+     * after the read loop is merely asked to end.
+     *
+     * Runs the read loop on a real dispatcher with a blocking read, the way a microphone behaves:
+     * on the test dispatcher the loop never yields, so nothing would be in flight to wait for.
+     */
+    @Test
+    fun `stop returns only once the microphone has been released`() = runBlocking {
+        DispatcherProvider.set(testDispatcher, Dispatchers.IO)
+        val reading = CountDownLatch(1)
+        val released = AtomicBoolean(false)
+        givenMicrophone(firstRead = 320)
+        every { anyConstructed<AudioRecord>().release() } answers { released.set(true) }
+        every { anyConstructed<AudioRecord>().read(any<ByteArray>(), any(), any()) } answers {
+            reading.countDown()
+            Thread.sleep(BLOCKING_READ_MS)
+            320
+        }
+        val scope = CoroutineScope(Dispatchers.IO)
+        val recorder = PreJoinMicrophoneRecorder(context, scope) { samples.add(it) }
+
+        recorder.start()
+        assertThat(reading.await(5, TimeUnit.SECONDS)).isTrue()
+        recorder.stop()
+
+        assertThat(released.get()).isTrue()
+        scope.cancel()
+    }
+
+    private companion object {
+        /** Long enough that a stop which does not wait would return mid-read. */
+        const val BLOCKING_READ_MS = 200L
     }
 }

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorderTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorderTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.call.utils
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.media.AudioRecord
+import androidx.core.content.ContextCompat
+import com.google.common.truth.Truth.assertThat
+import io.getstream.video.android.core.dispatchers.DispatcherProvider
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.mockkStatic
+import io.mockk.runs
+import io.mockk.unmockkAll
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [PreJoinMicrophoneRecorder], which reads the microphone while the call has no
+ * RTC session. [AudioRecord] is mocked, so no test opens a real microphone.
+ */
+class PreJoinMicrophoneRecorderTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testScope = TestScope(testDispatcher)
+
+    private lateinit var context: Context
+    private val samples = mutableListOf<ByteArray>()
+
+    @Before
+    fun setup() {
+        context = mockk(relaxed = true)
+        samples.clear()
+        mockkStatic(ContextCompat::class)
+        mockkStatic(AudioRecord::class)
+        mockkConstructor(AudioRecord::class)
+        DispatcherProvider.set(testDispatcher, testDispatcher)
+        grantRecordAudio(true)
+    }
+
+    @After
+    fun tearDown() {
+        DispatcherProvider.reset()
+        unmockkAll()
+    }
+
+    private fun recorder() = PreJoinMicrophoneRecorder(context, testScope) { samples.add(it) }
+
+    private fun grantRecordAudio(granted: Boolean) {
+        every { ContextCompat.checkSelfPermission(context, any()) } returns
+            if (granted) PackageManager.PERMISSION_GRANTED else PackageManager.PERMISSION_DENIED
+    }
+
+    /** One buffer of [firstRead] bytes, then an error so the read loop ends. */
+    private fun givenMicrophone(firstRead: Int) {
+        every { AudioRecord.getMinBufferSize(any(), any(), any()) } returns 640
+        every { anyConstructed<AudioRecord>().state } returns AudioRecord.STATE_INITIALIZED
+        every { anyConstructed<AudioRecord>().startRecording() } just runs
+        every { anyConstructed<AudioRecord>().recordingState } returns
+            AudioRecord.RECORDSTATE_RECORDING
+        every { anyConstructed<AudioRecord>().stop() } just runs
+        every { anyConstructed<AudioRecord>().release() } just runs
+        var reads = 0
+        every { anyConstructed<AudioRecord>().read(any<ByteArray>(), any(), any()) } answers {
+            if (reads++ == 0) firstRead else AudioRecord.ERROR_INVALID_OPERATION
+        }
+    }
+
+    @Test
+    fun `samples read from the microphone reach the callback`() = runTest(testDispatcher) {
+        givenMicrophone(firstRead = 320)
+
+        recorder().start()
+        advanceUntilIdle()
+
+        assertThat(samples).hasSize(1)
+        assertThat(samples.single()).hasLength(320)
+    }
+
+    @Test
+    fun `nothing is recorded without the RECORD_AUDIO permission`() = runTest(testDispatcher) {
+        grantRecordAudio(false)
+        givenMicrophone(firstRead = 320)
+
+        recorder().start()
+        advanceUntilIdle()
+
+        assertThat(samples).isEmpty()
+    }
+
+    @Test
+    fun `an unusable microphone is given up on instead of reading`() = runTest(testDispatcher) {
+        givenMicrophone(firstRead = 320)
+        every { AudioRecord.getMinBufferSize(any(), any(), any()) } returns
+            AudioRecord.ERROR_BAD_VALUE
+
+        recorder().start()
+        advanceUntilIdle()
+
+        assertThat(samples).isEmpty()
+    }
+
+    @Test
+    fun `stop is safe before anything was started`() {
+        recorder().stop()
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorderTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/call/utils/PreJoinMicrophoneRecorderTest.kt
@@ -117,6 +117,26 @@ class PreJoinMicrophoneRecorderTest {
         assertThat(samples).isEmpty()
     }
 
+    /**
+     * A source can be constructed and still refuse to record, so the fallback has to cover the
+     * start as well as the construction.
+     */
+    @Test
+    fun `a source that will not start recording falls back to the next one`() = runTest(
+        testDispatcher,
+    ) {
+        givenMicrophone(firstRead = 320)
+        var starts = 0
+        every { anyConstructed<AudioRecord>().recordingState } answers {
+            if (starts++ == 0) AudioRecord.RECORDSTATE_STOPPED else AudioRecord.RECORDSTATE_RECORDING
+        }
+
+        recorder().start()
+        advanceUntilIdle()
+
+        assertThat(samples).hasSize(1)
+    }
+
     @Test
     fun `an unusable microphone is given up on instead of reading`() = runTest(testDispatcher) {
         givenMicrophone(firstRead = 320)


### PR DESCRIPTION
### Goal

Closes [AND-1505](https://linear.app/stream/issue/AND-1505/feed-the-local-microphone-level-before-the-call-is-joined-as)

WebRTC only records once a peer connection sends the audio track, so nothing fed the
sound processor before a call was joined. The lobby sound indicator stayed in its
resting state even with the microphone on and the permission granted. iOS already
meters an `AVAudioRecorder` in its pre-join view, so the platforms behaved differently.

### Implementation

- `PreJoinMicrophoneRecorder` reads the microphone with a plain `AudioRecord` while the
  call has no session. It prefers `MediaRecorder.AudioSource.VOICE_COMMUNICATION`, the
  same source WebRTC uses, and falls back to `MIC`. It checks `RECORD_AUDIO` before it
  starts and releases the device when it stops.
- The samples go to the existing `SoundInputProcessor`, the one the WebRTC callback
  already feeds, so the level reaches `localMicrophoneAudioLevel` through a single path
  and no UI code changes.
- `CallMediaManager` runs the recorder while the microphone is enabled and there is no
  session, and stops it once the session is installed. The session is installed before
  WebRTC starts capturing, so the two never use the microphone at the same time.
- The observer starts from the `mediaManager` lazy block, not from `Call.init`, because
  reading the microphone state there would build the media manager and the native EGL
  context up front.
- The read window is 10ms, matching WebRTC's `CALLBACK_BUFFER_SIZE_MS`. The level is
  smoothed by a ramp that takes about 250ms to rise and fall, so slower updates measure
  the same peaks but show a visibly lower bar.
- No public API change. `PreJoinMicrophoneRecorderFactory` is internal and exists so
  tests never open a real microphone.

### Testing

Manual, in the demo app lobby:

1. Open the lobby with the microphone permission granted and the microphone on. The
   sound indicator bars follow your voice before you join.
2. Turn the microphone off. The bars stop and the plain mute icon is shown.
3. Join the call. The bars keep following your voice, now fed by WebRTC.
4. Deny the microphone permission. The bars stay at rest and nothing is recorded.

Verified on the emulator.

Automated:

- `./gradlew spotlessCheck` passed.
- `./gradlew :stream-video-android-core:apiCheck` passed, the public API is unchanged.
- `./gradlew :stream-video-android-core:testDebugUnitTest` passed, including 4 new
  `PreJoinMicrophoneRecorderTest` cases (samples reach the callback, the permission gate,
  an unusable microphone, a safe stop) and 5 new `CallMediaManagerTest` cases covering
  the start and stop handover.
- This repo has no `detekt` task, so that check was not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microphone audio levels are now available before joining a call, allowing lobby screens to display live input levels when the microphone is enabled and permission is granted.
  * Pre-join microphone monitoring automatically starts and stops based on microphone and call state.

* **Bug Fixes**
  * Improved handling of microphone permissions, unavailable recording hardware, recording errors, and recorder cleanup for a more reliable pre-join experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
