### PR TITLE
Join encrypted from a scanned encryption_key link

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -49,6 +49,7 @@ import io.getstream.video.android.ui.common.StreamCallActivity
 import io.getstream.video.android.ui.common.StreamCallActivityConfiguration
 import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
 import io.getstream.video.android.ui.lobby.deriveE2EEKey
+import io.getstream.video.android.util.DemoE2eeKeys
 import io.getstream.video.android.util.FullScreenCircleProgressBar
 import io.getstream.video.android.util.StreamVideoInitHelper
 import kotlinx.coroutines.CoroutineScope
@@ -87,6 +88,7 @@ class CallActivity : ComposeStreamCallActivity() {
     private val previousRingingStates = ConcurrentHashMap.newKeySet<RingingState>()
     override val callJoinInterceptor = DemoCallJoinInterceptor(previousRingingStates)
     private var e2eeManager: StreamEncryptionManager? = null
+    private var e2eeCid: String? = null
 
     /**
      * This code is required to pass the UI-tests (as it hardcodes the configuration)
@@ -191,6 +193,9 @@ class CallActivity : ComposeStreamCallActivity() {
         }
         e2eeManager?.dispose()
         e2eeManager = manager
+        // Kept so the in-call share sheet can put the passphrase back on the invite link.
+        e2eeCid = call.cid
+        DemoE2eeKeys.remember(call.cid, passphrase)
     }
 
     private class StreamDemoUiDelegate : StreamCallActivityComposeDelegate() {
@@ -295,5 +300,7 @@ class CallActivity : ComposeStreamCallActivity() {
         previousRingingStates.clear()
         e2eeManager?.dispose()
         e2eeManager = null
+        e2eeCid?.let { DemoE2eeKeys.forget(it) }
+        e2eeCid = null
     }
 }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -19,6 +19,7 @@ package io.getstream.video.android
 import android.content.Intent
 import android.os.Bundle
 import android.os.PersistableBundle
+import android.util.Log
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.runtime.Composable
@@ -38,6 +39,8 @@ import io.getstream.video.android.core.MemberState
 import io.getstream.video.android.core.RingingState
 import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.core.call.state.CallAction
+import io.getstream.video.android.core.e2ee.E2EEEventType
+import io.getstream.video.android.core.e2ee.StreamEncryptionManager
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.ui.call.CallScreen
 import io.getstream.video.android.ui.call.DemoComponentFactory
@@ -45,6 +48,7 @@ import io.getstream.video.android.ui.common.StreamActivityUiDelegate
 import io.getstream.video.android.ui.common.StreamCallActivity
 import io.getstream.video.android.ui.common.StreamCallActivityConfiguration
 import io.getstream.video.android.ui.common.util.StreamCallActivityDelicateApi
+import io.getstream.video.android.ui.lobby.deriveE2EEKey
 import io.getstream.video.android.util.FullScreenCircleProgressBar
 import io.getstream.video.android.util.StreamVideoInitHelper
 import kotlinx.coroutines.CoroutineScope
@@ -63,6 +67,18 @@ class CallActivity : ComposeStreamCallActivity() {
 
     companion object {
         var USE_CALL_JOIN_INTERCEPTOR = false
+
+        /** Shared E2EE passphrase, forwarded from a deeplink or scanned QR code. */
+        const val EXTRA_E2EE_PASSPHRASE = "e2ee_passphrase"
+
+        /**
+         * The key index every participant agrees on. A frame carries the index it was encrypted
+         * with, so a receiver looking elsewhere fails every decrypt. Kept in step with the lobby
+         * and with the web demo, which both use slot 0.
+         */
+        private const val E2EE_KEY_INDEX = 0
+
+        private const val E2EE_TAG = "CallActivityE2EE"
     }
 
     override val uiDelegate: StreamActivityUiDelegate<StreamCallActivity> = StreamDemoUiDelegate()
