### PR TITLE
Bump target sdk to 36 for video sdk

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Android SDK versions
-compileSdk = "35"
-targetSdk = "35"
+compileSdk = "36"
+targetSdk = "36"
 minSdk = "24"
 
 allureKotlin = "2.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@
 compileSdk = "36"
 targetSdk = "36"
 minSdk = "24"
+paparazziCompileSdk = "35"
 
 allureKotlin = "2.4.0"
 androidGradlePlugin = "8.9.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ targetSdk = "36"
 minSdk = "24"
 
 allureKotlin = "2.4.0"
-androidGradlePlugin = "8.5.2"
+androidGradlePlugin = "8.9.1"
 cameraCamera2 = "1.3.4"
 spotless = "6.21.0"
 streamConventions = "0.14.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/stream-video-android-ui-compose/build.gradle.kts
+++ b/stream-video-android-ui-compose/build.gradle.kts
@@ -20,7 +20,9 @@ plugins {
 
 android {
     namespace = "io.getstream.video.android.compose"
-    compileSdk = libs.versions.compileSdk.get().toInt()
+    // Paparazzi 1.3.4's layoutlib cannot load Android 16 framework classes. Keep this module on
+    // API 35 until the project can move to Kotlin 2 and Paparazzi 2; other modules remain on API 36.
+    compileSdk = libs.versions.paparazziCompileSdk.get().toInt()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()


### PR DESCRIPTION
### Goal

Closes #AND-1523

Bump target sdk to 36 for video sdk as we need to publish our demo-app in Play Store

### Implementation

1. Bump target sdk to 36 for video sdk
2. Paparazzi tests were failing because current Paparazzi version cannot resolve API 36 classes, so for now we need to use compile sdk as 35 for `stream-video-ui-compose` module. The other option is to bump Paparazzi version but it requires Kotlin 2.0+ which is a breaking change

### 🎨 UI Changes

None

### Testing

None just smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android SDK compile and target versions to 36.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->