### PR TITLE
Send the SDK name and version as X-Stream-Client on SFU requests

### DIFF
--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
@@ -86,6 +86,15 @@ class HeadersUtil {
         }.sanitize()
     }
 
+    /**
+     * Builds the client information header (X-Stream-Client) sent to the SFU, e.g.
+     * `stream-android@1.30.0`. The name matches the one reported as `SendStatsRequest.sdk`.
+     *
+     * @return Header value as a string.
+     */
+    internal fun buildSfuSdkTrackingHeader(): String =
+        "stream-android@${BuildConfig.STREAM_VIDEO_VERSION}"
+
     private fun buildAppVersionForHeader() = (StreamVideo.instanceOrNull() as? StreamVideoClient)?.let { streamVideoImpl ->
         "|app_version=" + (streamVideoImpl.appVersion ?: getAppVersionName())
     } ?: ""

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
@@ -86,9 +86,9 @@ class HeadersUtil {
         }.sanitize()
     }
 
-    /** Builds the X-Stream-Client header sent to the SFU, e.g. `stream-video-android@1.30.0`. */
+    /** Builds the X-Stream-Client header sent to the SFU, e.g. `stream-video-android-v1.30.0`. */
     internal fun buildSfuSdkTrackingHeader(): String =
-        "stream-video-android@${BuildConfig.STREAM_VIDEO_VERSION}"
+        "stream-video-android-v${BuildConfig.STREAM_VIDEO_VERSION}"
 
     private fun buildAppVersionForHeader() = (StreamVideo.instanceOrNull() as? StreamVideoClient)?.let { streamVideoImpl ->
         "|app_version=" + (streamVideoImpl.appVersion ?: getAppVersionName())

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/header/HeadersUtil.kt
@@ -86,14 +86,9 @@ class HeadersUtil {
         }.sanitize()
     }
 
-    /**
-     * Builds the client information header (X-Stream-Client) sent to the SFU, e.g.
-     * `stream-android@1.30.0`. The name matches the one reported as `SendStatsRequest.sdk`.
-     *
-     * @return Header value as a string.
-     */
+    /** Builds the X-Stream-Client header sent to the SFU, e.g. `stream-video-android@1.30.0`. */
     internal fun buildSfuSdkTrackingHeader(): String =
