### PR TITLE
Fix back navigation in demo-app in call-activity

### DIFF
--- a/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
+++ b/demo-app/src/main/kotlin/io/getstream/video/android/CallActivity.kt
@@ -283,17 +283,17 @@ class CallActivity : ComposeStreamCallActivity() {
         }
 
         private fun StreamCallActivity.goBackToMainScreen() {
-            if (!isFinishing) {
-                val intent = Intent(this, MainActivity::class.java).apply {
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
-                }
-                startActivity(intent)
-                safeFinish()
-            }
+            safeFinish()
         }
     }
 
     override fun finish() {
+        if (isTaskRoot && !isFinishing) {
+            val intent = Intent(this, MainActivity::class.java).apply {
+                flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            }
+            startActivity(intent)
+        }
         super.finish()
         observeCallReadyToJoinJob?.cancel()
         observeRingingJob?.cancel()


### PR DESCRIPTION
### Goal
Closes AND-1526
Fix back navigation in demo-app in call-activity

### Implementation

Fix back navigation in demo-app in call-activity

### 🎨 UI Changes

None

### Testing

Smoke test with join error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved activity navigation when closing a call screen, ensuring the main screen is restored correctly when needed.
  * Simplified back-navigation handling to provide more consistent behavior when finishing the activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->