@@ -70,6 +86,7 @@ class CallActivity : ComposeStreamCallActivity() {
     var observeRingingJob: Job? = null
     private val previousRingingStates = ConcurrentHashMap.newKeySet<RingingState>()
     override val callJoinInterceptor = DemoCallJoinInterceptor(previousRingingStates)
+    private var e2eeManager: StreamEncryptionManager? = null
 
     /**
      * This code is required to pass the UI-tests (as it hardcodes the configuration)
@@ -109,6 +126,71 @@ class CallActivity : ComposeStreamCallActivity() {
             }
         }
         super.onPreCreate(savedInstanceState, persistentState)
+    }
+
+    /**
+     * Applies the shared key carried by the invite link before the call is joined.
+     * [Call.setE2EEManager] is rejected once a session exists, so this is the last point at which a
+     * scanned link can still become an encrypted call.
+     */
+    @StreamCallActivityDelicateApi
+    override fun join(
+        call: Call,
+        onSuccess: (suspend (Call) -> Unit)?,
+        onError: (suspend (Exception) -> Unit)?,
+    ) {
+        intent.getStringExtra(EXTRA_E2EE_PASSPHRASE)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { enableE2EE(call, it) }
+        super.join(call, onSuccess, onError)
+    }
+
+    private fun enableE2EE(call: Call, passphrase: String) {
+        // join() cannot suspend, but the derivation is 100k PBKDF2 iterations - keep it off main.
+        val key = runCatching {
+            runBlocking(Dispatchers.Default) { deriveE2EEKey(passphrase) }
+        }.getOrElse {
+            Log.e(E2EE_TAG, "Could not derive the E2EE key from the link", it)
+            return
+        }
+        // EncryptionManager's JNI is registered by libjingle_peerconnection_so's JNI_OnLoad. The
+        // lobby gets that for free from its camera preview, but a scanned link joins without ever
+        // building a factory first, so without this create() fails with an UnsatisfiedLinkError.
+        runCatching { System.loadLibrary("jingle_peerconnection_so") }.onFailure {
+            Log.e(E2EE_TAG, "Could not load the WebRTC native library", it)
+            return
+        }
+        val manager = StreamEncryptionManager.create(call.user.id).getOrElse {
+            Log.e(E2EE_TAG, "Could not create the E2EE manager", it)
+            return
+        }
+        manager.setEventListener { event ->
+            val message = "Native E2EE event: $event"
+            when (event.type) {
+                E2EEEventType.DECRYPTION_RESUMED -> Log.i(E2EE_TAG, message)
+                E2EEEventType.KEY_STATE,
+                E2EEEventType.PERF_REPORT,
+                -> Log.d(E2EE_TAG, message)
+                E2EEEventType.DECRYPTION_FAILED,
+                E2EEEventType.DECRYPTION_STALLED,
+                E2EEEventType.ENCRYPTION_FAILED,
+                E2EEEventType.MISSING_KEY,
+                E2EEEventType.UNENCRYPTED_FRAME,
+                E2EEEventType.UNSUPPORTED_VERSION,
+                E2EEEventType.UNKNOWN,
+                -> Log.w(E2EE_TAG, message)
+            }
+        }
+        manager.enablePerformanceReporting(true)
+        manager.setSharedKey(E2EE_KEY_INDEX, key)
+        val attached = call.setE2EEManager(manager)
+        if (attached.isFailure) {
+            Log.e(E2EE_TAG, "Could not attach the E2EE manager", attached.exceptionOrNull())
+            manager.dispose()
+            return
+        }
+        e2eeManager?.dispose()
+        e2eeManager = manager
     }
 
     private class StreamDemoUiDelegate : StreamCallActivityComposeDelegate() {
@@ -211,5 +293,7 @@ class CallActivity : ComposeStreamCallActivity() {
         observeCallReadyToJoinJob?.cancel()
         observeRingingJob?.cancel()
         previousRingingStates.clear()
+        e2eeManager?.dispose()
+        e2eeManager = null
     }
 }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
@@ -144,6 +144,13 @@ class DeeplinkingActivity : ComponentActivity() {
         return data?.getQueryParameter("type") ?: "default"
     }
 
+    /**
+     * The shared E2EE passphrase, when the link carries one. Matches the `encryption_key` parameter
+     * the web demo puts on its invite links, so a QR code generated there joins encrypted here.
+     */
+    private fun extractEncryptionKey(data: Uri?): String? =
+        data?.getQueryParameter("encryption_key")?.takeIf { it.isNotBlank() }
+
     private fun extractCallId(data: Uri?): String? {
         if (data == null) {
             // No data, return null
@@ -191,6 +198,9 @@ class DeeplinkingActivity : ComponentActivity() {
                             clazz = CallActivity::class.java,
                         ).apply {
                             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                            extractEncryptionKey(data)?.let {
+                                putExtra(CallActivity.EXTRA_E2EE_PASSPHRASE, it)
+                            }
                         }
                         startActivity(intent)
                         finish()

--- a/demo-app/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/DeeplinkingActivity.kt
@@ -41,6 +41,7 @@ import io.getstream.video.android.core.StreamVideo
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.ui.common.StreamCallActivity
+import io.getstream.video.android.util.E2EE_KEY_QUERY_PARAM
 import io.getstream.video.android.util.InitializedState
 import io.getstream.video.android.util.StreamVideoInitHelper
 import io.getstream.video.android.util.config.AppConfig
@@ -149,7 +150,7 @@ class DeeplinkingActivity : ComponentActivity() {
      * the web demo puts on its invite links, so a QR code generated there joins encrypted here.
      */
     private fun extractEncryptionKey(data: Uri?): String? =
-        data?.getQueryParameter("encryption_key")?.takeIf { it.isNotBlank() }
+        data?.getQueryParameter(E2EE_KEY_QUERY_PARAM)?.takeIf { it.isNotBlank() }
 
     private fun extractCallId(data: Uri?): String? {
         if (data == null) {

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/ShareCall.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/ShareCall.kt
@@ -38,6 +38,7 @@ import androidx.compose.material.icons.filled.CopyAll
 import androidx.compose.material.icons.filled.PersonAddAlt1
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -49,6 +50,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.getstream.video.android.compose.theme.VideoTheme
 import io.getstream.video.android.compose.ui.components.base.StreamButton
 import io.getstream.video.android.core.Call
@@ -66,7 +68,8 @@ public fun ShareCallWithOthers(
     env: State<StreamEnvironment?>,
     context: Context,
 ) {
-    val shareUrl = shareUrl(env.value?.sharelink, call)
+    val encrypted by call.state.e2eeEnabled.collectAsStateWithLifecycle()
+    val shareUrl = shareUrl(env.value?.sharelink, call, encrypted)
     val configuration = LocalConfiguration.current
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
@@ -94,12 +97,17 @@ public fun ShareCallWithOthers(
 }
 
 /**
- * The invite link for [call], carrying the shared passphrase when this process joined encrypted.
- * Without it the person scanning the code joins a call whose media they cannot decrypt, so the
- * parameter is what makes the QR code usable for an encrypted call at all.
+ * The invite link for [call], carrying the shared passphrase when the call is actually encrypted.
+ * Without it the person scanning the code joins a call whose media they cannot decrypt, which is
+ * what makes the parameter worth having at all.
+ *
+ * [encrypted] comes from the SDK's own call state, so a passphrase is only ever advertised for a
+ * call that really is using it — a leftover from an earlier session of the same call ID cannot be
+ * passed off as this call's key.
  */
-private fun shareUrl(sharelink: String?, call: Call): String {
+private fun shareUrl(sharelink: String?, call: Call, encrypted: Boolean): String {
     val base = "$sharelink${call.id}"
+    if (!encrypted) return base
     val passphrase = DemoE2eeKeys.of(call.cid) ?: return base
     return Uri.parse(base)
         .buildUpon()

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/ShareCall.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/call/ShareCall.kt
@@ -21,6 +21,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.content.res.Configuration
+import android.net.Uri
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -53,6 +54,8 @@ import io.getstream.video.android.compose.ui.components.base.StreamButton
 import io.getstream.video.android.core.Call
 import io.getstream.video.android.mock.StreamPreviewDataUtils
 import io.getstream.video.android.mock.previewCall
+import io.getstream.video.android.util.DemoE2eeKeys
+import io.getstream.video.android.util.E2EE_KEY_QUERY_PARAM
 import io.getstream.video.android.util.config.types.StreamEnvironment
 
 @Composable
@@ -63,7 +66,7 @@ public fun ShareCallWithOthers(
     env: State<StreamEnvironment?>,
     context: Context,
 ) {
-    val shareUrl = "${env.value?.sharelink}${call.id}"
+    val shareUrl = shareUrl(env.value?.sharelink, call)
     val configuration = LocalConfiguration.current
     val isPortrait = configuration.orientation == Configuration.ORIENTATION_PORTRAIT
 
@@ -88,6 +91,21 @@ public fun ShareCallWithOthers(
             context.startActivity(shareIntent)
         }
     }
+}
+
+/**
+ * The invite link for [call], carrying the shared passphrase when this process joined encrypted.
+ * Without it the person scanning the code joins a call whose media they cannot decrypt, so the
+ * parameter is what makes the QR code usable for an encrypted call at all.
+ */
+private fun shareUrl(sharelink: String?, call: Call): String {
+    val base = "$sharelink${call.id}"
+    val passphrase = DemoE2eeKeys.of(call.cid) ?: return base
+    return Uri.parse(base)
+        .buildUpon()
+        .appendQueryParameter(E2EE_KEY_QUERY_PARAM, passphrase)
+        .build()
+        .toString()
 }
 
 @Composable

--- a/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyViewModel.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/ui/lobby/CallLobbyViewModel.kt
@@ -31,6 +31,7 @@ import io.getstream.video.android.core.e2ee.StreamEncryptionManager
 import io.getstream.video.android.datastore.delegate.StreamUserDataStore
 import io.getstream.video.android.model.StreamCallId
 import io.getstream.video.android.model.User
+import io.getstream.video.android.util.DemoE2eeKeys
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -240,6 +241,8 @@ class CallLobbyViewModel @Inject constructor(
         val previous = e2eeManager
         e2eeManager = created
         previous?.dispose()
+        // Kept so the in-call share sheet can put the passphrase back on the invite link.
+        DemoE2eeKeys.remember(call.cid, passphrase)
         return Result.success(Unit)
     }
 
@@ -251,6 +254,7 @@ class CallLobbyViewModel @Inject constructor(
             current?.dispose()
         } finally {
             e2eeManager = null
+            DemoE2eeKeys.forget(call.cid)
         }
         return Result.success(Unit)
     }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/DemoE2eeKeys.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/DemoE2eeKeys.kt
@@ -16,8 +16,6 @@
 
 package io.getstream.video.android.util
 
-import java.util.concurrent.ConcurrentHashMap
-
 /**
  * Name of the invite-link query parameter carrying the shared passphrase. Read when joining and
  * written when sharing, so it lives in one place — the two sides have to agree on it, and they
@@ -26,25 +24,30 @@ import java.util.concurrent.ConcurrentHashMap
 internal const val E2EE_KEY_QUERY_PARAM = "encryption_key"
 
 /**
- * Passphrases of the calls this process joined encrypted, so the in-call share sheet can put one
- * back on the invite link.
+ * The passphrase of the call being joined, so the in-call share sheet can put it back on the
+ * invite link. The passphrase travels in that link anyway, so this is not about keeping it secret.
  *
- * Memory only, and deliberately: the passphrase is the key. Persisting it would leave key material
- * on disk, and putting it anywhere the coordinator stores — custom call data, a member field —
- * would hand the server the key and make the encryption pointless.
+ * It holds one call at a time, and [of] answers only for the cid it was stored against. Applying
+ * one call's passphrase to another is the thing to prevent: everyone who saw the first call's link
+ * could then decrypt the second. Demo call IDs are short and get reused, so a per-cid cache would
+ * happily serve a passphrase from an earlier session of the same ID — hence a single slot that
+ * every join overwrites, rather than a map that accumulates.
  */
 internal object DemoE2eeKeys {
 
-    private val passphrases = ConcurrentHashMap<String, String>()
+    @Volatile
+    private var current: Entry? = null
+
+    private data class Entry(val cid: String, val passphrase: String)
 
     fun remember(cid: String, passphrase: String) {
-        passphrases[cid] = passphrase
+        current = Entry(cid, passphrase)
     }
 
-    /** The passphrase for [cid], or null when this process did not join that call encrypted. */
-    fun of(cid: String): String? = passphrases[cid]
+    /** The passphrase stored for [cid], or null when the stored one belongs to another call. */
+    fun of(cid: String): String? = current?.takeIf { it.cid == cid }?.passphrase
 
     fun forget(cid: String) {
-        passphrases.remove(cid)
+        if (current?.cid == cid) current = null
     }
 }

--- a/demo-app/src/main/kotlin/io/getstream/video/android/util/DemoE2eeKeys.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/util/DemoE2eeKeys.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-video-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.video.android.util
+
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Name of the invite-link query parameter carrying the shared passphrase. Read when joining and
+ * written when sharing, so it lives in one place — the two sides have to agree on it, and they
+ * have to agree with the web demo.
+ */
+internal const val E2EE_KEY_QUERY_PARAM = "encryption_key"
+
+/**
+ * Passphrases of the calls this process joined encrypted, so the in-call share sheet can put one
+ * back on the invite link.
+ *
+ * Memory only, and deliberately: the passphrase is the key. Persisting it would leave key material
+ * on disk, and putting it anywhere the coordinator stores — custom call data, a member field —
+ * would hand the server the key and make the encryption pointless.
+ */
+internal object DemoE2eeKeys {
+
+    private val passphrases = ConcurrentHashMap<String, String>()
+
+    fun remember(cid: String, passphrase: String) {
+        passphrases[cid] = passphrase
+    }
+
+    /** The passphrase for [cid], or null when this process did not join that call encrypted. */
+    fun of(cid: String): String? = passphrases[cid]
+
+    fun forget(cid: String) {
+        passphrases.remove(cid)
+    }
+}


### PR DESCRIPTION
### Goal

Closes [AND-1512](https://linear.app/stream/issue/AND-1512/video-demo-app-join-encrypted-when-a-scanned-link-carries-encryption) — a scanned QR code or deeplink carrying `encryption_key` now joins the call E2EE-encrypted with that passphrase instead of dropping it.

### Implementation

- `DeeplinkingActivity` forwards `encryption_key` from the `Uri` to `CallActivity` as an intent extra.
- `CallActivity.join()` derives the key and attaches a `StreamEncryptionManager` before `super.join()` — `Call.setE2EEManager` is rejected once a session exists.
- Reuses the lobby's `deriveE2EEKey` (PBKDF2-HMAC-SHA256, salt `stream-e2ee`, 100k iterations, 128-bit, slot 0) so the passphrase yields the same key as on web.
- Loads the WebRTC native library first: a scanned link builds no `PeerConnectionFactory`, so `create()` otherwise fails with `UnsatisfiedLinkError`.

demo-app only; no SDK modules touched.

### Testing

On-device testing is needed to verify this against an encrypted call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added end-to-end encryption support for calls launched through deeplinks containing an encryption passphrase.
  - Encrypted calls can share invite links that include the required passphrase.
  - Encryption passphrases are retained only in memory during the app session.
  - Added cleanup of encryption resources and stored passphrases when calls or encryption sessions end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->