-        "stream-android@${BuildConfig.STREAM_VIDEO_VERSION}"
+        "stream-video-android@${BuildConfig.STREAM_VIDEO_VERSION}"
 
     private fun buildAppVersionForHeader() = (StreamVideo.instanceOrNull() as? StreamVideoClient)?.let { streamVideoImpl ->
         "|app_version=" + (streamVideoImpl.appVersion ?: getAppVersionName())

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuConnectionModule.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuConnectionModule.kt
@@ -54,8 +54,7 @@ internal class SfuConnectionModule(
     // Internal logic
     override val http: OkHttpClient = buildSfuOkHttpClient()
 
-    // Twirp calls carry the SDK identity; the socket built on [http] sets its own X-Stream-Client,
-    // so the header is added here rather than on the shared client.
+    // Not on [http] — the socket built on it already sets its own X-Stream-Client.
     private val signalHttp: OkHttpClient by lazy {
         http.newBuilder().addInterceptor(SfuHeadersInterceptor(HeadersUtil())).build()
     }

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuConnectionModule.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuConnectionModule.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.Lifecycle
 import io.getstream.video.android.core.analytics.call.observer.SfuAnalytics
 import io.getstream.video.android.core.api.SignalServerService
 import io.getstream.video.android.core.call.utils.RetryableSignalingServiceDecorator
+import io.getstream.video.android.core.header.HeadersUtil
 import io.getstream.video.android.core.internal.network.NetworkStateProvider
 import io.getstream.video.android.core.socket.common.token.ConstantTokenProvider
 import io.getstream.video.android.core.socket.common.token.TokenRepository
@@ -53,8 +54,14 @@ internal class SfuConnectionModule(
     // Internal logic
     override val http: OkHttpClient = buildSfuOkHttpClient()
 
+    // Twirp calls carry the SDK identity; the socket built on [http] sets its own X-Stream-Client,
+    // so the header is added here rather than on the shared client.
+    private val signalHttp: OkHttpClient by lazy {
+        http.newBuilder().addInterceptor(SfuHeadersInterceptor(HeadersUtil())).build()
+    }
+
     private val signalRetrofitClient: Retrofit by lazy {
-        Retrofit.Builder().client(http).addConverterFactory(WireConverterFactory.create())
+        Retrofit.Builder().client(signalHttp).addConverterFactory(WireConverterFactory.create())
             .baseUrl("$apiUrl/").build()
     }
     private fun buildSfuOkHttpClient(): OkHttpClient {

--- a/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptor.kt
+++ b/stream-video-android-core/src/main/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptor.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.internal.module
+
+import io.getstream.video.android.core.header.HeadersUtil
+import okhttp3.Interceptor
+import okhttp3.Response
+
+internal class SfuHeadersInterceptor(private val headersUtil: HeadersUtil) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+            .newBuilder()
+            .addHeader("X-Stream-Client", headersUtil.buildSfuSdkTrackingHeader())
+            .build()
+        return chain.proceed(request)
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptorTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptorTest.kt
@@ -36,7 +36,7 @@ class SfuHeadersInterceptorTest {
         val request = sendTwirpRequest()
 
         assertThat(request.header("X-Stream-Client"))
-            .isEqualTo("stream-video-android@${BuildConfig.STREAM_VIDEO_VERSION}")
+            .isEqualTo("stream-video-android-v${BuildConfig.STREAM_VIDEO_VERSION}")
     }
 
     @Test

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptorTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptorTest.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.core.internal.module
+
+import com.google.common.truth.Truth.assertThat
+import io.getstream.video.android.core.BuildConfig
+import io.getstream.video.android.core.header.HeadersUtil
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Test
+
+class SfuHeadersInterceptorTest {
+
+    private val twirpUrl = "https://sfu.example.com/twirp/signal.SignalServer/SendStats"
+
+    @Test
+    fun `identifies the SDK and its version on every twirp request`() {
+        val request = sendTwirpRequest()
+
+        assertThat(request.header("X-Stream-Client"))
+            .isEqualTo("stream-android@${BuildConfig.STREAM_VIDEO_VERSION}")
+    }
+
+    @Test
+    fun `sends a single client header`() {
+        val request = sendTwirpRequest()
+
+        assertThat(request.headers("X-Stream-Client")).hasSize(1)
+    }
+
+    private fun sendTwirpRequest(): Request {
+        lateinit var sent: Request
+        val client = OkHttpClient.Builder()
+            .addInterceptor(SfuHeadersInterceptor(HeadersUtil()))
+            .addInterceptor(
+                Interceptor { chain ->
+                    sent = chain.request()
+                    Response.Builder()
+                        .request(chain.request())
+                        .protocol(Protocol.HTTP_1_1)
+                        .code(200)
+                        .message("OK")
+                        .body("".toResponseBody())
+                        .build()
+                },
+            )
+            .build()
+
+        client.newCall(Request.Builder().url(twirpUrl).build()).execute().close()
+        return sent
+    }
+}

--- a/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptorTest.kt
+++ b/stream-video-android-core/src/test/kotlin/io/getstream/video/android/core/internal/module/SfuHeadersInterceptorTest.kt
@@ -36,7 +36,7 @@ class SfuHeadersInterceptorTest {
         val request = sendTwirpRequest()
 
         assertThat(request.header("X-Stream-Client"))
-            .isEqualTo("stream-android@${BuildConfig.STREAM_VIDEO_VERSION}")
+            .isEqualTo("stream-video-android@${BuildConfig.STREAM_VIDEO_VERSION}")
     }
 
     @Test


### PR DESCRIPTION
### Goal

Closes [AND-1509](https://linear.app/stream/issue/AND-1509/send-x-stream-client-with-the-sdk-version-on-every-sfu-twirp-request)

The SFU's Twirp calls carried no SDK identity — only the coordinator API sent
`X-Stream-Client`. Same change as the JS SDK's GetStream/stream-video-js#2425.

### Implementation

- `SfuHeadersInterceptor` adds `X-Stream-Client: stream-video-android-v<sdk-version>`, built by
  `HeadersUtil.buildSfuSdkTrackingHeader()`.
- `SendStatsRequest.sdk` is unchanged and keeps reporting `stream-android`.
- Registered on `http.newBuilder()` for the signaling Retrofit client, not on the shared SFU
  `OkHttpClient`: the SFU socket is built on that same client and `SocketFactory` already sets
  its own `X-Stream-Client`, so registering there would put two values on the upgrade request.
- The `-v` matches the other SDKs' coordinator token (`stream-video-swift-v…`,
  `stream-video-react-v…`) rather than our own coordinator prefix, which has no `v`. So the same
  app sends `stream-video-android-1.30.0` to the coordinator and `stream-video-android-v1.30.0`
  to the SFU. Deliberate — cross-SDK consistency was chosen over `@` in the format thread.

### 🎨 UI Changes

None.

### Testing

- `SfuHeadersInterceptorTest` pins the header value and that exactly one is sent. Red-proved by
  dropping the `v`, which is the near-miss value given our coordinator prefix doesn't carry one.
- `./gradlew :stream-video-android-core:testDebugUnitTest :stream-video-android-core:spotlessCheck :stream-video-android-core:apiCheck`
- Not yet observed on the wire against a live SFU.