### PR TITLE
Pin the video buddy to 1.8.1 and widen the flaky E2E waits

### DIFF
--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
@@ -108,7 +108,10 @@ class UserRobot {
         if (callId != null) {
             CallDetailsPage.callIdInputField.waitToAppear().typeText(callId)
         }
-        CallDetailsPage.joinCallButton.waitToAppearAndClick()
+        // The call details screen is the first screen after launch or login, so this wait
+        // overlaps app startup on an emulator that is still settling. The 5s default was the
+        // single most common nightly failure, so the window is deliberately wider.
+        CallDetailsPage.joinCallButton.waitToAppearAndClick(timeOutMillis = 15.seconds)
         waitForLobbyToOpen()
         return this
     }
@@ -127,7 +130,9 @@ class UserRobot {
     }
 
     private fun waitForLobbyToOpen(): UserRobot {
-        LobbyPage.closeButton.waitToAppear()
+        // Reached right after a login, so the lobby composes while the app is still starting
+        // up. At the 5s default this failed about half the time locally on the re-enter tests.
+        LobbyPage.closeButton.waitToAppear(timeOutMillis = 15.seconds)
         return this
     }
 
@@ -342,7 +347,8 @@ class UserRobot {
         CallPage.callViewButton.waitToAppearAndClick()
         // With many live video tiles the emulator UI is busy, and the opened menu can take
         // several seconds to land in the accessibility tree, so the items get a wide window.
-        val timeOutMillis = 15.seconds
+        // 15s still timed out on the six-participant test, so the window is wider again.
+        val timeOutMillis = 30.seconds
         when (mode) {
             VideoView.DYNAMIC -> CallPage.ViewMenu.dynamic.waitToAppearAndClick(timeOutMillis)
             VideoView.SPOTLIGHT -> CallPage.ViewMenu.spotlight.waitToAppearAndClick(timeOutMillis)

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobot.kt
@@ -160,7 +160,9 @@ class UserRobot {
     }
 
     fun waitForIncomingCall(): UserRobot {
-        RingPage.acceptCallButton.waitToAppear(timeOutMillis = 15.seconds)
+        // Ring delivery goes through the coordinator and the push or socket path before the
+        // incoming screen renders, and 15s timed out on the nightlies.
+        RingPage.acceptCallButton.waitToAppear(timeOutMillis = 30.seconds)
         return this
     }
 
@@ -364,15 +366,18 @@ class UserRobot {
 
     fun acceptCallRecording(): UserRobot {
         // The recording-consent dialog only appears once the backend composite recorder
-        // emits call.recording_started, which can take 20-30s, so 10s is too short.
-        CallPage.RecordingButtons.accept.waitToAppearAndClick(timeOutMillis = 30.seconds)
+        // emits call.recording_started. The buddy starts the recording within seconds, so
+        // this wait is really the recorder's start-up latency: usually 10-20s, but 30s still
+        // timed out four times in the nightlies. Callers with a recording window have to
+        // outlive this wait, see testReconnectionDuringCallRecording.
+        CallPage.RecordingButtons.accept.waitToAppearAndClick(timeOutMillis = 60.seconds)
         return this
     }
 
     fun declineCallRecording(): UserRobot {
         // See acceptCallRecording: the consent dialog is gated on the backend recorder
-        // starting (call.recording_started), which can take 20-30s.
-        CallPage.RecordingButtons.leave.waitToAppearAndClick(timeOutMillis = 30.seconds)
+        // starting (call.recording_started).
+        CallPage.RecordingButtons.leave.waitToAppearAndClick(timeOutMillis = 60.seconds)
         return this
     }
 

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/robots/UserRobotCallAsserts.kt
@@ -32,6 +32,7 @@ import io.getstream.video.android.uiautomator.findObjects
 import io.getstream.video.android.uiautomator.isDisplayed
 import io.getstream.video.android.uiautomator.retryOnStaleObjectException
 import io.getstream.video.android.uiautomator.seconds
+import io.getstream.video.android.uiautomator.wait
 import io.getstream.video.android.uiautomator.waitDisplayed
 import io.getstream.video.android.uiautomator.waitForCount
 import io.getstream.video.android.uiautomator.waitForText
@@ -130,8 +131,10 @@ fun UserRobot.assertBackground(background: Background, isEnabled: Boolean): User
         Background.IMAGE -> SettingsMenu.imageBackgroundEnabledToggle
         Background.BLUR -> SettingsMenu.blurBackgroundEnabledToggle
     }
-    val expectedCount = if (isEnabled) 1 else 0
-    assertEquals(expectedCount, locator.findObjects().size)
+    // The menu items land in the accessibility tree a moment after the sheet opens, so an
+    // instant count right after settings(ENABLE) can read 0 for a toggle that is there.
+    val toggles = if (isEnabled) locator.wait().findObjects() else locator.waitToDisappear().findObjects()
+    assertEquals(if (isEnabled) 1 else 0, toggles.size)
     return this
 }
 
@@ -270,7 +273,12 @@ fun UserRobot.assertSpotlightView(): UserRobot {
 
 fun UserRobot.assertIncomingCall(isDisplayed: Boolean): UserRobot {
     if (isDisplayed) {
-        assertTrue("Accept call button", RingPage.acceptCallButton.waitToAppear().isDisplayed())
+        // Often the first wait after the participant rings, so it carries the whole ring
+        // delivery latency. Same budget as waitForIncomingCall.
+        assertTrue(
+            "Accept call button",
+            RingPage.acceptCallButton.waitToAppear(timeOutMillis = 30.seconds).isDisplayed(),
+        )
         assertTrue("Decline call button", RingPage.declineCallButton.isDisplayed())
         assertTrue("Call label", RingPage.incomingCallLabel.isDisplayed())
         assertTrue("Avatar", RingPage.callParticipantAvatar.isDisplayed())

--- a/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/ReconnectionTests.kt
+++ b/demo-app/src/androidTestE2etestingDebug/kotlin/io/getstream/video/android/tests/ReconnectionTests.kt
@@ -114,13 +114,14 @@ class ReconnectionTests : StreamTestCase() {
         }
         step("AND participant joins the call") {
             // The recording window counts from the participant's start request, and the
-            // composite recorder alone can take 20-30s to start. The window has to outlive
-            // the drop, the reconnect and the final polling assert on a slow CI emulator,
-            // otherwise the participant stops the recording on schedule before the assert
-            // and the test fails on a recording that legitimately ended.
+            // composite recorder alone can take up to the 60s acceptCallRecording waits for.
+            // The window has to outlive that, the drop, the reconnect and the final polling
+            // assert on a slow CI emulator, otherwise the participant stops the recording on
+            // schedule before the assert and the test fails on a recording that
+            // legitimately ended.
             participantRobot
                 .setUserCount(participants)
-                .setCallRecordingDuration(90)
+                .setCallRecordingDuration(120)
                 .joinCall(callId, actions = arrayOf(Actions.RECORD_CALL))
         }
         step("AND participant starts recording a call") {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -143,7 +143,7 @@ lane :install_video_buddy do
   sh("npm install -g playwright@#{playwright_version}")
   sh('npx playwright install chromium')
 
-  stream_video_buddy_version = '1.6.32'
+  stream_video_buddy_version = '1.8.1'
   sh("npm list -g stream-video-buddy | grep -q '#{stream_video_buddy_version}' || " \
      "npm install -g 'https://github.com/GetStream/stream-video-buddy##{stream_video_buddy_version}'")
 end


### PR DESCRIPTION
### Goal

Refs [AND-1445](https://linear.app/stream/issue/AND-1445/stabilize-the-video-e2e-emulator-tests)

The nightly E2E has been red most nights. Two separate causes.

The first is in stream-video-buddy. Its lobby page poll calls `page.locator().count()` in a loop, and when the page navigates mid-poll Playwright rejects the call. Nothing catches it, so the buddy process dies and no participant ever joins. The Android test waiting for those participants then fails far from the real cause. Every uncaught exception in the nightly buddy logs from Sep 1 to Sep 8 was this one line, 8 of them. GetStream/stream-video-buddy#13 fixes it and 1.8.1 is the first release that contains it.

The second is our own waits. Counting every timeout in the same nightly artifacts, and leaving out the shard where an emulator launcher ANR covered the screen, the join call button on the call details screen timed out 9 times at the 5s default and the spotlight menu item timed out twice at 15s.

### Implementation

- `fastlane/Fastfile`: `stream_video_buddy_version` goes from `1.6.32` to `1.8.1`.
- `UserRobot.enterLobby`: the join call button wait goes from the 5s default to 15s. It is the first screen after launch or login, so it overlaps app startup.
- `UserRobot.waitForLobbyToOpen`: the lobby close button wait goes from the 5s default to 15s. Same reason, and it failed about half the time locally on the re-enter tests.
- `UserRobot.setView`: the view menu items wait goes from 15s to 30s. 15s still timed out on the six-participant test.

### Testing

- Nightly dispatched on this branch with the buddy pinned to the merged commit of #13 and the artifact upload temporarily set to `always()` so green shards also uploaded `video-buddy-server.log`: [run 34467476054](https://github.com/GetStream/stream-video-android/actions/runs/34467476054). All 6 shards green, 40 tests each. `Execution context was destroyed` appears 0 times across the six buddy logs, against 8 occurrences in the Sep 1 to Sep 8 nightlies. The only retries were `testReconnectionDuringCallRecording` on API 31 and 32, both on the recording consent dialog, which is a pre-existing backend recorder latency flake (same message in the Sep 2 and Aug 28 runs) and passed on the second attempt.
- The `1.8.1` tag points at the same buddy code as that commit plus the version bump.
- Locally, full E2E suite on a fresh API 35 emulator with the widened waits: 39 of 40 on the first attempt, the one failure being the lobby close button at the 5s default, which is what prompted the third widening.
- `bundle exec rubocop fastlane/Fastfile` clean, `:demo-app:assembleE2etestingDebugAndroidTest` compiles.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of call lobby and view-selection flows, particularly on slower devices or emulators.

* **Chores**
  * Updated supporting video development tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->