### PR TITLE
Run e2e on android 16

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -9,7 +9,7 @@ on:
         description: 'Android API level to run on'
         type: string
         required: false
-        default: '34'
+        default: '36'
       test_class:
         description: 'Fully qualified test class to run on its own, optionally with #method. Every batch job then runs it, giving independent samples of a flaky test.'
         type: string


### PR DESCRIPTION
### Goal
Closes #AND-1317

Run e2e on android 16
### Implementation

Run e2e on android 16
### 🎨 UI Changes

None

### Testing

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default Android API level used when manually running end-to-end tests from 34 to 36.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->